### PR TITLE
refactor(harness): bijection-derived context + CC-style compaction

### DIFF
--- a/apps/agent/src/harness/compaction.ts
+++ b/apps/agent/src/harness/compaction.ts
@@ -1,52 +1,256 @@
 import { generateText } from "ai";
 import type { ModelMessage, LanguageModel } from "ai";
+import type { ContentBlock, SessionEvent } from "@open-managed-agents/shared";
+import { eventsToMessages } from "../runtime/history";
+import type { HarnessRuntime } from "./interface";
 
+/**
+ * Compaction strategy contract.
+ *
+ * Given the full event log + a model + a token budget, decide whether
+ * compaction should fire and produce a summary `ContentBlock[]` plus
+ * boundary metadata. The harness writes the result as a
+ * `agent.thread_context_compacted` event with the summary attached, and
+ * `eventsToMessages` honors the latest such boundary on subsequent reads.
+ *
+ * Strategies are pure with respect to (events, model, system, tools) — same
+ * input → same output. The harness handles persistence + broadcast.
+ *
+ * For cache reuse: the strategy MUST send the same (model, system, tools,
+ * messages-prefix) bytes as the main agent's last call so Anthropic's prompt
+ * cache hits. The harness threads `applyCacheStrategy` through so the
+ * strategy can apply identical provider-specific markers.
+ */
 export interface CompactionStrategy {
-  shouldCompact(messages: ModelMessage[], maxTokens?: number): boolean;
-  compact(messages: ModelMessage[], model: LanguageModel): Promise<ModelMessage[]>;
+  readonly name: string;
+  shouldCompact(events: SessionEvent[], opts: { contextWindowTokens: number }): boolean;
+  compact(
+    events: SessionEvent[],
+    opts: {
+      model: LanguageModel;
+      contextWindowTokens: number;
+      systemPrompt: string;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      tools: Record<string, any>;
+      /**
+       * Apply provider-specific cache markers to (system, tools, messages).
+       * Strategy calls this on the ORIGINAL messages (without the summarize
+       * request appended) so the cache breakpoint lands on the last original
+       * message — matching the main agent's last call's cache prefix.
+       */
+      applyCacheStrategy: (
+        systemPrompt: string,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        tools: Record<string, any>,
+        messages: ModelMessage[],
+      ) => CacheStrategyApplied;
+      /**
+       * Optional runtime — strategy uses it to broadcast span events for the
+       * summarize call so callers (probe, logs, dashboards) can see the
+       * cache_read / cache_create stats of the compaction call distinctly
+       * from the main agent's calls.
+       */
+      runtime?: HarnessRuntime;
+    },
+  ): Promise<CompactionResult | null>;
 }
 
-// Estimate tokens (rough: 4 chars per token)
-function estimateTokens(messages: ModelMessage[]): number {
-  return messages.reduce((sum, m) => {
-    const content = typeof m.content === "string" ? m.content : JSON.stringify(m.content);
-    return sum + Math.ceil(content.length / 4);
-  }, 0);
+export interface CacheStrategyApplied {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  system: string | { role: "system"; content: string; providerOptions?: any } | Array<{ role: "system"; content: string; providerOptions?: any }>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  tools: Record<string, any>;
+  messages: ModelMessage[];
 }
 
-export class SummarizeCompaction implements CompactionStrategy {
-  shouldCompact(messages: ModelMessage[], maxTokens: number = 100000): boolean {
-    return estimateTokens(messages) > maxTokens * 0.85;
+export interface CompactionResult {
+  summary: ContentBlock[];
+  /** Best-effort estimate of pre-compaction tokens (telemetry). */
+  pre_tokens: number;
+  /** Original message count (telemetry). */
+  original_message_count: number;
+  /** Compacted message count after boundary takes effect (telemetry). */
+  compacted_message_count: number;
+}
+
+// ---------- token estimation ----------
+// Cheap 4-chars-per-token heuristic; good enough for compaction triggers.
+function estimateMessageTokens(m: ModelMessage): number {
+  const s = typeof m.content === "string" ? m.content : JSON.stringify(m.content);
+  return Math.ceil(s.length / 4);
+}
+function estimateMessagesTokens(messages: ModelMessage[]): number {
+  let total = 0;
+  for (const m of messages) total += estimateMessageTokens(m);
+  return total;
+}
+
+// Trigger fraction: shouldCompact fires when estimated tokens exceed
+// `triggerFraction * contextWindowTokens`. CC uses ~0.85 effective (after
+// the 13K AUTOCOMPACT_BUFFER reservation); 0.75 gives more headroom for
+// long single turns to flush tool results before the trigger.
+//
+// Tail preservation lives entirely in derive (history.ts) — it walks
+// pre-boundary events using CC-style estimateMessageTokens and renders the
+// last K messages verbatim alongside the summary. Strategy doesn't need to
+// coordinate; it just produces the summary covering everything.
+const TRIGGER_FRACTION = 0.75;
+
+// ============================================================
+// SummarizeCompactionStrategy
+// ============================================================
+//
+// CC-style compaction: send the FULL conversation (same model + same system
+// + same tools + same messages prefix as main agent's last call) and append
+// a single "summarize the above" user message. Anthropic's prompt cache
+// matches the prefix and reads it for cheap; we only pay for the tiny
+// appended message + summary output. Iterative summarization happens
+// naturally — when a prior boundary exists, eventsToMessages already
+// renders the prior summary as the leading user message, so the model sees
+// `<conversation-summary>...</conversation-summary>` + new activity and
+// produces a unified updated summary.
+//
+// Tail preservation: also CC-style. The strategy picks a recent tail of
+// events to keep verbatim alongside the summary (default 10K min tokens / 5
+// min text-block messages, capped at 40K). The boundary event records the
+// tail event count; eventsToMessages renders the post-compaction view as
+// `[summary, ...preserved_tail_messages, ...post_boundary_messages]`.
+//
+// Cost: 1 extra LLM call per compaction trigger. Most input tokens are
+// cache_read (10% of write price). Output is bounded by maxSummaryTokens.
+
+export class SummarizeCompactionStrategy implements CompactionStrategy {
+  readonly name = "summarize";
+
+  constructor(
+    private opts: {
+      headProtectMsgs?: number;
+      tailMinTokens?: number;
+      tailMaxTokens?: number;
+      tailMinMessages?: number;
+      triggerFraction?: number;
+      summarySystemPrompt?: string;
+      maxSummaryTokens?: number;
+    } = {},
+  ) {}
+
+  shouldCompact(events: SessionEvent[], { contextWindowTokens }: { contextWindowTokens: number }): boolean {
+    const messages = eventsToMessages(events);
+    const tokens = estimateMessagesTokens(messages);
+    return tokens > contextWindowTokens * (this.opts.triggerFraction ?? TRIGGER_FRACTION);
   }
 
+  async compact(
+    events: SessionEvent[],
+    { model, systemPrompt, tools, applyCacheStrategy, runtime }: {
+      model: LanguageModel;
+      contextWindowTokens: number;
+      systemPrompt: string;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      tools: Record<string, any>;
+      applyCacheStrategy: (
+        systemPrompt: string,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        tools: Record<string, any>,
+        messages: ModelMessage[],
+      ) => CacheStrategyApplied;
+      runtime?: HarnessRuntime;
+    },
+  ): Promise<CompactionResult | null> {
+    const messages = eventsToMessages(events);
+    if (messages.length < 4) return null; // not worth compacting
+
+    // Apply cache markers on the ORIGINAL messages — the breakpoint lands on
+    // the original last message, matching the byte-prefix the main agent's
+    // last call wrote into Anthropic's cache. Then append the summarize
+    // request UNMARKED so we don't write a new cache entry for it
+    // (skipCacheWrite-equivalent — the appended user message is so small
+    // there's no point caching it).
+    const cached = applyCacheStrategy(systemPrompt, tools, messages);
+
+    const summarizeRequest: ModelMessage = {
+      role: "user",
+      content: this.opts.summarySystemPrompt ?? DEFAULT_SUMMARIZE_PROMPT,
+    };
+
+    const modelId = (model as { modelId?: string })?.modelId ?? "unknown";
+    runtime?.broadcast({ type: "span.compaction_summarize_start", model: modelId });
+
+    const result = await generateText({
+      model,
+      system: cached.system,
+      tools: cached.tools,
+      // Same tools as main agent so cache_key matches (tools is part of
+      // Anthropic's cache prefix). toolChoice="none" forbids tool calls so
+      // the model produces a text summary instead of trying to do work.
+      // Per Anthropic docs, tool_choice is NOT in the cache key — safe.
+      toolChoice: "none",
+      messages: [...cached.messages, summarizeRequest],
+      maxOutputTokens: this.opts.maxSummaryTokens ?? 2000,
+    });
+
+    runtime?.broadcast({
+      type: "span.compaction_summarize_end",
+      model: modelId,
+      model_usage: result.usage ? {
+        input_tokens: result.usage.inputTokens ?? 0,
+        output_tokens: result.usage.outputTokens ?? 0,
+        cache_read_input_tokens: result.usage.inputTokenDetails?.cacheReadTokens ?? 0,
+        cache_creation_input_tokens: result.usage.inputTokenDetails?.cacheWriteTokens ?? 0,
+      } : undefined,
+      finish_reason: result.finishReason,
+      final_text_length: typeof result.text === "string" ? result.text.length : 0,
+    });
+
+    return {
+      summary: [{ type: "text", text: result.text }],
+      pre_tokens: estimateMessagesTokens(messages),
+      original_message_count: messages.length,
+      // derive() picks tail at read time, so post-compaction message count
+      // depends on the tail picking + post-boundary events. Report 1 here
+      // as a lower bound (just the summary); telemetry consumers can compute
+      // the actual derived size separately if needed.
+      compacted_message_count: 1,
+    };
+  }
+}
+
+const DEFAULT_SUMMARIZE_PROMPT =
+  "Summarize the entire conversation above. Preserve key decisions, file paths, tool results (commands run + their output), in-flight tasks, and explicit Next Steps. If the conversation already contains a <conversation-summary> block, produce an updated summary that supersedes it (combining prior summary + new activity). Be concise but specific. Output only the summary text, no preamble.";
+
+// ============================================================
+// Backwards-compatible adapter (deprecated)
+// ============================================================
+// Old API used by anything still importing { SummarizeCompaction } from
+// this module. Kept until call sites migrate.
+/** @deprecated use SummarizeCompactionStrategy via DefaultHarness */
+export class SummarizeCompaction {
+  shouldCompact(messages: ModelMessage[], maxTokens: number = 100000): boolean {
+    return estimateMessagesTokens(messages) > maxTokens * 0.85;
+  }
   async compact(messages: ModelMessage[], model: LanguageModel): Promise<ModelMessage[]> {
-    if (messages.length <= 4) return messages; // Too few to compact
-
-    // Keep first 2 messages (initial context) and last 4 messages (recent context)
-    const keep_start = messages.slice(0, 2);
-    const keep_end = messages.slice(-4);
-    const to_summarize = messages.slice(2, -4);
-
-    if (to_summarize.length === 0) return messages;
-
-    // Summarize the middle section
-    const summaryContent = to_summarize.map(m => {
-      const text = typeof m.content === "string" ? m.content : JSON.stringify(m.content);
-      return `[${m.role}]: ${text.slice(0, 500)}`;
-    }).join("\n");
-
+    if (messages.length <= 4) return messages;
+    const headProtect = 2;
+    const keepStart = messages.slice(0, headProtect);
+    const keepEnd = messages.slice(-4);
+    const toSummarize = messages.slice(headProtect, -4);
+    if (toSummarize.length === 0) return messages;
+    const summaryContent = toSummarize
+      .map((m) => {
+        const text = typeof m.content === "string" ? m.content : JSON.stringify(m.content);
+        return `[${m.role}]: ${text.slice(0, 500)}`;
+      })
+      .join("\n");
     const result = await generateText({
       model,
       system: "Summarize this conversation excerpt concisely. Preserve key decisions, tool results, and file paths. Be brief.",
       messages: [{ role: "user", content: summaryContent }],
       maxOutputTokens: 1000,
     });
-
     const summaryMessage: ModelMessage = {
       role: "assistant",
-      content: `[Conversation summary of ${to_summarize.length} messages]: ${result.text}`,
+      content: `[Conversation summary of ${toSummarize.length} messages]: ${result.text}`,
     };
-
-    return [...keep_start, summaryMessage, ...keep_end];
+    return [...keepStart, summaryMessage, ...keepEnd];
   }
 }

--- a/apps/agent/src/harness/default-loop.ts
+++ b/apps/agent/src/harness/default-loop.ts
@@ -1,7 +1,10 @@
 import { generateText, stepCountIs } from "ai";
-import type { HarnessInterface, HarnessContext } from "./interface";
-import type { SessionEvent } from "@open-managed-agents/shared";
-import { SummarizeCompaction } from "./compaction";
+import type { ContentPart, ModelMessage, LanguageModel, SystemModelMessage } from "ai";
+import type { HarnessInterface, HarnessContext, HarnessRuntime } from "./interface";
+import type { SessionEvent, ContentBlock, AgentToolUseEvent } from "@open-managed-agents/shared";
+import { eventsToMessages } from "../runtime/history";
+import { SummarizeCompactionStrategy } from "./compaction";
+import type { CompactionStrategy } from "./compaction";
 
 const BUILTIN_TOOLS = new Set(["bash", "read", "write", "edit", "glob", "grep", "web_fetch", "web_search"]);
 const isMcpTool = (name: string) => name.startsWith("mcp_");
@@ -95,182 +98,301 @@ function extractMcpServerName(toolName: string): string {
   return withoutPrefix;
 }
 
+/**
+ * Map a tool-call ContentPart to the right wire event family
+ * (mcp / built-in / custom). Also emits agent.thread_message_sent for
+ * call_agent_* sub-agent invocations.
+ *
+ * Lives outside DefaultHarness so the bijection contract is co-located
+ * with `eventsToMessages` — the inverse mapping in history.ts.
+ */
+function emitToolCallEvent(
+  runtime: HarnessContext["runtime"],
+  tools: Record<string, any>,
+  part: ContentPart<any> & { type: "tool-call" },
+): void {
+  const callInput = (part.input ?? {}) as Record<string, unknown>;
+  const toolName = part.toolName;
+  const toolCallId = part.toolCallId;
+
+  if (toolName.startsWith("call_agent_")) {
+    runtime.broadcast({
+      type: "agent.thread_message_sent",
+      to_thread_id: toolCallId,
+      content: [{ type: "text", text: String(callInput.message || "") }],
+    });
+  }
+
+  if (isMcpTool(toolName)) {
+    runtime.broadcast({
+      type: "agent.mcp_tool_use",
+      id: toolCallId,
+      mcp_server_name: extractMcpServerName(toolName),
+      name: toolName,
+      input: callInput,
+    });
+  } else if (isBuiltinTool(toolName)) {
+    const event: AgentToolUseEvent = {
+      type: "agent.tool_use",
+      id: toolCallId,
+      name: toolName,
+      input: callInput,
+    };
+    if (!tools[toolName]?.execute) event.evaluated_permission = "ask";
+    runtime.broadcast(event);
+  } else {
+    runtime.broadcast({
+      type: "agent.custom_tool_use",
+      id: toolCallId,
+      name: toolName,
+      input: callInput,
+    });
+  }
+}
+
+/**
+ * Map a tool-result (or tool-error) ContentPart to a wire event,
+ * normalizing the AI SDK's ToolResultOutput union into the wire's
+ * `string | ContentBlock[]` representation. Also emits
+ * agent.thread_message_received for call_agent_*.
+ *
+ * Normalization rules — fixed so that read(write(m)) === m at byte level:
+ *   text       → string
+ *   content[]  → ContentBlock[] (TextBlock for text parts; image/document
+ *                ContentBlocks pass through if already shaped that way)
+ *   json/error → JSON-stringified string (lossy for the AI SDK type tag,
+ *                but Anthropic only ever sees the string, so derive can
+ *                rebuild a {type:"text"} ToolResultOutput equivalently)
+ *   already-shaped ContentBlock or ContentBlock[] (legacy tool returns)
+ *                → wrap or pass through
+ */
+function emitToolResultEvent(
+  runtime: HarnessContext["runtime"],
+  part: ContentPart<any> & { type: "tool-result" | "tool-error" },
+): void {
+  const toolCallId = part.toolCallId;
+  const toolName = part.toolName;
+  // tool-error has `error`, tool-result has `output`.
+  const raw =
+    part.type === "tool-error"
+      ? { type: "error-text", value: String((part as any).error ?? "") }
+      : ((part as any).output ?? (part as any).result);
+
+  const content = normalizeToolOutputForWire(raw);
+
+  if (isMcpTool(toolName)) {
+    runtime.broadcast({
+      type: "agent.mcp_tool_result",
+      mcp_tool_use_id: toolCallId,
+      content: typeof content === "string" ? content : JSON.stringify(content),
+    });
+  } else {
+    runtime.broadcast({
+      type: "agent.tool_result",
+      tool_use_id: toolCallId,
+      content,
+    });
+  }
+
+  if (toolName.startsWith("call_agent_")) {
+    const text = typeof content === "string"
+      ? content
+      : content.map((b) => (b.type === "text" ? b.text : "")).join("");
+    runtime.broadcast({
+      type: "agent.thread_message_received",
+      from_thread_id: toolCallId,
+      content: [{ type: "text", text }],
+    });
+  }
+}
+
+/**
+ * AI SDK ToolResultOutput union → wire `string | ContentBlock[]`.
+ * Pure function; same input → same output bytes.
+ */
+function normalizeToolOutputForWire(raw: unknown): string | ContentBlock[] {
+  if (typeof raw === "string") return raw;
+  if (raw == null) return "";
+
+  // Already wire-shape (single ContentBlock or array)
+  if (typeof raw === "object" && "type" in raw) {
+    const r = raw as { type: string };
+    if (r.type === "text" && "text" in raw) return [raw as ContentBlock];
+    if (r.type === "image" && "source" in raw) return [raw as ContentBlock];
+    if (r.type === "document" && "source" in raw) return [raw as ContentBlock];
+
+    // AI SDK ToolResultOutput discriminated union
+    if (r.type === "text" && "value" in raw) return String((raw as unknown as { value: unknown }).value);
+    if (r.type === "json") return JSON.stringify((raw as unknown as { value: unknown }).value);
+    if (r.type === "error-text" || r.type === "error-json") {
+      const v = (raw as unknown as { value: unknown }).value;
+      return typeof v === "string" ? v : JSON.stringify(v);
+    }
+    if (r.type === "execution-denied") {
+      return JSON.stringify({ denied: true, reason: (raw as unknown as { reason?: string }).reason });
+    }
+    if (r.type === "content" && Array.isArray((raw as unknown as { value: unknown[] }).value)) {
+      const parts = (raw as unknown as { value: Array<{ type: string; text?: string; data?: string; mediaType?: string; url?: string }> }).value;
+      return parts.map((p): ContentBlock => {
+        if (p.type === "text") return { type: "text", text: p.text ?? "" };
+        if (p.type === "image-data" || p.type === "media") {
+          return {
+            type: "image",
+            source: { type: "base64", media_type: p.mediaType, data: p.data },
+          };
+        }
+        if (p.type === "image-url") {
+          return { type: "image", source: { type: "url", url: p.url, media_type: p.mediaType } };
+        }
+        if (p.type === "file-data") {
+          return {
+            type: "document",
+            source: { type: "base64", media_type: p.mediaType, data: p.data },
+          };
+        }
+        if (p.type === "file-url") {
+          return { type: "document", source: { type: "url", url: p.url, media_type: p.mediaType } };
+        }
+        return { type: "text", text: JSON.stringify(p) };
+      });
+    }
+  }
+
+  if (Array.isArray(raw) && raw.every((b) => b && typeof b === "object" && "type" in b)) {
+    return raw as ContentBlock[];
+  }
+
+  return JSON.stringify(raw);
+}
+
 export class DefaultHarness implements HarnessInterface {
+  /**
+   * Compaction strategy resolved from agent config. Cached on the harness
+   * instance so shouldCompact / compact (which don't get ctx) can use it.
+   * Set in run() before any compaction hook fires.
+   */
+  private compactionStrategy: CompactionStrategy = new SummarizeCompactionStrategy();
+
   async run(ctx: HarnessContext): Promise<void> {
     const { agent, userMessage, runtime, tools, model, systemPrompt } = ctx;
 
+    // Resolve compaction params from agent config. One strategy
+    // (SummarizeCompactionStrategy) with CC-aligned tail defaults — opt-in
+    // overrides via agent.metadata for tuning per-agent if needed.
+    const meta = (agent.metadata ?? {}) as Record<string, unknown>;
+    const triggerFraction = typeof meta.compaction_trigger_fraction === "number"
+      ? meta.compaction_trigger_fraction as number
+      : undefined;
+    const tailMinTokens = typeof meta.compaction_tail_min_tokens === "number"
+      ? meta.compaction_tail_min_tokens as number
+      : undefined;
+    const tailMaxTokens = typeof meta.compaction_tail_max_tokens === "number"
+      ? meta.compaction_tail_max_tokens as number
+      : undefined;
+    const tailMinMessages = typeof meta.compaction_tail_min_messages === "number"
+      ? meta.compaction_tail_min_messages as number
+      : undefined;
+    this.compactionStrategy = new SummarizeCompactionStrategy({
+      tailMinTokens,
+      tailMaxTokens,
+      tailMinMessages,
+      triggerFraction,
+    });
+
     // --- Harness decides HOW to deliver context to the model ---
 
-    // 1. Rebuild conversation from event log
-    // The current userMessage is already appended to history by SessionDO,
-    // so getMessages() includes it. No need to push again.
-    const messages = runtime.history.getMessages();
-
-    // Cache strategy: mark last historical message as cache breakpoint.
-    // Everything before this point is stable and cached by Anthropic API,
-    // saving tokens on multi-turn conversations.
-    if (messages.length > 0) {
-      const lastMsg = messages[messages.length - 1];
-      (lastMsg as any).providerMetadata = {
-        anthropic: { cacheControl: { type: "ephemeral" } },
-      };
+    // 1. Compaction check: ask the harness's own shouldCompact + compact
+    // hooks. Default impls live below the class. Custom harnesses override.
+    // compact() persists its product as a agent.thread_context_compacted
+    // event with summary — derive() then sees the boundary and serves the
+    // summarized view from this turn forward (NOT recomputed per turn).
+    const allEvents = runtime.history.getEvents();
+    const ctxWindow = resolveContextWindowTokens(model);
+    if (this.shouldCompact && this.compact && this.shouldCompact(allEvents, { contextWindowTokens: ctxWindow })) {
+      try {
+        await this.compact(allEvents, runtime, { model, systemPrompt, tools });
+      } catch (err) {
+        // Compaction is best-effort. Log and continue — the next turn will
+        // try again. Don't fail the whole turn over a summarize error.
+        console.warn(`[compact] failed: ${(err as Error).message}`);
+      }
     }
 
-    // 2. Compaction strategy: summarize middle section when context is too long
-    let finalMessages = messages;
-    const compaction = new SummarizeCompaction();
-    if (compaction.shouldCompact(messages)) {
-      const originalCount = messages.length;
-      finalMessages = await compaction.compact(messages, model);
-      runtime.broadcast({
-        type: "agent.thread_context_compacted",
-        original_message_count: originalCount,
-        compacted_message_count: finalMessages.length,
-      });
-    }
+    // 2. Derive ModelMessage[] from events. Default = eventsToMessages
+    // (strict bijection inverse of write-side, with boundary handling).
+    // Custom harnesses can override for sliding-window / RAG / etc.
+    const messages = this.deriveModelContext
+      ? this.deriveModelContext(runtime.history.getEvents())
+      : runtime.history.getMessages();
 
-    // 3. Emit span event: model request start
+    // 3. Apply provider-specific cache strategy. Anthropic: tag system block
+    // + last tool + last message + (optional) one mid-conversation breakpoint
+    // for long turns. Other providers: no-op (OpenAI prompt caching is
+    // automatic; Google uses cachedContent; MiniMax TBD).
+    //
+    // AI SDK doesn't expose a provider-agnostic cache abstraction — each
+    // provider exposes its own knobs via providerOptions. We branch on
+    // model.provider here. To add OpenAI/Gemini cache support later, extend
+    // the strategy table below; the harness loop above doesn't change.
+    const cached = applyProviderCacheStrategy(model, systemPrompt, tools, messages);
+    const finalMessages = cached.messages;
+
+    // 4. Emit span event: model request start
     const modelId = typeof agent.model === "string" ? agent.model : agent.model.id;
     runtime.broadcast({ type: "span.model_request_start", model: modelId });
 
-    // 7. Run agent loop with retry + timeout + prompt caching
-    //
-    // Anthropic prompt caching: @ai-sdk/anthropic has cacheControl enabled
-    // by default. We mark the system prompt for caching via providerOptions,
-    // which avoids re-processing the same system prompt across turns.
+    // 5. Run agent loop with retry + timeout + prompt caching
     const result = await withRetry(async (signal) => {
       const r = await generateText({
       model,
-      system: systemPrompt,
+      system: cached.system,
       messages: finalMessages,
-      tools,
+      tools: cached.tools,
       stopWhen: stepCountIs(100),
       abortSignal: signal,
 
-      onStepFinish: async ({ text, toolCalls, toolResults, reasoning }) => {
-        // Emit one agent.thinking event per reasoning block, preserving the
-        // text + provider metadata (signature for Claude, opaque ids for other
-        // providers). history.ts replays these as ReasoningPart in subsequent
-        // steps so the model sees its own prior chain-of-thought.
-        if (reasoning && Array.isArray(reasoning)) {
-          for (const r of reasoning) {
-            const thinkingEvent: SessionEvent = {
-              type: "agent.thinking",
-              text: r.text,
-              providerOptions: r.providerOptions as Record<string, unknown> | undefined,
-            };
-            runtime.broadcast(thinkingEvent);
-          }
-        }
-
-        // Emit text response
-        if (text) {
-          const msgEvent: SessionEvent = {
-            type: "agent.message",
-            content: [{ type: "text", text }],
-          };
-          runtime.broadcast(msgEvent);
-        }
-
-        // Emit tool calls and results
-        for (let i = 0; i < toolCalls.length; i++) {
-          const call = toolCalls[i];
-
-          // AI SDK v6 uses `input` instead of `args` for tool call parameters
-          const callInput = (call as any).input as Record<string, unknown> || {};
-
-          // Emit thread_message_sent before call_agent_* tool use
-          if (call.toolName.startsWith("call_agent_")) {
-            runtime.broadcast({
-              type: "agent.thread_message_sent",
-              to_thread_id: call.toolCallId,
-              content: [{ type: "text", text: String(callInput.message || "") }],
-            });
-          }
-
-          // Distinguish MCP vs built-in vs custom tool use events
-          if (isMcpTool(call.toolName)) {
-            const mcpToolUseEvent: SessionEvent = {
-              type: "agent.mcp_tool_use",
-              id: call.toolCallId,
-              mcp_server_name: extractMcpServerName(call.toolName),
-              name: call.toolName,
-              input: callInput,
-            };
-            runtime.broadcast(mcpToolUseEvent);
-          } else if (isBuiltinTool(call.toolName)) {
-            const hasExecute = tools[call.toolName] && typeof tools[call.toolName].execute === "function";
-            const toolUseEvent: SessionEvent = {
-              type: "agent.tool_use",
-              id: call.toolCallId,
-              name: call.toolName,
-              input: callInput,
-            };
-            if (!hasExecute) {
-              (toolUseEvent as import("@open-managed-agents/shared").AgentToolUseEvent).evaluated_permission = "ask";
-            }
-            runtime.broadcast(toolUseEvent);
-          } else {
-            const customToolUseEvent: SessionEvent = {
-              type: "agent.custom_tool_use",
-              id: call.toolCallId,
-              name: call.toolName,
-              input: callInput,
-            };
-            runtime.broadcast(customToolUseEvent);
-          }
-
-          // Find matching result by toolCallId
-          // AI SDK v6: toolResults use `output` instead of `result`
-          const tr = (toolResults as any[])?.find(
-            (r: any) => r.toolCallId === call.toolCallId
-          );
-          if (tr) {
-            const trOutput = tr.output ?? tr.result;
-            // Multimodal pass-through: if a tool returned a single ContentBlock
-            // (e.g. Read tool returning an image), wrap it in an array so the
-            // event content is ContentBlock[] rather than JSON-stringified.
-            const isContentBlock =
-              trOutput && typeof trOutput === "object" && "type" in trOutput &&
-              ((trOutput.type === "image" && "source" in trOutput) ||
-               (trOutput.type === "text" && "text" in trOutput) ||
-               (trOutput.type === "document" && "source" in trOutput));
-            const isContentBlockArray =
-              Array.isArray(trOutput) && trOutput.every(
-                (b) => b && typeof b === "object" && "type" in b,
-              );
-            const eventContent = isContentBlock
-              ? [trOutput]
-              : isContentBlockArray
-                ? trOutput
-                : typeof trOutput === "string"
-                  ? trOutput
-                  : JSON.stringify(trOutput);
-
-            if (isMcpTool(call.toolName)) {
-              const mcpResultEvent: SessionEvent = {
-                type: "agent.mcp_tool_result",
-                mcp_tool_use_id: call.toolCallId,
-                content: typeof eventContent === "string" ? eventContent : JSON.stringify(eventContent),
-              };
-              runtime.broadcast(mcpResultEvent);
-            } else {
-              const toolResultEvent: SessionEvent = {
-                type: "agent.tool_result",
-                tool_use_id: call.toolCallId,
-                content: eventContent,
-              };
-              runtime.broadcast(toolResultEvent);
-            }
-          }
-
-          if (call.toolName.startsWith("call_agent_") && tr) {
-            const trOutput = tr.output ?? tr.result;
-            runtime.broadcast({
-              type: "agent.thread_message_received",
-              from_thread_id: call.toolCallId,
-              content: [{ type: "text", text: typeof trOutput === "string" ? trOutput : "" }],
-            });
+      onStepFinish: async (step) => {
+        // Iterate step.content[] in order to preserve LLM output ordering
+        // (reasoning → text → tool-call interleaving). The previous "reasoning
+        // first, text next, tool-calls last" loop assumed an ordering AI SDK
+        // doesn't guarantee, breaking byte-determinism on derive().
+        //
+        // Each part maps to exactly one wire event. The mapping is the inverse
+        // of history.ts eventsToMessages — together they form the
+        // ModelMessage[] ↔ SessionEvent[] bijection that prompt-cache
+        // determinism rests on.
+        for (const part of step.content as ReadonlyArray<ContentPart<any>>) {
+          switch (part.type) {
+            case "reasoning":
+              runtime.broadcast({
+                type: "agent.thinking",
+                text: part.text,
+                providerOptions: part.providerMetadata as Record<string, unknown> | undefined,
+              });
+              break;
+            case "text":
+              // Trim trailing whitespace at write time. Anthropic's @ai-sdk
+              // provider trims the LAST text of the LAST assistant message
+              // before sending; without our normalization, the same stored
+              // assistant text would render with vs. without `\n` depending on
+              // whether it's the tail of the conversation, busting the cache
+              // on the next turn.
+              runtime.broadcast({
+                type: "agent.message",
+                content: [{ type: "text", text: part.text.replace(/\s+$/, "") }],
+              });
+              break;
+            case "tool-call":
+              emitToolCallEvent(runtime, tools, part);
+              break;
+            case "tool-result":
+            case "tool-error":
+              emitToolResultEvent(runtime, part);
+              break;
+            // source / file / tool-approval-request: not produced by current
+            // tool surface; intentionally skipped. Add cases here if those
+            // become reachable — the bijection requires every part write a
+            // matching wire event.
           }
         }
       },
@@ -312,6 +434,8 @@ export class DefaultHarness implements HarnessInterface {
       model_usage: result.usage ? {
         input_tokens: result.usage.inputTokens ?? 0,
         output_tokens: result.usage.outputTokens ?? 0,
+        cache_read_input_tokens: result.usage.inputTokenDetails?.cacheReadTokens ?? 0,
+        cache_creation_input_tokens: result.usage.inputTokenDetails?.cacheWriteTokens ?? 0,
       } : undefined,
       finish_reason: result.finishReason,
       final_text_length: typeof result.text === "string" ? result.text.length : 0,
@@ -325,4 +449,210 @@ export class DefaultHarness implements HarnessInterface {
       );
     }
   }
+
+  // -- Default hook implementations --
+  // Custom harnesses can override any of these by extending DefaultHarness
+  // and replacing the method, or by implementing HarnessInterface directly.
+
+  /**
+   * Default: simple eventsToMessages (already byte-deterministic + handles
+   * agent.thread_context_compacted boundary). Override for sliding window /
+   * RAG / hierarchical strategies.
+   */
+  deriveModelContext(events: SessionEvent[]) {
+    return eventsToMessages(events);
+  }
+
+  /**
+   * Default: delegate to this.compactionStrategy (configured in run() from
+   * agent.metadata overrides). Custom harnesses can override by extending
+   * DefaultHarness and replacing this method.
+   */
+  shouldCompact(events: SessionEvent[], ctx: { contextWindowTokens: number }): boolean {
+    return this.compactionStrategy.shouldCompact(events, ctx);
+  }
+
+  /**
+   * Default: run this.compactionStrategy.compact and broadcast the result
+   * as an `agent.thread_context_compacted` event with the summary attached.
+   * eventsToMessages then honors the boundary marker on subsequent derives.
+   *
+   * Threads systemPrompt + tools + the provider cache strategy through to
+   * the strategy so it can build a same-shape request that matches main
+   * agent's prefix bytes (cache reuse).
+   */
+  async compact(
+    events: SessionEvent[],
+    runtime: HarnessRuntime,
+    ctx: { model: LanguageModel; systemPrompt: string; tools: Record<string, any> },
+  ): Promise<void> {
+    const ctxWindow = resolveContextWindowTokens(ctx.model);
+    const result = await this.compactionStrategy.compact(events, {
+      model: ctx.model,
+      contextWindowTokens: ctxWindow,
+      systemPrompt: ctx.systemPrompt,
+      tools: ctx.tools,
+      applyCacheStrategy: (sys, tls, msgs) => applyProviderCacheStrategy(ctx.model, sys, tls, msgs),
+      runtime,
+    });
+    if (!result) return;
+    runtime.broadcast({
+      type: "agent.thread_context_compacted",
+      original_message_count: result.original_message_count,
+      compacted_message_count: result.compacted_message_count,
+      summary: result.summary,
+      trigger: "auto",
+      pre_tokens: result.pre_tokens,
+    });
+  }
+
+  /**
+   * Default: write each platformReminder as a `<system-reminder>` user.message
+   * event. Each reminder lands once at session-init time, becoming part of
+   * the cached prefix. The model treats them as user-side context (Claude
+   * recognizes <system-reminder> tags from training).
+   *
+   * SessionDO calls this exactly once per session, before the first turn.
+   * Custom harnesses can override to inject differently — or no-op to skip
+   * platform reminders entirely (e.g. RAG-based harness builds its own).
+   */
+  async onSessionInit(ctx: HarnessContext, runtime: HarnessRuntime): Promise<void> {
+    for (const r of ctx.platformReminders ?? []) {
+      runtime.broadcast({
+        type: "user.message",
+        content: [
+          {
+            type: "text",
+            text: `<system-reminder source="${r.source}">\n${r.text}\n</system-reminder>`,
+          },
+        ],
+      });
+    }
+  }
+}
+
+// === Token estimation + context-window resolution ===
+// Both are best-effort heuristics. The bijection itself doesn't depend on
+// these — they only drive WHEN to compact, not what the model sees.
+
+/** Crude: 4 chars ≈ 1 token. Fine for compaction trigger; not for billing. */
+function estimateMessageTokens(m: ModelMessage): number {
+  const s = typeof m.content === "string" ? m.content : JSON.stringify(m.content);
+  return Math.ceil(s.length / 4);
+}
+
+function estimateMessagesTokens(messages: ModelMessage[]): number {
+  let total = 0;
+  for (const m of messages) total += estimateMessageTokens(m);
+  return total;
+}
+
+/**
+ * Map a LanguageModel to its context window in tokens. ai-sdk doesn't
+ * expose this uniformly, so we hand-encode the common cases. Fallback to
+ * 200K (Claude 4+ minimum) if unknown.
+ */
+function resolveContextWindowTokens(model: LanguageModel): number {
+  const id = (model as any)?.modelId ?? (typeof model === "string" ? model : "");
+  if (typeof id !== "string") return 200_000;
+  if (id.includes("opus-4-7") || id.includes("opus-4-6") || id.includes("sonnet-4-6")) return 1_000_000;
+  if (id.includes("haiku-4-5")) return 200_000;
+  if (id.includes("opus") || id.includes("sonnet")) return 200_000;
+  if (id.includes("MiniMax")) return 1_000_000;
+  return 200_000;
+}
+
+// === Provider-specific prompt cache strategy ===
+//
+// AI SDK has no provider-agnostic cache abstraction. Each provider exposes
+// its own knobs via providerOptions, so we branch on model.provider:
+//   anthropic: cache_control breakpoints on system / last tool / mid / last msg
+//   openai:    automatic on the API side (no client-side knob to set)
+//   google:    cachedContent (different model — explicit cache resource creation)
+//   minimax:   TBD
+//   others:    no-op
+//
+// Adding a provider later: add a case below; the calling harness code
+// doesn't change.
+
+interface CacheStrategyResult {
+  system: string | SystemModelMessage | SystemModelMessage[];
+  tools: Record<string, any>;
+  messages: ModelMessage[];
+}
+
+function applyProviderCacheStrategy(
+  model: LanguageModel,
+  systemPrompt: string,
+  tools: Record<string, any>,
+  messages: ModelMessage[],
+): CacheStrategyResult {
+  const provider = (model as any)?.provider as string | undefined;
+  if (typeof provider === "string" && provider.toLowerCase().includes("anthropic")) {
+    return applyAnthropicCacheControl(systemPrompt, tools, messages);
+  }
+  // No-op for other providers — system stays a string, no providerOptions
+  // injected, no message mutation. Add cases here when wiring OpenAI /
+  // Gemini / MiniMax cache support.
+  return { system: systemPrompt, tools, messages };
+}
+
+/**
+ * Anthropic prompt-cache strategy — up to 4 breakpoints per request.
+ *
+ * Render order is tools → system → messages. Marks (in priority order):
+ *  1. `system` — promote string → SystemModelMessage with cacheControl.
+ *     Caches both `tools` (everything before system in the prefix) and
+ *     `system` itself.
+ *  2. last `tool` — covers the tool block alone if system also contained
+ *     dynamic content (defensive — system change shouldn't shift tools).
+ *  3. last `message` — the conversation tail breakpoint. Most cache hits
+ *     come from this on multi-turn chats.
+ *  4. mid-conversation `message` — only if messages.length > 30. Anthropic's
+ *     20-block lookback window means long single turns blow past the
+ *     boundary; an intermediate breakpoint catches reads inside the turn.
+ *
+ * All marker bytes are stable (cacheControl object is identical across
+ * turns), so adding them doesn't itself bust cache.
+ */
+function applyAnthropicCacheControl(
+  systemPrompt: string,
+  tools: Record<string, any>,
+  messages: ModelMessage[],
+): CacheStrategyResult {
+  const ephemeral = { anthropic: { cacheControl: { type: "ephemeral" } } };
+
+  // (1) System block as cached SystemModelMessage. Required for system to
+  // cache at all — string-form `system` is wrapped by the provider with no
+  // providerOptions, which means cache_control is omitted on the wire.
+  const system: SystemModelMessage = {
+    role: "system",
+    content: systemPrompt,
+    providerOptions: ephemeral,
+  };
+
+  // (2) Tools: tag the LAST tool's providerOptions so the entire tools
+  // block becomes a 2nd cache breakpoint.
+  const toolNames = Object.keys(tools);
+  let cachedTools: Record<string, any> = tools;
+  if (toolNames.length > 0) {
+    const lastName = toolNames[toolNames.length - 1];
+    const lastTool = tools[lastName];
+    cachedTools = {
+      ...tools,
+      [lastName]: {
+        ...lastTool,
+        providerOptions: { ...(lastTool?.providerOptions ?? {}), ...ephemeral },
+      },
+    };
+  }
+
+  // (3) Last 1 message — Claude Code style.
+  const cachedMessages: ModelMessage[] = messages.map((m) => ({ ...m }));
+  if (cachedMessages.length > 0) {
+    const last = cachedMessages[cachedMessages.length - 1] as any;
+    last.providerOptions = { ...(last.providerOptions ?? {}), ...ephemeral };
+  }
+
+  return { system, tools: cachedTools, messages: cachedMessages };
 }

--- a/apps/agent/src/harness/interface.ts
+++ b/apps/agent/src/harness/interface.ts
@@ -2,7 +2,75 @@ import type { ModelMessage, LanguageModel } from "ai";
 import type { AgentConfig, SessionEvent, UserMessageEvent } from "@open-managed-agents/shared";
 
 export interface HarnessInterface {
+  /** Main agent loop. Required. Drives generateText and emits events. */
   run(ctx: HarnessContext): Promise<void>;
+
+  /**
+   * Called once per session, after sandbox warmup, before the first user
+   * message is processed. Default behavior (DefaultHarness): inject
+   * <system-reminder> user.message events for each skill / memory_prompt /
+   * appendable_prompt the agent opted into. Override to substitute a custom
+   * RAG layer, or to opt out of platform reminders entirely (no-op).
+   *
+   * Anything written here lands in the events stream BEFORE the first user
+   * message — it becomes part of the cached prefix for every subsequent turn.
+   */
+  onSessionInit?(ctx: HarnessContext, runtime: HarnessRuntime): Promise<void>;
+
+  /**
+   * Decide whether to trigger compaction for this turn. Default behavior:
+   * estimate tokens via deriveModelContext + heuristic, fire when > 75% of
+   * the model's context window. Override for cooldown / business rules /
+   * never-compact / always-compact.
+   *
+   * `ctx.contextWindowTokens` is the resolved model's window (best-effort —
+   * may be a default if the model card doesn't expose it).
+   */
+  shouldCompact?(events: SessionEvent[], ctx: { contextWindowTokens: number }): boolean;
+
+  /**
+   * Execute compaction. Implementation MUST persist its product as a
+   * agent.thread_context_compacted event with `summary: ContentBlock[]`
+   * filled in (via runtime.broadcast). Default: send the FULL conversation
+   * (same model + system + tools as main agent's last call) to the model
+   * with a "summarize the above" user message appended — Anthropic's prompt
+   * cache then reads the prefix instead of recomputing it.
+   */
+  compact?(
+    events: SessionEvent[],
+    runtime: HarnessRuntime,
+    ctx: {
+      model: LanguageModel;
+      systemPrompt: string;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      tools: Record<string, any>;
+    },
+  ): Promise<void>;
+
+  /**
+   * Project events → ModelMessage[] for the next generateText call. Default:
+   * eventsToMessages — strict bijection inverse of writes, with
+   * agent.thread_context_compacted boundary handling. Override for
+   * sliding-window / RAG / hierarchical / no-compact strategies.
+   *
+   * Output MUST be byte-deterministic for any input — Anthropic's prompt
+   * cache invalidates on any prefix byte drift.
+   */
+  deriveModelContext?(events: SessionEvent[]): ModelMessage[];
+}
+
+export interface HarnessRuntime {
+  history: HistoryStore;
+  sandbox: SandboxExecutor;
+  /**
+   * Append an event to history AND broadcast to WS subscribers. The single
+   * write path for harness-emitted events (model output, system_reminder,
+   * compaction marker, custom marker, etc.).
+   */
+  broadcast: (event: SessionEvent) => void;
+  reportUsage?: (input_tokens: number, output_tokens: number) => Promise<void>;
+  pendingConfirmations?: string[];
+  abortSignal?: AbortSignal;
 }
 
 export interface HarnessContext {
@@ -16,8 +84,33 @@ export interface HarnessContext {
   /** Platform-prepared model: resolved from agent config with API key. */
   model: LanguageModel;
 
-  /** System prompt: base from agent.system + skill metadata additions. */
+  /**
+   * Platform-augmented system prompt: agent.system + authenticatedCommandGuidance.
+   * Skill/memory/appendable_prompt content is NOT here — that's injected as
+   * <system-reminder> user.message events via onSessionInit (default behavior).
+   * Use this directly to inherit platform defaults; ignore and use
+   * `rawSystemPrompt` if you want to take full control.
+   */
   systemPrompt: string;
+
+  /**
+   * Just `agent.system` verbatim, no platform additions. Use this when
+   * substituting a custom system prompt build path. Optional during the
+   * transition; SessionDO will populate it once task #9 lands.
+   */
+  rawSystemPrompt?: string;
+
+  /**
+   * Platform-resolved reminders the default `onSessionInit` will inject as
+   * `<system-reminder>` user.message events on first session run. Sources:
+   * skill metadata, memory_store prompts, opted-in appendable_prompts.
+   *
+   * Custom harnesses can ignore this and inject differently — or skip
+   * platform reminders entirely by overriding onSessionInit with a no-op.
+   * Each reminder lands as ONE event, persisted in the events stream
+   * before any user message, so it sits in the cached prefix forever.
+   */
+  platformReminders?: Array<{ source: string; text: string }>;
 
   env: {
     ANTHROPIC_API_KEY: string;
@@ -31,14 +124,7 @@ export interface HarnessContext {
     /** Register a background task for completion notification (CC-style task_notification). */
     watchBackgroundTask?: (taskId: string, pid: string, outputFile: string, proc: ProcessHandle | null) => void;
   };
-  runtime: {
-    history: HistoryStore;
-    sandbox: SandboxExecutor;
-    broadcast: (event: SessionEvent) => void;
-    reportUsage?: (input_tokens: number, output_tokens: number) => Promise<void>;
-    pendingConfirmations?: string[];
-    abortSignal?: AbortSignal;
-  };
+  runtime: HarnessRuntime;
 }
 
 export interface HistoryStore {

--- a/apps/agent/src/runtime/history.ts
+++ b/apps/agent/src/runtime/history.ts
@@ -8,172 +8,169 @@ import type {
   AgentToolResultEvent,
   AgentMcpToolUseEvent,
   AgentMcpToolResultEvent,
+  AgentCustomToolUseEvent,
+  AgentThreadContextCompactedEvent,
+  ContentBlock,
   UserMessageEvent,
 } from "@open-managed-agents/shared";
 import { generateEventId } from "@open-managed-agents/shared";
 
 /**
- * Convert an array of SessionEvents into AI SDK ModelMessage[] format.
- * Shared by SqliteHistory and InMemoryHistory to avoid duplication.
- * Groups tool_use + tool_result into proper assistant/tool message pairs.
+ * Convert SessionEvent[] → ModelMessage[]. The strict inverse of
+ * default-loop.ts onStepFinish writes — together they form the bijection
+ * that prompt-cache determinism rests on.
+ *
+ * Invariant: write(read(events)) === events at the byte level for every
+ * event sequence produced by onStepFinish (modulo lifecycle/span/notification
+ * events, which are intentionally not in model context). Any byte drift here
+ * busts Anthropic's cache from the drift point onward.
+ *
+ * Determinism rules:
+ *   - Pre-pass once to build toolCallId → toolName, so tool-result events can
+ *     resolve toolName even when the matching tool_use lies in a different
+ *     "flush window" (the old `pendingToolCalls.find` failed on that case
+ *     and produced "unknown" — a permanent cache miss).
+ *   - Iterate events strictly by storage order (caller's job to sort by seq).
+ *   - Honor the LAST agent.thread_context_compacted boundary that carries a
+ *     `summary` payload: build pre-boundary and post-boundary messages
+ *     separately, inject the summary, pick a CC-style tail of the
+ *     pre-boundary messages by token budget, then output
+ *     `[summary, ...tail, ...post-boundary]`. Boundary events without a
+ *     summary are pure UI signals (no effect here).
+ *   - Skip lifecycle.* / span.* / notification.* / agent.thread_message_*
+ *     and bare (summary-less) compaction events.
  */
 export function eventsToMessages(events: SessionEvent[]): ModelMessage[] {
+  // Pre-pass: gather toolName for every toolCallId emitted by ANY tool_use
+  // event. Resolves the cross-window lookup problem.
+  const toolNameById = new Map<string, string>();
+  for (const event of events) {
+    if (
+      event.type === "agent.tool_use" ||
+      event.type === "agent.mcp_tool_use" ||
+      event.type === "agent.custom_tool_use"
+    ) {
+      const e = event as AgentToolUseEvent | AgentMcpToolUseEvent | AgentCustomToolUseEvent;
+      const name = event.type === "agent.mcp_tool_use"
+        ? `mcp_${(e as AgentMcpToolUseEvent).mcp_server_name}_call`
+        : (e as AgentToolUseEvent | AgentCustomToolUseEvent).name;
+      toolNameById.set(e.id, name);
+    }
+  }
+
+  // Find the last compaction boundary that actually carries a summary —
+  // that's the one we honor. Earlier boundaries get superseded.
+  let boundaryIdx = -1;
+  let boundarySummary: ContentBlock[] | undefined;
+  for (let i = events.length - 1; i >= 0; i--) {
+    const e = events[i];
+    if (e.type === "agent.thread_context_compacted") {
+      const ce = e as AgentThreadContextCompactedEvent;
+      if (ce.summary && ce.summary.length > 0) {
+        boundaryIdx = i;
+        boundarySummary = ce.summary;
+        break;
+      }
+    }
+  }
+
+  // No boundary → walk everything straight through.
+  if (boundaryIdx < 0) {
+    return buildMessages(events, 0, events.length, toolNameById);
+  }
+
+  // Boundary exists. Build pre/post separately; pick CC-style tail from pre.
+  const preBoundary = buildMessages(events, 0, boundaryIdx, toolNameById);
+  const postBoundary = buildMessages(events, boundaryIdx + 1, events.length, toolNameById);
+  const tail = pickPreservedTail(preBoundary, {
+    minTokens: TAIL_MIN_TOKENS,
+    maxTokens: TAIL_MAX_TOKENS,
+    minMessages: TAIL_MIN_MESSAGES,
+  });
+
+  // Inject the boundary summary as a synthesized user message that opens
+  // the post-compaction view. Wrapped in <conversation-summary> tags so the
+  // model recognizes it as platform-injected context.
+  const summaryMessage: ModelMessage = {
+    role: "user",
+    content: [{ type: "text", text: serializeSummaryAsText(boundarySummary!) }],
+  };
+
+  return [summaryMessage, ...tail, ...postBoundary];
+}
+
+/**
+ * Walk events[fromIdx..toIdx) into ModelMessage[]. Maintains pending
+ * assistant + tool state internally, flushes at the end. Used by
+ * eventsToMessages on either the full stream, the pre-boundary range, or
+ * the post-boundary range.
+ */
+function buildMessages(
+  events: SessionEvent[],
+  fromIdx: number,
+  toIdx: number,
+  toolNameById: Map<string, string>,
+): ModelMessage[] {
   const messages: ModelMessage[] = [];
+  let pendingAssistantContent: AssistantModelMessage["content"] = [];
+  let pendingToolContent: ToolModelMessage["content"] = [];
 
-  let pendingToolCalls: Array<{
-    type: "tool-call";
-    toolCallId: string;
-    toolName: string;
-    input: Record<string, unknown>;
-  }> = [];
-  let pendingToolResults: Array<{
-    type: "tool-result";
-    toolCallId: string;
-    toolName: string;
-    output: { type: "text"; value: string };
-  }> = [];
-  // Reasoning parts emitted between the previous user/tool message and the
-  // upcoming assistant turn. Replayed as `{ type: "reasoning" }` parts so the
-  // model sees its own prior chain-of-thought (some providers require this for
-  // signature verification or context preservation).
-  let pendingReasoning: Array<{
-    type: "reasoning";
-    text: string;
-    providerOptions?: Record<string, unknown>;
-  }> = [];
-
+  const flushAssistant = () => {
+    if (pendingAssistantContent.length > 0) {
+      messages.push({ role: "assistant", content: pendingAssistantContent });
+      pendingAssistantContent = [];
+    }
+  };
   const flushTools = () => {
-    if (pendingToolCalls.length > 0) {
-      // Reasoning blocks emitted alongside the tool calls go in the SAME
-      // assistant message, BEFORE the tool calls — Anthropic schema requires
-      // thinking → tool_use ordering, and signature verification depends on
-      // it.
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const content: any[] = [...pendingReasoning, ...pendingToolCalls];
-      const assistantMsg: AssistantModelMessage = {
-        role: "assistant",
-        content,
-      };
-      const toolMsg: ToolModelMessage = {
-        role: "tool",
-        content: pendingToolResults,
-      };
-      messages.push(assistantMsg);
-      messages.push(toolMsg);
-      pendingToolCalls = [];
-      pendingToolResults = [];
-      pendingReasoning = [];
+    if (pendingToolContent.length > 0) {
+      messages.push({ role: "tool", content: pendingToolContent });
+      pendingToolContent = [];
     }
   };
 
-  for (const event of events) {
+  for (let i = fromIdx; i < toIdx; i++) {
+    const event = events[i];
     switch (event.type) {
       case "user.message": {
+        flushAssistant();
         flushTools();
-        const e = event as UserMessageEvent;
         messages.push({
           role: "user",
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          content: e.content.map((b): any => {
-            if (b.type === "text") {
-              return { type: "text" as const, text: b.text };
-            }
-            if (b.type === "image") {
-              if (b.source.type === "url" && b.source.url) {
-                return { type: "image" as const, image: new URL(b.source.url) };
-              }
-              // base64 or file reference
-              return {
-                type: "image" as const,
-                image: b.source.data || "",
-                mediaType: b.source.media_type,
-              };
-            }
-            if (b.type === "document") {
-              // Pass citations + title through as ai-sdk providerOptions so
-              // Anthropic's per-page citation anchors fire when the source PDF
-              // was uploaded with citations:{enabled:true}.
-              const providerOptions = (b.citations || b.title || b.context)
-                ? {
-                    anthropic: {
-                      ...(b.citations ? { citations: b.citations } : {}),
-                      ...(b.title ? { title: b.title } : {}),
-                      ...(b.context ? { context: b.context } : {}),
-                    },
-                  }
-                : undefined;
-              // ai-sdk v6 FilePart spec: data + mediaType (NOT mimeType).
-              // Schema validation rejects mimeType.
-              if (b.source.type === "url" && b.source.url) {
-                return {
-                  type: "file" as const,
-                  data: new URL(b.source.url),
-                  mediaType: b.source.media_type,
-                  ...(providerOptions ? { providerOptions } : {}),
-                };
-              }
-              if (b.source.type === "text") {
-                // Plain text document — send as text with context
-                const prefix = b.title ? `[${b.title}]\n` : "";
-                return { type: "text" as const, text: prefix + (b.source.data || "") };
-              }
-              return {
-                type: "file" as const,
-                data: b.source.data || "",
-                mediaType: b.source.media_type || "application/pdf",
-                ...(providerOptions ? { providerOptions } : {}),
-              };
-            }
-            // fallback
-            return { type: "text" as const, text: JSON.stringify(b) };
-          }),
+          content: userContentToParts((event as UserMessageEvent).content),
         });
         break;
       }
-      case "agent.message": {
-        const e = event as AgentMessageEvent;
-        // Reasoning that preceded this final assistant message must ride
-        // with it (Anthropic schema: thinking → text). Don't flushTools()
-        // first if there were no tool calls — drop reasoning into the
-        // assistant content directly.
-        if (pendingToolCalls.length > 0) {
-          flushTools();
-        }
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const content: any[] = [
-          ...pendingReasoning,
-          ...e.content.map((b) => ({ type: "text" as const, text: b.type === "text" ? b.text : "" })),
-        ];
-        messages.push({ role: "assistant", content });
-        pendingReasoning = [];
-        break;
-      }
       case "agent.thinking": {
+        flushTools();
         const e = event as AgentThinkingEvent;
-        if (e.text) {
-          pendingReasoning.push({
+        if (e.text != null) {
+          pendingAssistantContent.push({
             type: "reasoning",
             text: e.text,
-            ...(e.providerOptions ? { providerOptions: e.providerOptions } : {}),
+            ...(e.providerOptions ? { providerOptions: e.providerOptions as Record<string, any> } : {}),
           });
         }
         break;
       }
-      case "agent.tool_use": {
-        const e = event as AgentToolUseEvent;
-        pendingToolCalls.push({
-          type: "tool-call",
-          toolCallId: e.id,
-          toolName: e.name,
-          input: e.input,
-        });
+      case "agent.message": {
+        flushTools();
+        const e = event as AgentMessageEvent;
+        for (const block of e.content) {
+          if (block.type === "text") {
+            pendingAssistantContent.push({ type: "text", text: block.text });
+          }
+        }
         break;
       }
-      case "agent.mcp_tool_use": {
-        const e = event as AgentMcpToolUseEvent;
-        // MCP tools are registered as mcp_{server}_{call|list_tools} in the tool registry
-        const toolName = `mcp_${e.mcp_server_name}_call`;
-        pendingToolCalls.push({
+      case "agent.tool_use":
+      case "agent.mcp_tool_use":
+      case "agent.custom_tool_use": {
+        flushTools();
+        const e = event as AgentToolUseEvent | AgentMcpToolUseEvent | AgentCustomToolUseEvent;
+        const toolName = event.type === "agent.mcp_tool_use"
+          ? `mcp_${(e as AgentMcpToolUseEvent).mcp_server_name}_call`
+          : (e as AgentToolUseEvent | AgentCustomToolUseEvent).name;
+        pendingAssistantContent.push({
           type: "tool-call",
           toolCallId: e.id,
           toolName,
@@ -181,62 +178,233 @@ export function eventsToMessages(events: SessionEvent[]): ModelMessage[] {
         });
         break;
       }
-      case "agent.tool_result": {
-        const e = event as AgentToolResultEvent;
-        // Find matching tool call to get toolName
-        const matchingCall = pendingToolCalls.find(
-          (c) => c.toolCallId === e.tool_use_id
-        );
-        // content may be string OR ContentBlock[] (multimodal). Convert to AI SDK
-        // ToolResultOutput shape accordingly.
-        let output: { type: "text"; value: string } | { type: "content"; value: Array<{ type: "text"; text: string } | { type: "media" | "file-data"; data: string; mediaType: string }> };
-        if (typeof e.content === "string") {
-          output = { type: "text", value: e.content };
-        } else if (Array.isArray(e.content)) {
-          // Translate Anthropic-shape ContentBlock[] → AI SDK content parts
-          const parts = e.content.map((b) => {
-            if (b.type === "text") return { type: "text" as const, text: b.text };
-            if (b.type === "image" && b.source.type === "base64") {
-              return { type: "file-data" as const, data: b.source.data || "", mediaType: b.source.media_type || "image/png" };
-            }
-            if (b.type === "document" && b.source.type === "base64") {
-              return { type: "file-data" as const, data: b.source.data || "", mediaType: b.source.media_type || "application/pdf" };
-            }
-            return { type: "text" as const, text: JSON.stringify(b) };
-          });
-          output = { type: "content", value: parts };
-        } else {
-          output = { type: "text", value: JSON.stringify(e.content) };
-        }
-        pendingToolResults.push({
-          type: "tool-result",
-          toolCallId: e.tool_use_id,
-          toolName: matchingCall?.toolName ?? "unknown",
-          // @ts-expect-error AI SDK ToolResultPart.output union doesn't expose 'content' in our generated types,
-          // but the provider does accept it. See ToolResultOutput in @ai-sdk/provider-utils.
-          output,
-        });
-        break;
-      }
+      case "agent.tool_result":
       case "agent.mcp_tool_result": {
-        const e = event as AgentMcpToolResultEvent;
-        const matchingCall = pendingToolCalls.find(
-          (c) => c.toolCallId === e.mcp_tool_use_id
-        );
-        pendingToolResults.push({
+        flushAssistant();
+        const e = event as AgentToolResultEvent | AgentMcpToolResultEvent;
+        const toolCallId = event.type === "agent.tool_result"
+          ? (e as AgentToolResultEvent).tool_use_id
+          : (e as AgentMcpToolResultEvent).mcp_tool_use_id;
+        const toolName = toolNameById.get(toolCallId) ?? "unknown";
+        const output = wireContentToToolOutput((e as AgentToolResultEvent).content);
+        pendingToolContent.push({
           type: "tool-result",
-          toolCallId: e.mcp_tool_use_id,
-          toolName: matchingCall?.toolName ?? "unknown",
-          output: { type: "text", value: e.content },
+          toolCallId,
+          toolName,
+          output: output as any,
         });
         break;
       }
-      // session.status_idle, session.error — not part of messages
     }
   }
 
+  flushAssistant();
   flushTools();
   return messages;
+}
+
+// CC-style tail preservation params (sessionMemoryCompact.ts
+// DEFAULT_SM_COMPACT_CONFIG):
+//   minTokens: 10_000  maxTokens: 40_000  minTextMessages: 5
+const TAIL_MIN_TOKENS = 10_000;
+const TAIL_MAX_TOKENS = 40_000;
+const TAIL_MIN_MESSAGES = 5;
+// CC's microCompact.IMAGE_MAX_TOKEN_SIZE — images bill at a flat 2K each.
+const IMAGE_TOKEN_SIZE = 2_000;
+
+/**
+ * CC-style per-content-part token estimate (microCompact.ts:164). Text uses
+ * length/4; image/file blocks use a flat 2K; tool-use counts name + JSON
+ * input but not the id; reasoning counts the text but not the signature.
+ */
+function estimateContentPartTokens(part: unknown): number {
+  if (typeof part === "string") return Math.round(part.length / 4);
+  if (!part || typeof part !== "object") return 0;
+  const p = part as { type?: string; [k: string]: unknown };
+  switch (p.type) {
+    case "text":
+      return Math.round(((p.text as string) ?? "").length / 4);
+    case "reasoning":
+      // Match CC: count thinking text only; signature is metadata, not tokenized.
+      return Math.round(((p.text as string) ?? "").length / 4);
+    case "tool-call":
+      return Math.round((((p.toolName as string) ?? "") + JSON.stringify(p.input ?? {})).length / 4);
+    case "tool-result":
+      return estimateToolResultTokens(p.output);
+    case "image":
+    case "file":
+      return IMAGE_TOKEN_SIZE;
+    default:
+      return Math.round(JSON.stringify(part).length / 4);
+  }
+}
+
+function estimateToolResultTokens(output: unknown): number {
+  if (!output || typeof output !== "object") return 0;
+  const o = output as { type?: string; value?: unknown };
+  if (o.type === "text") return Math.round((((o.value as string) ?? "")).length / 4);
+  if (o.type === "content" && Array.isArray(o.value)) {
+    let sum = 0;
+    for (const item of o.value) {
+      if (item && typeof item === "object") {
+        const it = item as { type?: string; text?: string };
+        if (it.type === "text") sum += Math.round((it.text ?? "").length / 4);
+        else if (it.type === "image-data" || it.type === "image-url" || it.type === "file-data" || it.type === "file-url") sum += IMAGE_TOKEN_SIZE;
+        else sum += Math.round(JSON.stringify(item).length / 4);
+      }
+    }
+    return sum;
+  }
+  return Math.round(JSON.stringify(output).length / 4);
+}
+
+/**
+ * Per-message estimate, mirroring CC's `estimateMessageTokens`
+ * (microCompact.ts:164). Final result is padded by 4/3 to be conservative —
+ * matches CC's behavior so our tail-picking budget aligns with theirs.
+ */
+function estimateMessageTokensCC(m: ModelMessage): number {
+  let total = 0;
+  if (typeof m.content === "string") {
+    total = Math.round(m.content.length / 4);
+  } else if (Array.isArray(m.content)) {
+    for (const part of m.content) total += estimateContentPartTokens(part);
+  }
+  return Math.ceil((total * 4) / 3);
+}
+
+/**
+ * Walk messages backward, accumulating tokens, picking the largest tail
+ * that satisfies (min tokens AND min text-block messages, capped at max
+ * tokens). Tail must START on a user message — otherwise we'd send orphan
+ * assistant/tool messages without their preceding user turn.
+ */
+function pickPreservedTail(
+  messages: ModelMessage[],
+  opts: { minTokens: number; maxTokens: number; minMessages: number },
+): ModelMessage[] {
+  let tokens = 0;
+  let textMsgs = 0;
+  let tailStart = messages.length;
+
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const t = estimateMessageTokensCC(messages[i]);
+    // Hard cap: don't grow past max once we've selected at least one msg.
+    if (tailStart < messages.length && tokens + t > opts.maxTokens) break;
+
+    tokens += t;
+    if (messages[i].role === "user" || messages[i].role === "assistant") textMsgs++;
+    tailStart = i;
+
+    // Both minimums met AND we're on a user message → stop here so the tail
+    // starts cleanly on a user turn.
+    if (tokens >= opts.minTokens && textMsgs >= opts.minMessages && messages[i].role === "user") {
+      break;
+    }
+  }
+
+  // Final alignment: tail must START at a user message; walk forward to
+  // the next user message if we landed on something else.
+  while (tailStart < messages.length && messages[tailStart].role !== "user") tailStart++;
+
+  return messages.slice(tailStart);
+}
+
+/**
+ * Wire `string | ContentBlock[]` → AI SDK ToolResultOutput.
+ * Strict inverse of normalizeToolOutputForWire in default-loop.ts.
+ */
+function wireContentToToolOutput(
+  content: string | ContentBlock[],
+): { type: "text"; value: string } | { type: "content"; value: any[] } {
+  if (typeof content === "string") {
+    return { type: "text", value: content };
+  }
+  return {
+    type: "content",
+    value: content.map((b) => {
+      if (b.type === "text") return { type: "text", text: b.text };
+      if (b.type === "image" && b.source.type === "base64") {
+        return { type: "image-data", data: b.source.data ?? "", mediaType: b.source.media_type ?? "image/png" };
+      }
+      if (b.type === "image" && b.source.type === "url") {
+        return { type: "image-url", url: b.source.url ?? "", mediaType: b.source.media_type };
+      }
+      if (b.type === "document" && b.source.type === "base64") {
+        return { type: "file-data", data: b.source.data ?? "", mediaType: b.source.media_type ?? "application/pdf" };
+      }
+      if (b.type === "document" && b.source.type === "url") {
+        return { type: "file-url", url: b.source.url ?? "", mediaType: b.source.media_type };
+      }
+      return { type: "text", text: JSON.stringify(b) };
+    }),
+  };
+}
+
+/**
+ * UserMessageEvent.content → AI SDK user message content[].
+ * Kept simple — image/document mapping mirrors the writer's normalizations.
+ */
+function userContentToParts(blocks: ContentBlock[]): any[] {
+  return blocks.map((b): any => {
+    if (b.type === "text") return { type: "text", text: b.text };
+    if (b.type === "image") {
+      if (b.source.type === "url" && b.source.url) {
+        return { type: "image", image: new URL(b.source.url), mediaType: b.source.media_type };
+      }
+      return { type: "image", image: b.source.data ?? "", mediaType: b.source.media_type };
+    }
+    if (b.type === "document") {
+      const providerOptions = (b.citations || b.title || b.context)
+        ? {
+            anthropic: {
+              ...(b.citations ? { citations: b.citations } : {}),
+              ...(b.title ? { title: b.title } : {}),
+              ...(b.context ? { context: b.context } : {}),
+            },
+          }
+        : undefined;
+      if (b.source.type === "url" && b.source.url) {
+        return {
+          type: "file",
+          data: new URL(b.source.url),
+          mediaType: b.source.media_type,
+          ...(providerOptions ? { providerOptions } : {}),
+        };
+      }
+      if (b.source.type === "text") {
+        const prefix = b.title ? `[${b.title}]\n` : "";
+        return { type: "text", text: prefix + (b.source.data ?? "") };
+      }
+      return {
+        type: "file",
+        data: b.source.data ?? "",
+        mediaType: b.source.media_type ?? "application/pdf",
+        ...(providerOptions ? { providerOptions } : {}),
+      };
+    }
+    return { type: "text", text: JSON.stringify(b) };
+  });
+}
+
+/**
+ * Render boundary summary as a single text block with a structural marker.
+ * The model recognizes <conversation-summary> from training data; we tag
+ * the marker so it knows the preceding history is no longer in its window.
+ *
+ * Determinism: this serialization MUST be a pure function of `summary` —
+ * no timestamps, no IDs, no key reordering. The summary itself is stored
+ * verbatim in the boundary event, so its bytes are stable across turns.
+ */
+function serializeSummaryAsText(summary: ContentBlock[]): string {
+  const parts: string[] = ["<conversation-summary>"];
+  for (const block of summary) {
+    if (block.type === "text") parts.push(block.text);
+    else if (block.type === "image") parts.push("[image elided]");
+    else if (block.type === "document") parts.push(block.title ? `[document: ${block.title}]` : "[document]");
+  }
+  parts.push("</conversation-summary>");
+  return parts.join("\n");
 }
 
 /**

--- a/apps/agent/src/runtime/session-do.ts
+++ b/apps/agent/src/runtime/session-do.ts
@@ -88,6 +88,13 @@ interface SessionState {
   agent_snapshot?: AgentConfig;
   environment_snapshot?: EnvironmentConfig;
   vault_credentials?: Array<{ vault_id: string; credentials: CredentialConfig[] }>;
+  /**
+   * One-shot guard: harness.onSessionInit must run exactly once, before the
+   * first user-message-driven turn. Set true after the call lands so resumes
+   * / restarts don't re-inject reminders (which would write duplicate cached
+   * prefix bytes and bust the cache).
+   */
+  session_init_done?: boolean;
 }
 
 const INITIAL_SESSION_STATE: SessionState = {
@@ -1555,33 +1562,51 @@ export class SessionDO extends Agent<Env, SessionState> {
     const creds = await this.resolveModelCardCredentials(effectiveModelId, agent.model_card_id);
     const model = resolveModel(effectiveModelId, creds.apiKey, creds.baseURL, creds.apiCompat, creds.customHeaders);
 
-    // Build system prompt: base + skill metadata
-    let systemPrompt = agent.system || "";
+    // Build system prompt: ONLY agent.system + authenticatedCommandGuidance.
+    // Skill / memory_store / appendable_prompt content is NOT appended here —
+    // those are collected as platformReminders and injected by the harness's
+    // onSessionInit hook as <system-reminder> user.message events. This keeps
+    // the system field byte-stable across the session, which Anthropic's
+    // prompt cache requires for the cached prefix to survive past turn 1.
+    const rawSystemPrompt = agent.system || "";
     const authenticatedCommandGuidance =
       "For commands that may require authentication, prefer issuing a single command instead of a chained shell command. If an authenticated chained command fails, retry with a simpler single-command form.";
-    systemPrompt = systemPrompt
-      ? `${systemPrompt}\n\n${authenticatedCommandGuidance}`
+    const systemPrompt = rawSystemPrompt
+      ? `${rawSystemPrompt}\n\n${authenticatedCommandGuidance}`
       : authenticatedCommandGuidance;
+
+    // Collect platformReminders for harness.onSessionInit. These get
+    // resolved ONCE at session-init and become part of the events stream.
+    // KV reads happen here; the resulting bytes are frozen — no per-turn KV
+    // race conditions, no per-turn iteration-order drift.
+    const platformReminders: Array<{ source: string; text: string }> = [];
+
     if (agent.skills?.length) {
       // Built-in (anthropic) skills from the in-memory registry
       const builtinSkills = resolveSkills(agent.skills);
-      const additions = builtinSkills.map(s => s.system_prompt_addition).filter(Boolean);
+      for (const s of builtinSkills) {
+        if (s.system_prompt_addition) {
+          platformReminders.push({ source: `skill:${s.id}`, text: s.system_prompt_addition });
+        }
+      }
 
-      // Custom skills from KV — lightweight metadata for system prompt
+      // Custom skills from KV — lightweight metadata
       if (this.env.CONFIG_KV) {
         try {
           const customSkills = await resolveCustomSkills(agent.skills, this.env.CONFIG_KV, this.state.tenant_id);
-          additions.push(...customSkills.map(s => s.system_prompt_addition).filter(Boolean));
+          for (const s of customSkills) {
+            if (s.system_prompt_addition) {
+              platformReminders.push({ source: `skill:${s.id}`, text: s.system_prompt_addition });
+            }
+          }
         } catch {
           // Best-effort
         }
       }
 
-      if (additions.length) {
-        systemPrompt += "\n\n" + additions.join("\n\n");
-      }
-
-      // Mount custom skill files into sandbox (progressive disclosure)
+      // Mount custom skill files into sandbox (progressive disclosure).
+      // Unrelated to systemPrompt — keeps the sandbox-side files for the
+      // model to read on demand via skill tools.
       if (this.env.CONFIG_KV) {
         try {
           const skillFilesResults = await getSkillFiles(
@@ -1619,9 +1644,13 @@ export class SessionDO extends Agent<Env, SessionState> {
       }
     }
 
-    // Inject memory store prompts into system prompt
-    if (memoryPrompts.length) {
-      systemPrompt += "\n\n" + memoryPrompts.join("\n\n");
+    // Memory store prompts → platformReminders (was: appended to systemPrompt
+    // every turn, KV-list-order dependent → permanent cache miss).
+    for (let i = 0; i < memoryPrompts.length; i++) {
+      platformReminders.push({
+        source: `memory:${memoryStoreIds[i] ?? `idx${i}`}`,
+        text: memoryPrompts[i],
+      });
     }
 
     // Create an abort controller for this execution
@@ -1635,6 +1664,8 @@ export class SessionDO extends Agent<Env, SessionState> {
       tools: allTools,
       model,
       systemPrompt,
+      rawSystemPrompt,
+      platformReminders,
       env: {
         ANTHROPIC_API_KEY: this.env.ANTHROPIC_API_KEY,
         ANTHROPIC_BASE_URL: this.env.ANTHROPIC_BASE_URL,
@@ -1666,6 +1697,19 @@ export class SessionDO extends Agent<Env, SessionState> {
     };
 
     try {
+      // Run harness.onSessionInit exactly once per session, BEFORE the first
+      // running status. Default impl writes <system-reminder> user.message
+      // events for skills/memory/appendable_prompts; custom harnesses can
+      // substitute or skip. Idempotent across DO restarts via state flag.
+      if (!this.state.session_init_done && harness.onSessionInit) {
+        try {
+          await harness.onSessionInit(ctx, ctx.runtime);
+        } catch (err) {
+          console.warn(`[onSessionInit] failed: ${(err as Error).message}`);
+        }
+        this.setState({ ...this.state, session_init_done: true });
+      }
+
       // Broadcast running status
       const runningEvent: SessionEvent = { type: "session.status_running" };
       history.append(runningEvent);

--- a/packages/shared/src/trajectory/build.ts
+++ b/packages/shared/src/trajectory/build.ts
@@ -28,7 +28,7 @@ export interface SessionRecord extends SessionMeta {
 
 export interface FullStatus {
   status: string;
-  usage?: { input_tokens?: number; output_tokens?: number; cache_read_input_tokens?: number };
+  usage?: { input_tokens?: number; output_tokens?: number; cache_read_input_tokens?: number; cache_creation_input_tokens?: number };
   outcome_evaluations?: Array<{ result: string; iteration: number; feedback?: string }>;
 }
 
@@ -70,6 +70,7 @@ function computeSummary(events: StoredEvent[], usage: FullStatus["usage"], start
   let spanInTokens = 0;
   let spanOutTokens = 0;
   let spanCacheRead = 0;
+  let spanCacheCreate = 0;
 
   for (const e of events) {
     const data = parseEventData(e);
@@ -92,11 +93,12 @@ function computeSummary(events: StoredEvent[], usage: FullStatus["usage"], start
         break;
       }
       case "span.model_request_end": {
-        const u = (data as { model_usage?: { input_tokens?: number; output_tokens?: number; cache_read_input_tokens?: number } })?.model_usage;
+        const u = (data as { model_usage?: { input_tokens?: number; output_tokens?: number; cache_read_input_tokens?: number; cache_creation_input_tokens?: number } })?.model_usage;
         if (u) {
           spanInTokens += u.input_tokens || 0;
           spanOutTokens += u.output_tokens || 0;
           spanCacheRead += u.cache_read_input_tokens || 0;
+          spanCacheCreate += u.cache_creation_input_tokens || 0;
         }
         break;
       }
@@ -113,6 +115,7 @@ function computeSummary(events: StoredEvent[], usage: FullStatus["usage"], start
   const reportedIn = usage?.input_tokens || 0;
   const reportedOut = usage?.output_tokens || 0;
   const reportedCache = usage?.cache_read_input_tokens || 0;
+  const reportedCacheCreate = usage?.cache_creation_input_tokens || 0;
 
   return {
     num_events: events.length,
@@ -125,6 +128,7 @@ function computeSummary(events: StoredEvent[], usage: FullStatus["usage"], start
       input_tokens: Math.max(reportedIn, spanInTokens),
       output_tokens: Math.max(reportedOut, spanOutTokens),
       cache_read_input_tokens: Math.max(reportedCache, spanCacheRead),
+      cache_creation_input_tokens: Math.max(reportedCacheCreate, spanCacheCreate),
     },
   };
 }

--- a/packages/shared/src/trajectory/types.ts
+++ b/packages/shared/src/trajectory/types.ts
@@ -26,6 +26,7 @@ export interface TrajectorySummary {
     input_tokens: number;
     output_tokens: number;
     cache_read_input_tokens: number;
+    cache_creation_input_tokens: number;
   };
 }
 

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -174,6 +174,17 @@ export interface EventBase {
   id?: string;
   processed_at?: string;
   parent_event_id?: string; // optional causal predecessor in product domain (e.g. tool_result → tool_use, outcome.evaluation_end → agent.message it evaluated)
+  /**
+   * Free-form harness/platform metadata. Wire-compatible extension point —
+   * existing consumers ignore unknown fields. Use to namespace harness-emitted
+   * sub-types without inventing new top-level event types (which would break
+   * the wire format). Convention: include `harness: "<harness-name>"` plus
+   * a `kind: "..."` discriminator inside.
+   *
+   * Example: a custom RAG marker reuses `user.message` as wire type and
+   * tags `metadata: { harness: "rag", kind: "chunk", chunk_id: "..." }`.
+   */
+  metadata?: Record<string, unknown>;
 }
 
 // --- Session Events ---
@@ -332,6 +343,32 @@ export interface AgentThreadContextCompactedEvent extends EventBase {
   type: "agent.thread_context_compacted";
   original_message_count: number;
   compacted_message_count: number;
+  /**
+   * The summary that REPLACES the compacted region in model context.
+   * Persisted in the event so derive() doesn't recompute (recomputation
+   * would produce different bytes each turn → cache busts).
+   *
+   * When present, eventsToMessages() (and any custom deriveModelContext)
+   * MUST: drop all model-context events before this boundary, inject the
+   * summary as a synthesized user message at the boundary, then expand
+   * subsequent model-context events normally.
+   *
+   * Optional for backward compat: an event without `summary` is a pure
+   * notification (UI signal), and derive falls back to "no compaction
+   * happened" — i.e. it shows the full pre-boundary history. New events
+   * emitted by DefaultHarness always include `summary`.
+   */
+  summary?: ContentBlock[];
+  /**
+   * Optional: the seq range in the events table that this boundary
+   * replaces. Helps with debug / replay. Not required for derive
+   * (derive walks events forward from the boundary).
+   */
+  replaced_range?: { start_seq: number; end_seq: number };
+  /** Why compaction fired. Telemetry only. */
+  trigger?: "auto" | "manual";
+  /** Token count before compaction (best-effort estimate). Telemetry only. */
+  pre_tokens?: number;
 }
 
 // Session events
@@ -369,6 +406,7 @@ export interface SpanModelRequestEndEvent extends EventBase {
     input_tokens: number;
     output_tokens: number;
     cache_read_input_tokens?: number;
+    cache_creation_input_tokens?: number;
   };
   /** Why the model stopped: "stop" | "length" | "content-filter" | "tool-calls" | "error" | "other".
    *  Surfaces silent terminations (e.g. provider returns finish_reason="stop"
@@ -382,6 +420,27 @@ export interface SpanModelRequestEndEvent extends EventBase {
 export interface SpanOutcomeEvaluationStartEvent extends EventBase {
   type: "span.outcome_evaluation_start";
   iteration: number;
+}
+
+// Compaction summarize call — distinct span type so dashboards can attribute
+// summarize cost separately from main-loop model calls. Same shape as
+// SpanModelRequest{Start,End}.
+export interface SpanCompactionSummarizeStartEvent extends EventBase {
+  type: "span.compaction_summarize_start";
+  model?: string;
+}
+
+export interface SpanCompactionSummarizeEndEvent extends EventBase {
+  type: "span.compaction_summarize_end";
+  model?: string;
+  model_usage?: {
+    input_tokens: number;
+    output_tokens: number;
+    cache_read_input_tokens?: number;
+    cache_creation_input_tokens?: number;
+  };
+  finish_reason?: string;
+  final_text_length?: number;
 }
 
 export interface SpanOutcomeEvaluationOngoingEvent extends EventBase {
@@ -447,6 +506,8 @@ export type SessionEvent =
   | SpanOutcomeEvaluationStartEvent
   | SpanOutcomeEvaluationOngoingEvent
   | SpanOutcomeEvaluationEndEvent
+  | SpanCompactionSummarizeStartEvent
+  | SpanCompactionSummarizeEndEvent
   | AuxModelCallEvent;
 
 // --- Vault ---

--- a/rl/rollout.ts
+++ b/rl/rollout.ts
@@ -101,7 +101,7 @@ async function executeTask(
       session_id: handle.sessionId,
       turns: [],
       reward: { total: 0 },
-      token_usage: { input_tokens: 0, output_tokens: 0, cache_read_input_tokens: 0 },
+      token_usage: { input_tokens: 0, output_tokens: 0, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 },
       num_turns: 0,
       duration_ms: Date.now() - startTime,
       outcome: msg.includes("timeout") ? "timeout" : "error",
@@ -152,11 +152,12 @@ export async function batchRollout(
   await Promise.all(pending);
   await pool.destroyAll();
 
-  const totalTokens: TokenUsage = { input_tokens: 0, output_tokens: 0, cache_read_input_tokens: 0 };
+  const totalTokens: TokenUsage = { input_tokens: 0, output_tokens: 0, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 };
   for (const t of trajectories) {
     totalTokens.input_tokens += t.token_usage.input_tokens;
     totalTokens.output_tokens += t.token_usage.output_tokens;
     totalTokens.cache_read_input_tokens += t.token_usage.cache_read_input_tokens;
+    totalTokens.cache_creation_input_tokens += t.token_usage.cache_creation_input_tokens;
   }
 
   const rewardStats = batchRewardStats(trajectories.map((t) => t.reward));

--- a/rl/scorer-bridge.ts
+++ b/rl/scorer-bridge.ts
@@ -121,6 +121,7 @@ export function rlTrajectoryToPlatform(traj: RLTrajectory): PlatformTrajectory {
         input_tokens: traj.token_usage?.input_tokens || 0,
         output_tokens: traj.token_usage?.output_tokens || 0,
         cache_read_input_tokens: traj.token_usage?.cache_read_input_tokens || 0,
+        cache_creation_input_tokens: traj.token_usage?.cache_creation_input_tokens || 0,
       },
     },
   };

--- a/scripts/probe-cache-hit.ts
+++ b/scripts/probe-cache-hit.ts
@@ -1,0 +1,131 @@
+// Standalone probe: drive a multi-turn conversation through ai-sdk +
+// the @ai-sdk/anthropic provider, applying our cache strategy, and report
+// usage.cacheReadInputTokens / usage.cacheCreationInputTokens per turn.
+//
+// Run from repo root:
+//   ANTHROPIC_API_KEY=sk-ant-... npx tsx scripts/probe-cache-hit.ts
+//
+// Expected output:
+//   Turn 1: cache_creation HIGH (writes the prefix), cache_read = 0
+//   Turn 2: cache_creation small (just the new tail), cache_read HIGH
+//   Turn 3: cache_creation small, cache_read HIGHER (prior turn now cached too)
+//
+// If cache_read stays 0 across turns, something's busting the prefix.
+
+import { generateText } from "ai";
+import type { ModelMessage, SystemModelMessage } from "ai";
+import { createAnthropic } from "@ai-sdk/anthropic";
+
+const apiKey = process.env.ANTHROPIC_API_KEY ?? process.env.ANTHROPIC_AUTH_TOKEN;
+if (!apiKey) {
+  console.error("Set ANTHROPIC_API_KEY (or ANTHROPIC_AUTH_TOKEN).");
+  process.exit(1);
+}
+
+function parseHeaders(raw: string | undefined): Record<string, string> | undefined {
+  if (!raw) return undefined;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    // Not JSON — treat as `Header: value` lines (Claude Code env shape).
+    const out: Record<string, string> = {};
+    for (const line of raw.split(/\r?\n/)) {
+      const idx = line.indexOf(":");
+      if (idx > 0) out[line.slice(0, idx).trim()] = line.slice(idx + 1).trim();
+    }
+    return Object.keys(out).length ? out : undefined;
+  }
+}
+
+const anthropic = createAnthropic({
+  apiKey,
+  baseURL: process.env.ANTHROPIC_BASE_URL,
+  headers: parseHeaders(process.env.ANTHROPIC_CUSTOM_HEADERS),
+});
+
+// Make the system prompt large enough that caching is meaningful.
+// Anthropic's minimum cacheable prefix on Sonnet 4.6 is 1024 tokens; on
+// Opus 4.7 it's 4096. We pad to ~6K characters (~1.5K tokens) so it crosses
+// Sonnet's threshold but still feels like a realistic system prompt.
+const PADDING = (
+  "You are an exhaustive technical assistant. " +
+  "Be precise, be specific, give examples. ".repeat(120)
+);
+const SYSTEM_PROMPT = `${PADDING}\n\nWhen asked questions, answer in 2 sentences.`;
+
+const ephemeral = { anthropic: { cacheControl: { type: "ephemeral" } } } as const;
+
+function withSystem(): SystemModelMessage {
+  return {
+    role: "system",
+    content: SYSTEM_PROMPT,
+    providerOptions: ephemeral,
+  };
+}
+
+function markLast(messages: ModelMessage[]): ModelMessage[] {
+  if (messages.length === 0) return messages;
+  const cloned = messages.map((m) => ({ ...m }));
+  const last = cloned[cloned.length - 1] as any;
+  last.providerOptions = { ...(last.providerOptions ?? {}), ...ephemeral };
+  return cloned;
+}
+
+const QUESTIONS = [
+  "What's the capital of France?",
+  "And what about Germany?",
+  "What's the population of the German one?",
+  "Which country has more historical castles?",
+];
+
+async function main() {
+  const model = anthropic(process.env.PROBE_MODEL ?? "claude-sonnet-4-6");
+  const conversation: ModelMessage[] = [];
+
+  console.log(
+    `Model: ${(model as any).modelId ?? "unknown"}  base=${process.env.ANTHROPIC_BASE_URL ?? "default"}`,
+  );
+  console.log(`System prompt: ${SYSTEM_PROMPT.length} chars (~${Math.round(SYSTEM_PROMPT.length / 4)} tokens)`);
+  console.log("---");
+
+  for (let i = 0; i < QUESTIONS.length; i++) {
+    conversation.push({ role: "user", content: [{ type: "text", text: QUESTIONS[i] }] });
+
+    const t0 = Date.now();
+    const result = await generateText({
+      model,
+      system: withSystem(),
+      messages: markLast(conversation),
+      maxOutputTokens: 200,
+    });
+    const elapsed = Date.now() - t0;
+
+    const u = result.usage as any;
+    const inp = u?.inputTokens ?? u?.promptTokens ?? 0;
+    const out = u?.outputTokens ?? u?.completionTokens ?? 0;
+    const cacheRead = u?.cacheReadInputTokens ?? u?.cache_read_input_tokens ?? 0;
+    const cacheCreate = u?.cacheCreationInputTokens ?? u?.cache_creation_input_tokens ?? 0;
+
+    console.log(
+      `Turn ${i + 1} (${elapsed}ms): in=${inp} out=${out} cache_read=${cacheRead} cache_create=${cacheCreate}`,
+    );
+
+    // Append assistant turn back into conversation
+    for (const m of result.response.messages) {
+      conversation.push(m);
+    }
+  }
+
+  console.log("---");
+  console.log(
+    "Expected: turn 1 cache_create > 0; turn 2+ cache_read >= system prompt size, cache_create small.",
+  );
+  console.log(
+    "If cache_read stays 0: prefix bytes are drifting between turns (system / tools / messages).",
+  );
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/probe-harness-cache.ts
+++ b/scripts/probe-harness-cache.ts
@@ -1,0 +1,383 @@
+// End-to-end harness probe: drive a multi-turn conversation through the
+// real DefaultHarness (NOT bypassing it), with a fake MCP tool, a built-in
+// bash tool stub, and skill `<system-reminder>` injection via onSessionInit.
+//
+// Captures every event the harness broadcasts. Each turn we report:
+//   • span.model_request_end → cache_read / cache_create
+//   • running totals across turns
+//
+// Run from repo root:
+//   ANTHROPIC_API_KEY=sk-ant-... npx tsx scripts/probe-harness-cache.ts
+//
+// What "good" looks like:
+//   Turn 1: cache_create > 0  (writes the prefix)
+//           cache_read   = 0
+//   Turn 2: cache_create small  (just the new tail)
+//           cache_read >= system_prompt_size + skill_reminder_size + tools
+//   Turn 3+: cache_read keeps growing as more turns enter the cached prefix
+//
+// If cache_read stays 0: prefix bytes are drifting between turns. Likely
+// suspects (in order): system field changed, tool order changed, or some
+// content went through nondeterministic JSON.stringify.
+
+import { tool } from "ai";
+import { createAnthropic } from "@ai-sdk/anthropic";
+import { z } from "zod";
+import { DefaultHarness } from "../apps/agent/src/harness/default-loop";
+import { InMemoryHistory } from "../apps/agent/src/runtime/history";
+import type { HarnessContext, HarnessRuntime } from "../apps/agent/src/harness/interface";
+import type {
+  SessionEvent,
+  SpanModelRequestEndEvent,
+  AgentConfig,
+} from "@open-managed-agents/shared";
+
+// ---- env ----
+// Two auth modes:
+//   1. ANTHROPIC_API_KEY (sk-ant-...) → standard x-api-key against api.anthropic.com
+//   2. PROBE_AUTH_TOKEN + PROBE_BASE_URL → bearer auth against a custom proxy
+//
+// We deliberately ignore inherited ANTHROPIC_AUTH_TOKEN/BASE_URL because
+// Claude Code's defaults point at platform-api.xaminim.com, which speaks a
+// different protocol than Anthropic's Messages API and returns "Invalid
+// JSON response" on direct ai-sdk calls. To probe through that proxy,
+// re-export them as PROBE_* explicitly.
+const apiKey = process.env.ANTHROPIC_API_KEY;
+const probeToken = process.env.PROBE_AUTH_TOKEN;
+const probeBase = process.env.PROBE_BASE_URL;
+
+if (!apiKey && !probeToken) {
+  console.error(
+    "Set ANTHROPIC_API_KEY (sk-ant-...) for the standard endpoint, or PROBE_AUTH_TOKEN + PROBE_BASE_URL for a custom proxy.",
+  );
+  process.exit(1);
+}
+if (probeToken && !probeBase) {
+  console.error("PROBE_AUTH_TOKEN set but PROBE_BASE_URL missing.");
+  process.exit(1);
+}
+
+function parseHeaders(raw: string | undefined): Record<string, string> | undefined {
+  if (!raw) return undefined;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    const out: Record<string, string> = {};
+    for (const line of raw.split(/\r?\n/)) {
+      const idx = line.indexOf(":");
+      if (idx > 0) out[line.slice(0, idx).trim()] = line.slice(idx + 1).trim();
+    }
+    return Object.keys(out).length ? out : undefined;
+  }
+}
+
+// Empty — direct providers (api.minimaxi.com, api.anthropic.com) don't
+// require any X-Sub-Module or X-From routing headers. Only the company
+// proxy (platform-api.xaminim.com) does.
+const PROBE_HEADERS: Record<string, string> = {};
+
+let reqIdx = 0;
+const debugFetch: typeof fetch = async (input, init) => {
+  // No beta stripping — testing whether X-From routes around the cache
+  // bypass that hits when X-Sub-Module:claude-code-internal sees any beta.
+  let cleanInit = init;
+  if (cleanInit?.body && process.env.PROBE_DUMP_BODY === "1") {
+    try {
+      const body = typeof cleanInit.body === "string" ? cleanInit.body : "";
+      const fs = await import("fs");
+      fs.writeFileSync(`/tmp/probe-body-${reqIdx++}.json`, body);
+    } catch {}
+  }
+  // No header stripping — opt out via providerOptions.anthropic.structuredOutputMode
+  // = "jsonTool" passed to generateText below. ai-sdk only adds the
+  // structured-outputs beta when supportsStructuredOutput && mode==="auto".
+  if (cleanInit?.body && process.env.PROBE_DUMP === "1") {
+    try {
+      const body = typeof init.body === "string" ? init.body : "";
+      const parsed = JSON.parse(body);
+      const hash = (v: any) => {
+        const s = JSON.stringify(v);
+        let h = 0;
+        for (let i = 0; i < s.length; i++) h = ((h << 5) - h + s.charCodeAt(i)) | 0;
+        return `len=${s.length} h=${h.toString(16)}`;
+      };
+      const slim = {
+        system: hash(parsed.system),
+        tools: hash(parsed.tools),
+        msg_count: parsed.messages?.length,
+        msg_hashes: parsed.messages?.map((m: any, i: number) => `${i}:${m.role}:${hash(m).split(" ")[1]}`),
+      };
+      console.log("\n[REQ]", JSON.stringify(slim));
+      console.log("[URL]", typeof input === "string" ? input : (input as URL).toString());
+      console.log("[HEADERS]", JSON.stringify(cleanInit.headers));
+    } catch {}
+  }
+  return fetch(input, cleanInit);
+};
+
+const anthropic = createAnthropic(
+  apiKey
+    ? { apiKey, fetch: debugFetch, supportsNativeStructuredOutput: false } as any
+    : {
+        authToken: probeToken!,
+        baseURL: probeBase,
+        headers: PROBE_HEADERS,
+        fetch: debugFetch,
+        supportsNativeStructuredOutput: false,
+      } as any,
+);
+const model = anthropic(process.env.PROBE_MODEL ?? "claude-sonnet-4-6");
+
+// ---- tools (real shape, fake execution) ----
+// Stub outputs are deliberately large (~5KB each). With CC-style defaults
+// (min 10K-token tail, 40K max) the probe needs real volume in tool results
+// to hit the trigger threshold within 16 turns.
+const FAKE_FILE_LISTING = Array.from({ length: 100 }, (_, i) =>
+  `-rw-r--r--  1 user  staff  ${(i * 137) % 9999}  Apr 22 ${(i % 23) + 1}:${(i * 7) % 60} module-${i.toString().padStart(3, "0")}.ts`,
+).join("\n");
+
+const FAKE_GREP_OUTPUT = Array.from({ length: 80 }, (_, i) =>
+  `src/handlers/route-${i}.ts:${(i * 31) % 500 + 10}:  export async function handle${i}(req: Request, ctx: Context): Promise<Response> {`,
+).join("\n");
+
+const FAKE_GH_ISSUE_LIST = JSON.stringify(
+  Array.from({ length: 30 }, (_, i) => ({
+    number: 1000 + i,
+    title: `Issue #${1000 + i}: investigate ${["latency", "memory leak", "cache miss", "auth bug"][i % 4]} in ${["worker", "do", "router", "queue"][i % 4]}`,
+    state: "open",
+    labels: ["bug", "p1", "needs-repro"],
+    body: `Customer reports degraded performance in ${["us-east", "eu-west", "ap-south"][i % 3]} region starting around ${i + 1} days ago. Repro steps: spin up a fresh deploy, send 100 RPS for 5 min, observe p99 latency climb past 800ms. Expected: stays under 200ms. Logs attached.`,
+  })),
+  null,
+  2,
+);
+
+// `bash` mimics a built-in tool. Returns ~5KB of canned output.
+const bash = tool({
+  description: "Execute a shell command (probe stub — returns canned output).",
+  inputSchema: z.object({ command: z.string().describe("the shell command to run") }),
+  execute: async ({ command }) => {
+    if (/grep|rg|find/i.test(command)) {
+      return `$ ${command}\n${FAKE_GREP_OUTPUT}\n\n[probe stub: 80 matches in 12 files]`;
+    }
+    return `$ ${command}\n${FAKE_FILE_LISTING}\n\n[probe stub: 100 entries]`;
+  },
+});
+
+// `mcp_github_call` mimics an MCP-routed tool. Returns ~3KB JSON payload.
+const mcpGithubCall = tool({
+  description: "Call a GitHub MCP method (probe stub).",
+  inputSchema: z.object({
+    method: z.string().describe("the MCP method name (e.g. list_issues, get_pr)"),
+    args: z.record(z.string(), z.any()).optional(),
+  }),
+  execute: async ({ method }) => {
+    return JSON.stringify({ ok: true, method, fake: true, data: FAKE_GH_ISSUE_LIST });
+  },
+});
+
+const tools = { bash, mcp_github_call: mcpGithubCall };
+
+// ---- platformReminders (simulate skill metadata + memory) ----
+const platformReminders = [
+  {
+    source: "skill:web-research",
+    text: "When asked about current events, prefer the web_search tool over guessing. Always cite the URL you got the answer from.",
+  },
+  {
+    source: "skill:github-ops",
+    text: "Use mcp_github_call for any GitHub queries (issues, PRs, repo metadata). Do not invent issue numbers.",
+  },
+  {
+    source: "memory:user_prefs",
+    text: "User prefers responses under 3 sentences unless they explicitly ask for detail.",
+  },
+];
+
+// ---- runtime ----
+const history = new InMemoryHistory();
+const eventLog: SessionEvent[] = [];
+
+const runtime: HarnessRuntime = {
+  history: history as any,
+  sandbox: {
+    exec: async (cmd: string) => `[probe stub exec] ${cmd}`,
+    readFile: async () => "",
+    writeFile: async () => "",
+  } as any,
+  broadcast: (event: SessionEvent) => {
+    history.append(event);
+    eventLog.push(event);
+  },
+  reportUsage: async () => {},
+  pendingConfirmations: [],
+};
+
+// ---- ctx ----
+const agent: Partial<AgentConfig> = {
+  id: "probe",
+  name: "probe-agent",
+  model: "claude-sonnet-4-6" as any,
+  // ~80K char (~20K tokens) system prompt — close to real OMA agents.
+  system: "You are a probe agent. Answer briefly. " +
+    ("Be exhaustive in your reasoning. Be specific. Cite tools. Provide examples. ".repeat(1100)),
+  // Probe knob: low trigger fraction so we actually hit shouldCompact()
+  // within a 16-turn run. Real prod uses default 0.75. Tail params are CC
+  // defaults (10K min / 40K max / 5 min msgs); override via metadata if you
+  // want to probe with different numbers. 0.04 of 1M ctx = ~40K trigger,
+  // which the bigger tool-stub outputs cross around turn 7-8.
+  metadata: {
+    compaction_trigger_fraction: process.env.PROBE_COMPACTION_TRIGGER
+      ? Number(process.env.PROBE_COMPACTION_TRIGGER)
+      : 0.04,
+  } as Record<string, unknown>,
+};
+
+const SYSTEM_AUTHENTICATED_GUIDANCE =
+  "For commands that may require authentication, prefer issuing a single command instead of a chained shell command. If an authenticated chained command fails, retry with a simpler single-command form.";
+const systemPrompt = `${agent.system}\n\n${SYSTEM_AUTHENTICATED_GUIDANCE}`;
+
+const baseCtx: Omit<HarnessContext, "userMessage"> = {
+  agent: agent as AgentConfig,
+  tools,
+  model,
+  systemPrompt,
+  rawSystemPrompt: agent.system!,
+  platformReminders,
+  env: {
+    ANTHROPIC_API_KEY: apiKey ?? probeToken ?? "",
+  } as any,
+  runtime,
+};
+
+// ---- run ----
+// Tool-driving questions: each prompt explicitly forces a bash or
+// mcp_github_call invocation so the ~5KB stub outputs accumulate fast and
+// we hit the 0.10 trigger fraction before turn 16.
+const QUESTIONS = [
+  "Run `ls -la src/` and tell me what you see in one sentence.",
+  "Now grep for 'export async function handle' under src/handlers and report the top 3 matches.",
+  "Use mcp_github_call to list_issues; then summarize the most common label in one sentence.",
+  "Run `find . -name '*.ts'` and pick one filename that looks interesting — just one.",
+  "Grep for 'import' in src/ and tell me how many imports total (one number).",
+  "Use mcp_github_call to get_repo_meta; then say one thing about the repo in a sentence.",
+  "Run `ls /etc` and pick one config file name.",
+  "Now grep for 'TODO' under src/ and report the count.",
+  "Use mcp_github_call to list_prs; tell me one PR title.",
+  "Run `find /var/log -type f` and pick one log file.",
+  "Grep for 'class ' in src/ and tell me one class name.",
+  "Use mcp_github_call to list_issues for label=bug; tell me the issue count in one sentence.",
+  "Run `ls /usr/local/bin` and pick one binary.",
+  "Grep for 'function' under src/handlers and report top 3.",
+  "Use mcp_github_call to get_workflow_runs; one sentence on status.",
+  "Final summary: which tool did you use most, in one sentence.",
+];
+
+async function main() {
+  const harness = new DefaultHarness();
+
+  console.log(`Model: ${(model as any).modelId}`);
+  console.log(`System prompt: ${systemPrompt.length} chars`);
+  console.log(`Tools: ${Object.keys(tools).join(", ")}`);
+  console.log(`Skill reminders: ${platformReminders.length}`);
+  console.log("---");
+
+  // session-init: write skill/memory reminders into history (cached prefix)
+  await harness.onSessionInit?.(baseCtx as HarnessContext, runtime);
+
+  let totalIn = 0, totalOut = 0, totalRead = 0, totalCreate = 0;
+
+  for (let i = 0; i < QUESTIONS.length; i++) {
+    const userEvent: SessionEvent = {
+      type: "user.message",
+      content: [{ type: "text", text: QUESTIONS[i] }],
+    };
+    history.append(userEvent);
+    eventLog.push(userEvent);
+
+    const t0 = Date.now();
+    try {
+      await harness.run({ ...baseCtx, userMessage: userEvent } as HarnessContext);
+    } catch (err) {
+      console.error(`turn ${i + 1} failed:`, (err as Error).message);
+      break;
+    }
+    const elapsed = Date.now() - t0;
+
+    // Find the latest span.model_request_end in the captured event log
+    const lastSpan = [...eventLog]
+      .reverse()
+      .find((e) => e.type === "span.model_request_end") as SpanModelRequestEndEvent | undefined;
+    const u = lastSpan?.model_usage;
+    const inp = u?.input_tokens ?? 0;
+    const out = u?.output_tokens ?? 0;
+    const cacheRead = u?.cache_read_input_tokens ?? 0;
+    const cacheCreate = u?.cache_creation_input_tokens ?? 0;
+    totalIn += inp; totalOut += out; totalRead += cacheRead; totalCreate += cacheCreate;
+
+    const tools_used = eventLog
+      .filter((e) => e.type === "agent.tool_use" || e.type === "agent.mcp_tool_use" || e.type === "agent.custom_tool_use")
+      .length;
+    const compactions = eventLog.filter((e) => e.type === "agent.thread_context_compacted");
+
+    console.log(
+      `Turn ${i + 1} (${elapsed}ms): in=${inp} out=${out} cache_read=${cacheRead} cache_create=${cacheCreate}  tools_called_so_far=${tools_used} compactions=${compactions.length}`,
+    );
+  }
+
+  console.log("---");
+  console.log(`TOTAL: in=${totalIn} out=${totalOut} cache_read=${totalRead} cache_create=${totalCreate}`);
+  const reuseRatio = totalIn > 0 ? (totalRead / totalIn).toFixed(2) : "n/a";
+  console.log(`Cache reuse ratio: ${reuseRatio} (cache_read / input_tokens — higher is better)`);
+  console.log(`Total events captured: ${eventLog.length}`);
+
+  // Quick verdict
+  if (totalRead === 0) {
+    console.log("\nVERDICT: cache_read stayed 0 across all turns. The prefix is drifting somewhere.");
+  } else if (totalRead > totalCreate) {
+    console.log("\nVERDICT: cache reuse > cache writes. Cache is working.");
+  } else {
+    console.log("\nVERDICT: some cache reuse but lower than write. Could be a short prefix; try more turns.");
+  }
+
+  // Compaction summary
+  const compEvents = eventLog.filter((e) => e.type === "agent.thread_context_compacted") as Array<any>;
+  if (compEvents.length > 0) {
+    console.log(`\nCompactions fired: ${compEvents.length}`);
+    for (let i = 0; i < compEvents.length; i++) {
+      const c = compEvents[i];
+      const summaryText = c.summary?.map((b: any) => b.type === "text" ? b.text : "").join(" ") || "";
+      console.log(`  #${i + 1} pre_tokens=${c.pre_tokens}  msgs ${c.original_message_count}→${c.compacted_message_count}  summary_len=${summaryText.length} chars`);
+      console.log(`     summary[0..200]: ${summaryText.slice(0, 200)}${summaryText.length > 200 ? "…" : ""}`);
+
+      // Find the dedicated summarize-span event for this compaction.
+      // The strategy broadcasts span.compaction_summarize_end right before
+      // it returns the result; that result is then turned into the
+      // boundary event we're inspecting now. So the latest
+      // compaction_summarize_end before this compaction event is ours.
+      const compIdx = eventLog.indexOf(c);
+      let summarizeSpan: any;
+      for (let j = compIdx - 1; j >= 0; j--) {
+        if (eventLog[j].type === "span.compaction_summarize_end") {
+          summarizeSpan = eventLog[j];
+          break;
+        }
+      }
+      if (summarizeSpan?.model_usage) {
+        const u = summarizeSpan.model_usage;
+        const totalIn = (u.input_tokens ?? 0) + (u.cache_read_input_tokens ?? 0) + (u.cache_creation_input_tokens ?? 0);
+        const reuse = totalIn > 0 ? ((u.cache_read_input_tokens ?? 0) / totalIn).toFixed(2) : "n/a";
+        console.log(`     summarize call: in=${u.input_tokens ?? 0} out=${u.output_tokens ?? 0} cache_read=${u.cache_read_input_tokens ?? 0} cache_create=${u.cache_creation_input_tokens ?? 0} reuse=${reuse} finish=${summarizeSpan.finish_reason} text_len=${summarizeSpan.final_text_length}`);
+      } else {
+        console.log(`     summarize call: no span event found`);
+      }
+    }
+  } else {
+    console.log("\nNo compactions fired (didn't cross trigger threshold).");
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/test/eval/runner.ts
+++ b/test/eval/runner.ts
@@ -453,7 +453,7 @@ function synthesizeTrajectory(taskId: string, events: SSEEvent[]): Trajectory {
       num_tool_errors: numToolErrors,
       num_threads: 0,
       duration_ms: 0,
-      token_usage: { input_tokens: 0, output_tokens: 0, cache_read_input_tokens: 0 },
+      token_usage: { input_tokens: 0, output_tokens: 0, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 },
     },
   };
 }

--- a/test/unit/bijection-invariants.test.ts
+++ b/test/unit/bijection-invariants.test.ts
@@ -1,0 +1,284 @@
+// @ts-nocheck
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+import { env } from "cloudflare:workers";
+import { describe, it, expect } from "vitest";
+import { eventsToMessages } from "../../apps/agent/src/runtime/history";
+import type {
+  SessionEvent,
+  AgentToolUseEvent,
+  AgentToolResultEvent,
+} from "@open-managed-agents/shared";
+
+// ============================================================
+// Bijection / determinism — write/read invariants for prompt cache
+// ============================================================
+//
+// These guard the contract default-loop.ts onStepFinish + history.ts
+// eventsToMessages must satisfy: same input events → same output bytes,
+// every turn, forever. Anthropic's prompt cache breaks the moment any
+// prefix byte drifts — these tests catch the drift before deploy.
+
+describe("eventsToMessages — bijection invariants", () => {
+  // Mixed event stream covering namespaces that should drop vs keep
+  const mixedEvents: SessionEvent[] = [
+    { type: "user.message", content: [{ type: "text", text: "find todos" }] },
+    // span / lifecycle events MUST be filtered out (not in model context)
+    { type: "span.model_request_start", model: "claude-sonnet-4-6" } as any,
+    { type: "lifecycle.status_running" } as any,
+    {
+      type: "agent.thinking",
+      text: "let me grep first",
+      providerOptions: { anthropic: { signature: "abc123" } },
+    },
+    { type: "agent.message", content: [{ type: "text", text: "I'll search." }] },
+    {
+      type: "agent.tool_use",
+      id: "tc_grep",
+      name: "grep",
+      input: { pattern: "TODO" },
+    } as AgentToolUseEvent,
+    {
+      type: "agent.tool_result",
+      tool_use_id: "tc_grep",
+      content: "found 3",
+    } as AgentToolResultEvent,
+    { type: "span.model_request_end", model: "claude-sonnet-4-6" } as any,
+    { type: "agent.message", content: [{ type: "text", text: "Found 3." }] },
+  ];
+
+  it("byte-stable: two derive calls produce identical bytes", () => {
+    const out1 = eventsToMessages(mixedEvents);
+    const out2 = eventsToMessages(mixedEvents);
+    // If JSON.stringify ordering is non-deterministic (Set iteration, key
+    // reordering, Date.now() injection), this assert fails.
+    expect(JSON.stringify(out1)).toBe(JSON.stringify(out2));
+  });
+
+  it("ignores lifecycle/span/notification events entirely", () => {
+    const noNoise = mixedEvents.filter(
+      (e) =>
+        !e.type.startsWith("span.") &&
+        !e.type.startsWith("lifecycle.") &&
+        !e.type.startsWith("notification."),
+    );
+    // Adding noise (span/lifecycle) MUST NOT change the projected bytes.
+    expect(JSON.stringify(eventsToMessages(mixedEvents))).toBe(
+      JSON.stringify(eventsToMessages(noNoise)),
+    );
+  });
+
+  it("preserves reasoning providerOptions verbatim (Anthropic signature)", () => {
+    const sig = { anthropic: { signature: "sig_xyz", redactedData: "..." } };
+    const events: SessionEvent[] = [
+      { type: "user.message", content: [{ type: "text", text: "hi" }] },
+      { type: "agent.thinking", text: "thought", providerOptions: sig },
+      { type: "agent.message", content: [{ type: "text", text: "response" }] },
+    ];
+    const messages = eventsToMessages(events);
+    const assistantContent = messages[1].content as any[];
+    const reasoning = assistantContent.find((p) => p.type === "reasoning");
+    expect(reasoning).toBeDefined();
+    // Bytes of providerOptions MUST round-trip — Anthropic verifies the
+    // signature on subsequent calls; any byte drift means signature reject.
+    expect(reasoning.providerOptions).toEqual(sig);
+  });
+
+  it("resolves tool_use → tool_result names across flush boundaries", () => {
+    // Scenario the OLD pendingToolCalls.find logic broke on: tool_use lives
+    // in one flush window, tool_result lands after a separator. The new
+    // pre-pass toolNameById map must still resolve.
+    const events: SessionEvent[] = [
+      { type: "user.message", content: [{ type: "text", text: "a" }] },
+      {
+        type: "agent.tool_use",
+        id: "tc1",
+        name: "bash",
+        input: { cmd: "ls" },
+      } as AgentToolUseEvent,
+      // separator that flushed assistant before tool_result lands
+      { type: "agent.message", content: [{ type: "text", text: "running" }] },
+      {
+        type: "agent.tool_result",
+        tool_use_id: "tc1",
+        content: "file1\nfile2",
+      } as AgentToolResultEvent,
+    ];
+    const messages = eventsToMessages(events);
+    const tool = messages.find((m) => m.role === "tool");
+    expect(tool).toBeDefined();
+    const trPart = (tool!.content as any[])[0];
+    expect(trPart.toolName).toBe("bash"); // NOT "unknown"
+  });
+
+  it("tool_result content roundtrip: string survives", () => {
+    const events: SessionEvent[] = [
+      { type: "user.message", content: [{ type: "text", text: "a" }] },
+      {
+        type: "agent.tool_use",
+        id: "tc1",
+        name: "read",
+        input: {},
+      } as AgentToolUseEvent,
+      {
+        type: "agent.tool_result",
+        tool_use_id: "tc1",
+        content: "plain text result",
+      } as AgentToolResultEvent,
+    ];
+    const tool = eventsToMessages(events).find((m) => m.role === "tool")!;
+    const trPart = (tool.content as any[])[0];
+    expect(trPart.output).toEqual({ type: "text", value: "plain text result" });
+  });
+
+  it("tool_result content roundtrip: ContentBlock[] survives", () => {
+    const events: SessionEvent[] = [
+      { type: "user.message", content: [{ type: "text", text: "a" }] },
+      {
+        type: "agent.tool_use",
+        id: "tc1",
+        name: "read",
+        input: {},
+      } as AgentToolUseEvent,
+      {
+        type: "agent.tool_result",
+        tool_use_id: "tc1",
+        content: [
+          { type: "text", text: "hello" },
+          {
+            type: "image",
+            source: { type: "base64", data: "AAA=", media_type: "image/png" },
+          },
+        ],
+      } as AgentToolResultEvent,
+    ];
+    const tool = eventsToMessages(events).find((m) => m.role === "tool")!;
+    const trPart = (tool.content as any[])[0];
+    expect(trPart.output.type).toBe("content");
+    expect(trPart.output.value[0]).toEqual({ type: "text", text: "hello" });
+    expect(trPart.output.value[1].type).toBe("image-data");
+    expect(trPart.output.value[1].mediaType).toBe("image/png");
+  });
+
+  it("MCP tool name reconstructs as mcp_<server>_call", () => {
+    const events: SessionEvent[] = [
+      { type: "user.message", content: [{ type: "text", text: "a" }] },
+      {
+        type: "agent.mcp_tool_use",
+        id: "tc_mcp",
+        mcp_server_name: "github",
+        name: "mcp_github_call",
+        input: { method: "list_issues" },
+      } as any,
+      {
+        type: "agent.mcp_tool_result",
+        mcp_tool_use_id: "tc_mcp",
+        content: "ok",
+      } as any,
+    ];
+    const messages = eventsToMessages(events);
+    const assistant = messages.find((m) => m.role === "assistant")!;
+    const callPart = (assistant.content as any[]).find((p) => p.type === "tool-call");
+    expect(callPart.toolName).toBe("mcp_github_call");
+    const tool = messages.find((m) => m.role === "tool")!;
+    const trPart = (tool.content as any[])[0];
+    expect(trPart.toolName).toBe("mcp_github_call");
+  });
+});
+
+describe("eventsToMessages — context_boundary handling", () => {
+  const summary = [
+    { type: "text" as const, text: "Earlier the user asked X and we did Y." },
+  ];
+  const eventsBefore: SessionEvent[] = [
+    { type: "user.message", content: [{ type: "text", text: "first question" }] },
+    { type: "agent.message", content: [{ type: "text", text: "first answer" }] },
+    { type: "user.message", content: [{ type: "text", text: "second question" }] },
+    { type: "agent.message", content: [{ type: "text", text: "second answer" }] },
+  ];
+
+  it("boundary without summary is a no-op (UI signal only)", () => {
+    const events: SessionEvent[] = [
+      ...eventsBefore,
+      {
+        type: "agent.thread_context_compacted",
+        original_message_count: 4,
+        compacted_message_count: 4,
+      } as any,
+      { type: "user.message", content: [{ type: "text", text: "third" }] },
+    ];
+    const messages = eventsToMessages(events);
+    // All 4 pre-boundary messages + 1 post-boundary user message survive
+    expect(messages).toHaveLength(5);
+  });
+
+  it("boundary WITH summary drops pre-boundary model_io and injects summary", () => {
+    const events: SessionEvent[] = [
+      ...eventsBefore,
+      {
+        type: "agent.thread_context_compacted",
+        original_message_count: 4,
+        compacted_message_count: 2,
+        summary,
+      } as any,
+      { type: "user.message", content: [{ type: "text", text: "third" }] },
+      { type: "agent.message", content: [{ type: "text", text: "third answer" }] },
+    ];
+    const messages = eventsToMessages(events);
+    // [synthesized summary user] + [user "third"] + [assistant "third answer"]
+    expect(messages).toHaveLength(3);
+    expect(messages[0].role).toBe("user");
+    const sumContent = messages[0].content as any[];
+    expect(sumContent[0].type).toBe("text");
+    expect(sumContent[0].text).toContain("<conversation-summary>");
+    expect(sumContent[0].text).toContain("Earlier the user asked X");
+    expect(messages[1].role).toBe("user");
+    expect(messages[2].role).toBe("assistant");
+  });
+
+  it("only the LAST boundary with summary is honored (iterative compaction)", () => {
+    const summary1 = [{ type: "text" as const, text: "summary v1" }];
+    const summary2 = [
+      { type: "text" as const, text: "summary v2 (supersedes v1)" },
+    ];
+    const events: SessionEvent[] = [
+      { type: "user.message", content: [{ type: "text", text: "q1" }] },
+      { type: "agent.message", content: [{ type: "text", text: "a1" }] },
+      {
+        type: "agent.thread_context_compacted",
+        original_message_count: 2,
+        compacted_message_count: 1,
+        summary: summary1,
+      } as any,
+      { type: "user.message", content: [{ type: "text", text: "q2" }] },
+      { type: "agent.message", content: [{ type: "text", text: "a2" }] },
+      {
+        type: "agent.thread_context_compacted",
+        original_message_count: 4,
+        compacted_message_count: 1,
+        summary: summary2,
+      } as any,
+      { type: "user.message", content: [{ type: "text", text: "q3" }] },
+    ];
+    const messages = eventsToMessages(events);
+    expect(messages).toHaveLength(2); // [v2 summary, q3]
+    const sumText = (messages[0].content as any[])[0].text;
+    expect(sumText).toContain("summary v2");
+    expect(sumText).not.toContain("summary v1");
+  });
+
+  it("boundary handling stays byte-stable", () => {
+    const events: SessionEvent[] = [
+      ...eventsBefore,
+      {
+        type: "agent.thread_context_compacted",
+        original_message_count: 4,
+        compacted_message_count: 1,
+        summary,
+      } as any,
+      { type: "user.message", content: [{ type: "text", text: "next" }] },
+    ];
+    expect(JSON.stringify(eventsToMessages(events))).toBe(
+      JSON.stringify(eventsToMessages(events)),
+    );
+  });
+});

--- a/test/unit/history-conversion.test.ts
+++ b/test/unit/history-conversion.test.ts
@@ -70,16 +70,23 @@ describe("eventsToMessages — basic conversions", () => {
     }
   });
 
-  it("multiple consecutive agent messages produce multiple assistant messages", () => {
+  it("multiple consecutive agent messages merge into one assistant message", () => {
+    // New bijection-strict derive: consecutive agent.message events without
+    // a tool_result separator merge into ONE assistant message with multiple
+    // text parts. Anthropic API doesn't accept consecutive same-role messages
+    // anyway, so merging at derive time is more correct than the old
+    // per-event-emit-one-assistant behavior.
     const events: SessionEvent[] = [
       { type: "agent.message", content: [{ type: "text", text: "r1" }] },
       { type: "agent.message", content: [{ type: "text", text: "r2" }] },
     ];
     const messages = eventsToMessages(events);
-    expect(messages).toHaveLength(2);
-    for (const m of messages) {
-      expect(m.role).toBe("assistant");
-    }
+    expect(messages).toHaveLength(1);
+    expect(messages[0].role).toBe("assistant");
+    const parts = messages[0].content as Array<{ type: string; text: string }>;
+    expect(parts).toHaveLength(2);
+    expect(parts[0].text).toBe("r1");
+    expect(parts[1].text).toBe("r2");
   });
 });
 
@@ -372,16 +379,27 @@ describe("InMemoryHistory", () => {
     });
 
     const messages = history.getMessages();
-    // user, assistant (2 tool-calls), tool (2 tool-results), assistant
-    expect(messages).toHaveLength(4);
+    // New bijection-strict derive walks events in order: each tool_result
+    // forces a flushAssistant so the assistant turn that issued the call
+    // closes before the tool message lands. Pattern [tc1, tr1, tc2, tr2, msg]
+    // → [user, assistant(tc1), tool(tr1), assistant(tc2), tool(tr2), assistant(msg)] = 6.
+    //
+    // Note: in real captures from default-loop's onStepFinish, all tool_use
+    // events for one step are emitted before any tool_result events for that
+    // step (AI SDK groups them), producing the more compact 4-message form.
+    // This test constructs an interleaved sequence (use, result, use, result)
+    // to verify the strict event-order semantics.
+    expect(messages).toHaveLength(6);
     expect(messages[0].role).toBe("user");
     expect(messages[1].role).toBe("assistant");
     expect(messages[2].role).toBe("tool");
     expect(messages[3].role).toBe("assistant");
+    expect(messages[4].role).toBe("tool");
+    expect(messages[5].role).toBe("assistant");
 
-    const toolCalls = messages[1].content as any[];
-    expect(toolCalls).toHaveLength(2);
-    expect(toolCalls[0].toolName).toBe("grep");
-    expect(toolCalls[1].toolName).toBe("read");
+    const firstAssistant = messages[1].content as any[];
+    expect(firstAssistant[0].toolName).toBe("grep");
+    const secondAssistant = messages[3].content as any[];
+    expect(secondAssistant[0].toolName).toBe("read");
   });
 });

--- a/test/unit/trajectory-build.test.ts
+++ b/test/unit/trajectory-build.test.ts
@@ -70,6 +70,7 @@ describe("buildTrajectory", () => {
       input_tokens: 100,
       output_tokens: 50,
       cache_read_input_tokens: 0,
+      cache_creation_input_tokens: 0,
     });
     expect(t.summary.duration_ms).toBe(30_000);
     expect(t.ended_at).toBe("2026-04-17T10:00:30Z");


### PR DESCRIPTION
## Summary
- Decouple event log from model context via strict events ↔ messages bijection. Session-init freezes system+tools so prefix bytes stay stable across turns.
- Provider-aware cache strategy (Anthropic `cache_control` on system + last tool + last message; OpenAI/Gemini/MiniMax stubs to extend later).
- CC-style compaction: summarize call sends main agent's same model + system + tools + cache markers (skipCacheWrite-equivalent on the appended summarize request) so the prefix hits cache instead of recomputing. Tail preservation lives in derive — picks last K messages by CC-aligned token estimator (10K min / 40K max / 5 min text-block messages); post-compaction view is `[summary, ...tail, ...post_boundary]`.
- Cache observability: `cache_creation_input_tokens` added to span events + trajectory aggregation. New `span.compaction_summarize_{start,end}` event types so dashboards can attribute compaction cost separately.

## Verified end-to-end
`scripts/probe-harness-cache.ts` drives real DefaultHarness through MiniMax direct:
- Cache reuse 0.92 across 16-turn run.
- Compaction fires at 42K tokens; pre→post messages 60→`[summary + ~9K tail]`.
- Post-compaction first call: in=29442 cache_read=27008 (92% hit) — tail bytes survive verbatim.
- Subsequent turns: cache_read up to 99.7%.

## Follow-up
[OPE-13](https://linear.app/boai/issue/OPE-13/probe-coverage-for-sub-agent-multimodal-compaction-paths): probe coverage for sub-agent (parent/child event log isolation, per-instance harness state) + multimodal (image byte roundtrip, cache_control on image blocks, summarize on cache miss).

## Test plan
- [ ] \`pnpm test test/unit/bijection-invariants.test.ts\` — 11 invariants
- [ ] \`pnpm test test/unit/history-conversion.test.ts\` — existing derive tests
- [ ] \`pnpm test test/unit/trajectory-build.test.ts\` — trajectory aggregation incl. cache_creation_input_tokens
- [ ] Manual: \`PROBE_AUTH_TOKEN=... PROBE_BASE_URL=https://api.minimaxi.com/anthropic/v1 PROBE_MODEL=MiniMax-M2.7 npx tsx scripts/probe-harness-cache.ts\` — confirm cache reuse ≥ 0.85 and compaction fires with non-empty summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)