### PR TITLE
test(harness): probe + invariants for sub-agent and multimodal cache paths

### DIFF
--- a/scripts/probe-harness-cache.ts
+++ b/scripts/probe-harness-cache.ts
@@ -9,7 +9,32 @@
 // Run from repo root:
 //   ANTHROPIC_API_KEY=sk-ant-... npx tsx scripts/probe-harness-cache.ts
 //
-// What "good" looks like:
+// Modes (PROBE_MODE env var; default = text):
+//   text       — current behavior: bash + mcp tool stubs only.
+//   sub-agent  — adds a `call_agent_researcher` stub that injects
+//                thread-tagged sub-session events (agent.message,
+//                agent.tool_use, agent.tool_result) into the parent's
+//                runtime BEFORE returning the response text. Faithfully
+//                simulates SessionDO.runSubAgent: the parent's getEvents()
+//                ends up with sub-session internal events, which derive()
+//                walks unless the bijection filters them out.
+//                Verdict signal: if cache_read drops to 0 on the turn
+//                AFTER each call_agent_* return, the sub-session events
+//                are polluting the parent's prefix.
+//   multimodal — every other tool result is an `agent.tool_result` whose
+//                content is a `ContentBlock[]` containing one TextBlock
+//                and one base64 PNG image. Same probe loop; the goal is
+//                that image bytes round-trip exactly through
+//                normalizeToolOutputForWire ↔ wireContentToToolOutput so
+//                cache_read keeps growing turn over turn.
+//                Also exercises the cacheControl-on-image-tail edge case:
+//                the last message of some turns ends with a tool_result
+//                whose final block is an image.
+//   all        — runs text → sub-agent → multimodal sequentially with
+//                a fresh DefaultHarness + InMemoryHistory between each
+//                so the per-mode totals are independent.
+//
+// What "good" looks like (per mode):
 //   Turn 1: cache_create > 0  (writes the prefix)
 //           cache_read   = 0
 //   Turn 2: cache_create small  (just the new tail)
@@ -30,7 +55,17 @@ import type {
   SessionEvent,
   SpanModelRequestEndEvent,
   AgentConfig,
+  ContentBlock,
 } from "@open-managed-agents/shared";
+
+// ---- mode ----
+type ProbeMode = "text" | "sub-agent" | "multimodal" | "all";
+const RAW_MODE = (process.env.PROBE_MODE ?? "text").toLowerCase();
+if (!["text", "sub-agent", "multimodal", "all"].includes(RAW_MODE)) {
+  console.error(`Unknown PROBE_MODE=${RAW_MODE}. Choose: text | sub-agent | multimodal | all`);
+  process.exit(1);
+}
+const MODE = RAW_MODE as ProbeMode;
 
 // ---- env ----
 // Two auth modes:
@@ -178,6 +213,94 @@ const mcpGithubCall = tool({
 
 const tools = { bash, mcp_github_call: mcpGithubCall };
 
+// ---- multimodal fixture ----
+// Smallest valid PNG: 1x1 transparent pixel. Constant bytes — used as the
+// image payload in multimodal-mode tool results so cache reuse across turns
+// requires byte-perfect round-trip through normalize/wireContent.
+const PNG_1X1_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkAAIAAAoAAv/lxKUAAAAASUVORK5CYII=";
+
+// ---- sub-agent fixture ----
+// Stub `call_agent_researcher` that simulates SessionDO.runSubAgent: tags a
+// sequence of sub-session events into the parent's runtime BEFORE returning.
+// If the parent's eventsToMessages walks tagged events, every call here will
+// add an unrelated assistant turn + tool round-trip to the parent's prefix
+// → cache_read collapses on the next turn.
+//
+// `runtime` is bound at construction time so the tool can broadcast directly.
+function makeCallAgentTool(rt: HarnessRuntime, threadCounter: { n: number }) {
+  return tool({
+    description:
+      "Delegate a research question to the researcher sub-agent (probe stub).",
+    inputSchema: z.object({
+      message: z.string().describe("question to send to the sub-agent"),
+    }),
+    execute: async ({ message }) => {
+      const threadId = `thread_probe_${threadCounter.n++}`;
+      const tag = (e: SessionEvent) => ({ ...e, session_thread_id: threadId } as SessionEvent);
+      // Mirrors SessionDO.runSubAgent (apps/agent/src/runtime/session-do.ts:1414):
+      // sub-agent's broadcasts append a tagged copy of the same event into the
+      // parent's history. Each event is the same `type` as a normal event —
+      // only the extra `session_thread_id` field distinguishes it.
+      rt.broadcast(tag({
+        type: "session.thread_created",
+        session_thread_id: threadId,
+        agent_id: "researcher",
+        agent_name: "researcher",
+      } as any));
+      rt.broadcast(tag({
+        type: "agent.message",
+        content: [{ type: "text", text: `[sub-agent] working on: ${message.slice(0, 80)}` }],
+      }));
+      rt.broadcast(tag({
+        type: "agent.tool_use",
+        id: `${threadId}_tc_grep`,
+        name: "grep",
+        input: { pattern: "TODO", path: "src/" },
+      } as any));
+      rt.broadcast(tag({
+        type: "agent.tool_result",
+        tool_use_id: `${threadId}_tc_grep`,
+        content: FAKE_GREP_OUTPUT,
+      } as any));
+      rt.broadcast(tag({
+        type: "agent.message",
+        content: [{ type: "text", text: `[sub-agent] done. Found ${80} matches across files.` }],
+      }));
+      rt.broadcast(tag({
+        type: "session.thread_idle",
+        session_thread_id: threadId,
+      } as any));
+      // Return the response text — what the parent sees as the tool result.
+      return `Researcher returned: 80 matches across the handlers tree (sample matches in trace).`;
+    },
+  });
+}
+
+// ---- multimodal fixture ----
+// Tool stub that returns a `ContentBlock[]` with a text block + a base64 PNG.
+// Built once per mode so the bytes are stable across turns. Default-loop's
+// normalizeToolOutputForWire detects the pre-shaped ContentBlock[] and
+// passes it through verbatim → wireContentToToolOutput on derive must
+// reconstruct the same bytes for cache reuse.
+function makeImageTool() {
+  const imageBlock: ContentBlock = {
+    type: "image",
+    source: { type: "base64", media_type: "image/png", data: PNG_1X1_BASE64 },
+  };
+  return tool({
+    description: "Render a chart and return [text-summary, image] (probe stub).",
+    inputSchema: z.object({ caption: z.string().describe("short caption for the chart") }),
+    // ai-sdk's strict typing forbids ContentBlock[] in `execute`'s declared
+    // return; cast to any since default-loop normalizes via the wire shape.
+    execute: async ({ caption }) =>
+      [
+        { type: "text", text: `Chart caption: ${caption}. Rendered 1x1 PNG below.` },
+        imageBlock,
+      ] as any,
+  });
+}
+
 // ---- platformReminders (simulate skill metadata + memory) ----
 const platformReminders = [
   {
@@ -194,26 +317,7 @@ const platformReminders = [
   },
 ];
 
-// ---- runtime ----
-const history = new InMemoryHistory();
-const eventLog: SessionEvent[] = [];
-
-const runtime: HarnessRuntime = {
-  history: history as any,
-  sandbox: {
-    exec: async (cmd: string) => `[probe stub exec] ${cmd}`,
-    readFile: async () => "",
-    writeFile: async () => "",
-  } as any,
-  broadcast: (event: SessionEvent) => {
-    history.append(event);
-    eventLog.push(event);
-  },
-  reportUsage: async () => {},
-  pendingConfirmations: [],
-};
-
-// ---- ctx ----
+// ---- agent + systemPrompt (shared across modes; baked into cached prefix) ----
 const agent: Partial<AgentConfig> = {
   id: "probe",
   name: "probe-agent",
@@ -237,24 +341,58 @@ const SYSTEM_AUTHENTICATED_GUIDANCE =
   "For commands that may require authentication, prefer issuing a single command instead of a chained shell command. If an authenticated chained command fails, retry with a simpler single-command form.";
 const systemPrompt = `${agent.system}\n\n${SYSTEM_AUTHENTICATED_GUIDANCE}`;
 
-const baseCtx: Omit<HarnessContext, "userMessage"> = {
-  agent: agent as AgentConfig,
-  tools,
-  model,
-  systemPrompt,
-  rawSystemPrompt: agent.system!,
-  platformReminders,
-  env: {
-    ANTHROPIC_API_KEY: apiKey ?? probeToken ?? "",
-  } as any,
-  runtime,
-};
+// ---- runtime + ctx (per mode) ----
+// Each mode gets a fresh history, runtime, and tool set so the per-mode
+// cache stats are independent. Module-level state used to be unique;
+// supporting "all" mode forced extracting this into a builder.
+function buildRunFor(mode: Exclude<ProbeMode, "all">) {
+  const history = new InMemoryHistory();
+  const eventLog: SessionEvent[] = [];
+  const runtime: HarnessRuntime = {
+    history: history as any,
+    sandbox: {
+      exec: async (cmd: string) => `[probe stub exec] ${cmd}`,
+      readFile: async () => "",
+      writeFile: async () => "",
+    } as any,
+    broadcast: (event: SessionEvent) => {
+      history.append(event);
+      eventLog.push(event);
+    },
+    reportUsage: async () => {},
+    pendingConfirmations: [],
+  };
 
-// ---- run ----
+  const threadCounter = { n: 0 };
+  const modeTools: Record<string, any> = { bash, mcp_github_call: mcpGithubCall };
+  if (mode === "sub-agent") {
+    modeTools.call_agent_researcher = makeCallAgentTool(runtime, threadCounter);
+  }
+  if (mode === "multimodal") {
+    modeTools.render_chart = makeImageTool();
+  }
+
+  const baseCtx: Omit<HarnessContext, "userMessage"> = {
+    agent: agent as AgentConfig,
+    tools: modeTools,
+    model,
+    systemPrompt,
+    rawSystemPrompt: agent.system!,
+    platformReminders,
+    env: {
+      ANTHROPIC_API_KEY: apiKey ?? probeToken ?? "",
+    } as any,
+    runtime,
+  };
+
+  return { history, eventLog, runtime, modeTools, baseCtx };
+}
+
+// ---- prompts (per mode) ----
 // Tool-driving questions: each prompt explicitly forces a bash or
 // mcp_github_call invocation so the ~5KB stub outputs accumulate fast and
 // we hit the 0.10 trigger fraction before turn 16.
-const QUESTIONS = [
+const QUESTIONS_TEXT = [
   "Run `ls -la src/` and tell me what you see in one sentence.",
   "Now grep for 'export async function handle' under src/handlers and report the top 3 matches.",
   "Use mcp_github_call to list_issues; then summarize the most common label in one sentence.",
@@ -273,12 +411,68 @@ const QUESTIONS = [
   "Final summary: which tool did you use most, in one sentence.",
 ];
 
-async function main() {
-  const harness = new DefaultHarness();
+// Sub-agent mode: alternate normal tool calls with `call_agent_researcher`
+// so we can compare cache_read on turns AFTER a sub-agent return vs
+// turns AFTER a normal tool. If the parent's prefix gets polluted by
+// sub-session events, cache_read will reset on every post-call_agent turn.
+const QUESTIONS_SUBAGENT = [
+  "Run `ls -la src/` and tell me what you see in one sentence.",
+  "Use call_agent_researcher to investigate `TODO usage in src/`. Then in one sentence relay what they said.",
+  "Now grep for 'export async function handle' under src/handlers; top 3 matches.",
+  "Use call_agent_researcher to look up `routes registered in src/handlers/`. One-sentence relay.",
+  "Use mcp_github_call to list_issues; the most common label in one sentence.",
+  "Use call_agent_researcher to summarize `auth bug history`. One-sentence relay.",
+  "Run `find . -name '*.ts'` and pick one interesting filename.",
+  "Use call_agent_researcher to look at `class definitions in src/`. One sentence.",
+  "Grep for 'import' in src/ and tell me how many imports total (one number).",
+  "Use call_agent_researcher to research `latency reports`. One sentence.",
+  "Use mcp_github_call to list_prs; one PR title.",
+  "Use call_agent_researcher to scan `error handling patterns`. One sentence.",
+  "Run `ls /etc` and pick one config file name.",
+  "Use call_agent_researcher to look at `TODO under src/handlers/`. One sentence.",
+  "Grep for 'function' under src/handlers and report top 3.",
+  "Final summary: which tool did you use most often?",
+];
 
+// Multimodal mode: drive `render_chart` on alternating turns so half the
+// turns end with a tool_result whose final block is a base64 image.
+// Tests both: image-byte preservation (between turns) AND cache_control
+// landing on a tail block that happens to be an image.
+const QUESTIONS_MULTIMODAL = [
+  "Run `ls -la src/` and tell me what you see in one sentence.",
+  "Use render_chart with caption `latency p99 over 7d` and tell me one observation.",
+  "Now grep for 'export async function handle' under src/handlers; top 3 matches.",
+  "Use render_chart with caption `error rate vs deploy times` and one observation.",
+  "Use mcp_github_call to list_issues; the most common label in one sentence.",
+  "Use render_chart with caption `RPS by region` and tell me one observation.",
+  "Run `find . -name '*.ts'` and pick one interesting filename.",
+  "Use render_chart with caption `memory usage over hours` and one observation.",
+  "Grep for 'import' in src/ and tell me how many imports total (one number).",
+  "Use render_chart with caption `queue depth weekly` and one observation.",
+  "Use mcp_github_call to list_prs; one PR title.",
+  "Use render_chart with caption `cold-start ms by hour` and one observation.",
+  "Run `ls /etc` and pick one config file name.",
+  "Use render_chart with caption `cache hit ratio by route` and one observation.",
+  "Grep for 'function' under src/handlers and report top 3.",
+  "Final summary: what was the most informative chart, in one sentence.",
+];
+
+function questionsFor(mode: Exclude<ProbeMode, "all">): string[] {
+  if (mode === "sub-agent") return QUESTIONS_SUBAGENT;
+  if (mode === "multimodal") return QUESTIONS_MULTIMODAL;
+  return QUESTIONS_TEXT;
+}
+
+// ---- per-mode runner ----
+async function runMode(mode: Exclude<ProbeMode, "all">) {
+  const { history, eventLog, runtime, modeTools, baseCtx } = buildRunFor(mode);
+  const harness = new DefaultHarness();
+  const questions = questionsFor(mode);
+
+  console.log(`\n=== mode=${mode} ===`);
   console.log(`Model: ${(model as any).modelId}`);
   console.log(`System prompt: ${systemPrompt.length} chars`);
-  console.log(`Tools: ${Object.keys(tools).join(", ")}`);
+  console.log(`Tools: ${Object.keys(modeTools).join(", ")}`);
   console.log(`Skill reminders: ${platformReminders.length}`);
   console.log("---");
 
@@ -286,11 +480,27 @@ async function main() {
   await harness.onSessionInit?.(baseCtx as HarnessContext, runtime);
 
   let totalIn = 0, totalOut = 0, totalRead = 0, totalCreate = 0;
+  // Per-turn tool/sub-agent markers — we annotate each turn with what kind
+  // of return preceded it, so post-call_agent_* and post-image turns are
+  // visually distinguishable in the per-turn cache log.
+  const turnMarker = (ev: SessionEvent | undefined): string => {
+    if (!ev) return "";
+    if (ev.type === "agent.tool_use" && (ev as any).name?.startsWith?.("call_agent_")) {
+      return " [post-call_agent]";
+    }
+    if (ev.type === "agent.tool_result") {
+      const c = (ev as any).content;
+      if (Array.isArray(c) && c.some((b: any) => b?.type === "image")) {
+        return " [post-image-result]";
+      }
+    }
+    return "";
+  };
 
-  for (let i = 0; i < QUESTIONS.length; i++) {
+  for (let i = 0; i < questions.length; i++) {
     const userEvent: SessionEvent = {
       type: "user.message",
-      content: [{ type: "text", text: QUESTIONS[i] }],
+      content: [{ type: "text", text: questions[i] }],
     };
     history.append(userEvent);
     eventLog.push(userEvent);
@@ -315,20 +525,28 @@ async function main() {
     const cacheCreate = u?.cache_creation_input_tokens ?? 0;
     totalIn += inp; totalOut += out; totalRead += cacheRead; totalCreate += cacheCreate;
 
+    // Look one event back for the LAST tool-related event in this turn.
+    const lastTurnEvent = [...eventLog].reverse().find(
+      (e) => e.type === "agent.tool_use" || e.type === "agent.tool_result" || e.type === "agent.mcp_tool_result",
+    );
+
     const tools_used = eventLog
       .filter((e) => e.type === "agent.tool_use" || e.type === "agent.mcp_tool_use" || e.type === "agent.custom_tool_use")
       .length;
     const compactions = eventLog.filter((e) => e.type === "agent.thread_context_compacted");
+    const subThreadEvents = eventLog.filter((e) => (e as any).session_thread_id != null);
 
     console.log(
-      `Turn ${i + 1} (${elapsed}ms): in=${inp} out=${out} cache_read=${cacheRead} cache_create=${cacheCreate}  tools_called_so_far=${tools_used} compactions=${compactions.length}`,
+      `Turn ${i + 1} (${elapsed}ms): in=${inp} out=${out} cache_read=${cacheRead} cache_create=${cacheCreate}` +
+      `  tools_called_so_far=${tools_used} sub_thread_evts=${subThreadEvents.length} compactions=${compactions.length}` +
+      turnMarker(lastTurnEvent),
     );
   }
 
   console.log("---");
-  console.log(`TOTAL: in=${totalIn} out=${totalOut} cache_read=${totalRead} cache_create=${totalCreate}`);
-  const reuseRatio = totalIn > 0 ? (totalRead / totalIn).toFixed(2) : "n/a";
-  console.log(`Cache reuse ratio: ${reuseRatio} (cache_read / input_tokens — higher is better)`);
+  console.log(`TOTAL[${mode}]: in=${totalIn} out=${totalOut} cache_read=${totalRead} cache_create=${totalCreate}`);
+  const reuseRatio = totalIn + totalRead > 0 ? (totalRead / (totalIn + totalRead)).toFixed(2) : "n/a";
+  console.log(`Cache reuse ratio: ${reuseRatio} (cache_read / (input_tokens + cache_read) — higher is better)`);
   console.log(`Total events captured: ${eventLog.length}`);
 
   // Quick verdict
@@ -338,6 +556,43 @@ async function main() {
     console.log("\nVERDICT: cache reuse > cache writes. Cache is working.");
   } else {
     console.log("\nVERDICT: some cache reuse but lower than write. Could be a short prefix; try more turns.");
+  }
+
+  // Mode-specific extra checks
+  if (mode === "sub-agent") {
+    // Identify the per-turn cache_read on the turn AFTER each call_agent_*.
+    // If the parent's prefix gets polluted by sub-session events, those
+    // post-call_agent turns will have cache_read collapse to ~0 while
+    // non-sub-agent turns keep growing.
+    const spanEvents = eventLog.filter((e) => e.type === "span.model_request_end") as SpanModelRequestEndEvent[];
+    const callAgentEvents = eventLog.filter(
+      (e) => e.type === "agent.tool_use" && (e as any).name?.startsWith?.("call_agent_"),
+    );
+    console.log(`\nSub-agent diagnostics:`);
+    console.log(`  call_agent_* invocations: ${callAgentEvents.length}`);
+    console.log(`  total tagged sub-session events injected: ${eventLog.filter((e) => (e as any).session_thread_id != null).length}`);
+    if (spanEvents.length >= 2) {
+      const last = spanEvents[spanEvents.length - 1].model_usage;
+      const first = spanEvents[0].model_usage;
+      console.log(`  first turn cache_read: ${first?.cache_read_input_tokens ?? 0}`);
+      console.log(`  last turn cache_read:  ${last?.cache_read_input_tokens ?? 0}`);
+      const lastReadIsZero = (last?.cache_read_input_tokens ?? 0) === 0;
+      if (lastReadIsZero && callAgentEvents.length > 0) {
+        console.log(`  WARNING: cache_read=0 on the last turn after sub-agent activity — check whether tagged events are polluting the parent's prefix.`);
+      }
+    }
+  }
+
+  if (mode === "multimodal") {
+    const imageResults = eventLog.filter(
+      (e) => e.type === "agent.tool_result" && Array.isArray((e as any).content) && (e as any).content.some((b: any) => b?.type === "image"),
+    );
+    console.log(`\nMultimodal diagnostics:`);
+    console.log(`  image-bearing tool_result events: ${imageResults.length}`);
+    console.log(`  PNG payload bytes per image: ${PNG_1X1_BASE64.length} chars (base64)`);
+    if (imageResults.length === 0) {
+      console.log(`  NOTE: model never invoked render_chart — probe didn't exercise image path. Try forcing it via prompt.`);
+    }
   }
 
   // Compaction summary
@@ -374,6 +629,14 @@ async function main() {
     }
   } else {
     console.log("\nNo compactions fired (didn't cross trigger threshold).");
+  }
+}
+
+async function main() {
+  const modes: Array<Exclude<ProbeMode, "all">> =
+    MODE === "all" ? ["text", "sub-agent", "multimodal"] : [MODE];
+  for (const m of modes) {
+    await runMode(m);
   }
 }
 

--- a/scripts/probe-harness-cache.ts
+++ b/scripts/probe-harness-cache.ts
@@ -70,13 +70,14 @@ const MODE = RAW_MODE as ProbeMode;
 // ---- env ----
 // Two auth modes:
 //   1. ANTHROPIC_API_KEY (sk-ant-...) → standard x-api-key against api.anthropic.com
-//   2. PROBE_AUTH_TOKEN + PROBE_BASE_URL → bearer auth against a custom proxy
+//   2. PROBE_AUTH_TOKEN + PROBE_BASE_URL → bearer auth against any
+//      Anthropic-Messages-compatible endpoint
 //
 // We deliberately ignore inherited ANTHROPIC_AUTH_TOKEN/BASE_URL because
-// Claude Code's defaults point at platform-api.xaminim.com, which speaks a
-// different protocol than Anthropic's Messages API and returns "Invalid
-// JSON response" on direct ai-sdk calls. To probe through that proxy,
-// re-export them as PROBE_* explicitly.
+// some local setups point at a proxy that doesn't speak Anthropic's
+// Messages API directly (returns "Invalid JSON response" on raw ai-sdk
+// calls). To probe through that kind of endpoint, re-export the auth as
+// PROBE_AUTH_TOKEN + PROBE_BASE_URL explicitly.
 const apiKey = process.env.ANTHROPIC_API_KEY;
 const probeToken = process.env.PROBE_AUTH_TOKEN;
 const probeBase = process.env.PROBE_BASE_URL;
@@ -106,10 +107,12 @@ function parseHeaders(raw: string | undefined): Record<string, string> | undefin
   }
 }
 
-// Empty — direct providers (api.minimaxi.com, api.anthropic.com) don't
-// require any X-Sub-Module or X-From routing headers. Only the company
-// proxy (platform-api.xaminim.com) does.
-const PROBE_HEADERS: Record<string, string> = {};
+// Routing headers for the proxy. Empty by default — direct providers
+// (api.anthropic.com and most Messages-API-compatible endpoints) don't
+// require routing headers. Set PROBE_HEADERS env var (JSON object or
+// `Header: Value\nHeader2: Value2` lines) to inject — required by some
+// internal proxies that route on custom headers.
+const PROBE_HEADERS: Record<string, string> = parseHeaders(process.env.PROBE_HEADERS) ?? {};
 
 let reqIdx = 0;
 const debugFetch: typeof fetch = async (input, init) => {

--- a/scripts/probe-harness-cache.ts
+++ b/scripts/probe-harness-cache.ts
@@ -34,6 +34,20 @@
 //                a fresh DefaultHarness + InMemoryHistory between each
 //                so the per-mode totals are independent.
 //
+// Compaction strategy (PROBE_COMPACTION_STRATEGY env var; default = "summarize"):
+//   summarize       — original strategy that reuses main agent's prefix
+//                     (system + tools) on the summarize call. Cache-aware
+//                     in design, but ai-sdk strips tools when toolChoice="none"
+//                     so cache_read on the summarize call ends up at 0%.
+//   cc-style        — Claude-Code-inspired isolated summarize call. Own
+//                     short system, empty tools, no toolChoice, images
+//                     stripped. Pays full input price on summarize but is
+//                     robust across providers (no toolChoice quirks).
+//   opencode-style  — OpenCode-inspired isolated summarize call. Same
+//                     structure as cc-style with a Goal/Instructions/
+//                     Discoveries/Accomplished/Files template instead of
+//                     a free-form summary.
+//
 // What "good" looks like (per mode):
 //   Turn 1: cache_create > 0  (writes the prefix)
 //           cache_read   = 0
@@ -337,6 +351,14 @@ const agent: Partial<AgentConfig> = {
     compaction_trigger_fraction: process.env.PROBE_COMPACTION_TRIGGER
       ? Number(process.env.PROBE_COMPACTION_TRIGGER)
       : 0.04,
+    // PROBE_COMPACTION_STRATEGY = "summarize" (default) | "cc-style"
+    // | "opencode-style". DefaultHarness reads this from agent.metadata
+    // and resolves the matching strategy class. Use this knob to A/B
+    // the legacy cache-prefix-sharing strategy against the isolated
+    // CC/OpenCode-style strategies.
+    ...(process.env.PROBE_COMPACTION_STRATEGY
+      ? { compaction_strategy: process.env.PROBE_COMPACTION_STRATEGY }
+      : {}),
   } as Record<string, unknown>,
 };
 
@@ -477,6 +499,7 @@ async function runMode(mode: Exclude<ProbeMode, "all">) {
   console.log(`System prompt: ${systemPrompt.length} chars`);
   console.log(`Tools: ${Object.keys(modeTools).join(", ")}`);
   console.log(`Skill reminders: ${platformReminders.length}`);
+  console.log(`Compaction strategy: ${process.env.PROBE_COMPACTION_STRATEGY ?? "summarize (default)"}`);
   console.log("---");
 
   // session-init: write skill/memory reminders into history (cached prefix)

--- a/test/unit/bijection-invariants.test.ts
+++ b/test/unit/bijection-invariants.test.ts
@@ -282,3 +282,265 @@ describe("eventsToMessages — context_boundary handling", () => {
     );
   });
 });
+
+// ============================================================
+// Sub-agent / thread-tagged events
+// ============================================================
+//
+// SessionDO.runSubAgent broadcasts each sub-session event into the parent
+// history with an extra `session_thread_id` field but the same `type`.
+// These tests pin down whether the parent's eventsToMessages walks those
+// tagged events or filters them — in either case, the contract MUST be
+// byte-stable so the prompt cache survives.
+//
+// If the spec changes to filter tagged events, only the assertion changes;
+// the byte-stability invariant stays.
+
+describe("eventsToMessages — sub-agent thread tagging", () => {
+  const buildParentWithSubThread = (): SessionEvent[] => [
+    { type: "user.message", content: [{ type: "text", text: "delegate it" }] },
+    {
+      type: "agent.tool_use",
+      id: "tc_call_agent",
+      name: "call_agent_researcher",
+      input: { message: "investigate X" },
+    } as AgentToolUseEvent,
+    // --- sub-session events tagged into the parent log ---
+    {
+      type: "session.thread_created",
+      session_thread_id: "thread_1",
+      agent_id: "researcher",
+      agent_name: "researcher",
+    } as any,
+    {
+      type: "agent.message",
+      session_thread_id: "thread_1",
+      content: [{ type: "text", text: "[sub] working" }],
+    } as any,
+    {
+      type: "agent.tool_use",
+      session_thread_id: "thread_1",
+      id: "thread_1_grep",
+      name: "grep",
+      input: { pattern: "TODO" },
+    } as any,
+    {
+      type: "agent.tool_result",
+      session_thread_id: "thread_1",
+      tool_use_id: "thread_1_grep",
+      content: "matches: 80",
+    } as any,
+    {
+      type: "agent.message",
+      session_thread_id: "thread_1",
+      content: [{ type: "text", text: "[sub] done" }],
+    } as any,
+    {
+      type: "session.thread_idle",
+      session_thread_id: "thread_1",
+    } as any,
+    // --- back to the parent: tool_result for the call_agent_* call ---
+    {
+      type: "agent.tool_result",
+      tool_use_id: "tc_call_agent",
+      content: "Researcher returned: 80 matches.",
+    } as AgentToolResultEvent,
+  ];
+
+  it("byte-stable across repeated derives (with tagged events present)", () => {
+    const events = buildParentWithSubThread();
+    expect(JSON.stringify(eventsToMessages(events))).toBe(
+      JSON.stringify(eventsToMessages(events)),
+    );
+  });
+
+  it("documents current shape: tagged events flow through (every type is walked)", () => {
+    // Pin the current behavior: tagged events are NOT filtered by type, so
+    // sub-session agent.tool_use / agent.tool_result events appear in the
+    // parent's projected messages alongside the parent's own tool round-trip.
+    //
+    // If a future change adds a "skip events with session_thread_id" branch
+    // to eventsToMessages, this test should be flipped (or the polluting
+    // events removed from the expected message stream). Either way it
+    // serves as a pin-down for the chosen contract.
+    const events = buildParentWithSubThread();
+    const messages = eventsToMessages(events);
+
+    // Find the assistant message holding the call_agent_* tool-call.
+    const assistantWithCall = messages.find((m) =>
+      m.role === "assistant" &&
+      Array.isArray(m.content) &&
+      (m.content as any[]).some(
+        (p) => p.type === "tool-call" && p.toolName === "call_agent_researcher",
+      ),
+    );
+    expect(assistantWithCall).toBeDefined();
+
+    // Tagged sub-session tool_use is currently surfaced as a normal tool-call.
+    const allToolCalls = messages
+      .filter((m) => m.role === "assistant")
+      .flatMap((m) => (Array.isArray(m.content) ? (m.content as any[]) : []))
+      .filter((p) => p.type === "tool-call");
+    const toolNames = allToolCalls.map((p) => p.toolName).sort();
+    expect(toolNames).toContain("call_agent_researcher");
+    // The sub-session's grep call is currently in there too — pin it down so
+    // a regression that "accidentally fixes" this without updating tests
+    // gets noticed and forces an explicit decision.
+    expect(toolNames).toContain("grep");
+  });
+
+  it("tagged events do not duplicate parent's own tool_result", () => {
+    // The parent's own agent.tool_result for tc_call_agent should still be
+    // exactly one tool message, regardless of how many sub-session events
+    // sit between the call and the result.
+    const events = buildParentWithSubThread();
+    const messages = eventsToMessages(events);
+    const toolMsgs = messages.filter((m) => m.role === "tool");
+    const callAgentResults = toolMsgs.flatMap((m) =>
+      (m.content as any[]).filter(
+        (p) => p.toolCallId === "tc_call_agent",
+      ),
+    );
+    expect(callAgentResults).toHaveLength(1);
+    expect(callAgentResults[0].toolName).toBe("call_agent_researcher");
+  });
+});
+
+// ============================================================
+// Multimodal — image bytes in tool_result content
+// ============================================================
+//
+// Anthropic's prompt cache hashes the wire bytes of every block. For
+// images that means the base64 payload must round-trip through
+// normalizeToolOutputForWire (write side) ↔ wireContentToToolOutput
+// (read side) without re-encoding, key reordering, or padding drift.
+// These tests pin down byte-perfect equality for the image path that the
+// multimodal probe exercises end-to-end.
+
+describe("eventsToMessages — multimodal image roundtrip", () => {
+  // 1×1 transparent PNG. Constant bytes — same fixture as the probe.
+  const PNG_1X1_BASE64 =
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkAAIAAAoAAv/lxKUAAAAASUVORK5CYII=";
+
+  const buildEventsWithImage = (data: string = PNG_1X1_BASE64): SessionEvent[] => [
+    { type: "user.message", content: [{ type: "text", text: "render it" }] },
+    {
+      type: "agent.tool_use",
+      id: "tc_chart",
+      name: "render_chart",
+      input: { caption: "p99" },
+    } as AgentToolUseEvent,
+    {
+      type: "agent.tool_result",
+      tool_use_id: "tc_chart",
+      content: [
+        { type: "text", text: "Chart caption: p99." },
+        { type: "image", source: { type: "base64", media_type: "image/png", data } },
+      ],
+    } as AgentToolResultEvent,
+  ];
+
+  it("base64 bytes survive verbatim through the wire shape", () => {
+    const events = buildEventsWithImage();
+    const messages = eventsToMessages(events);
+    const tool = messages.find((m) => m.role === "tool")!;
+    const trPart = (tool.content as any[])[0];
+    expect(trPart.output.type).toBe("content");
+    const parts = trPart.output.value as any[];
+    expect(parts).toHaveLength(2);
+    expect(parts[0]).toEqual({ type: "text", text: "Chart caption: p99." });
+    expect(parts[1].type).toBe("image-data");
+    expect(parts[1].mediaType).toBe("image/png");
+    // Byte-perfect: any whitespace/padding drift here busts cache.
+    expect(parts[1].data).toBe(PNG_1X1_BASE64);
+    expect(parts[1].data.length).toBe(PNG_1X1_BASE64.length);
+  });
+
+  it("two derives produce identical bytes for image-bearing tool_results", () => {
+    const events = buildEventsWithImage();
+    expect(JSON.stringify(eventsToMessages(events))).toBe(
+      JSON.stringify(eventsToMessages(events)),
+    );
+  });
+
+  it("two distinct image payloads project to distinct bytes (no cross-contamination)", () => {
+    const altPng =
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGNgYAAAAAQAAcngHTwAAAAASUVORK5CYII=";
+    const a = JSON.stringify(eventsToMessages(buildEventsWithImage(PNG_1X1_BASE64)));
+    const b = JSON.stringify(eventsToMessages(buildEventsWithImage(altPng)));
+    expect(a).not.toBe(b);
+  });
+
+  it("two image-bearing tool_results in sequence each preserve their own bytes", () => {
+    const altPng =
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGNgYAAAAAQAAcngHTwAAAAASUVORK5CYII=";
+    const events: SessionEvent[] = [
+      { type: "user.message", content: [{ type: "text", text: "render two" }] },
+      {
+        type: "agent.tool_use",
+        id: "tc_chart_a",
+        name: "render_chart",
+        input: { caption: "a" },
+      } as AgentToolUseEvent,
+      {
+        type: "agent.tool_result",
+        tool_use_id: "tc_chart_a",
+        content: [
+          { type: "image", source: { type: "base64", media_type: "image/png", data: PNG_1X1_BASE64 } },
+        ],
+      } as AgentToolResultEvent,
+      {
+        type: "agent.tool_use",
+        id: "tc_chart_b",
+        name: "render_chart",
+        input: { caption: "b" },
+      } as AgentToolUseEvent,
+      {
+        type: "agent.tool_result",
+        tool_use_id: "tc_chart_b",
+        content: [
+          { type: "image", source: { type: "base64", media_type: "image/png", data: altPng } },
+        ],
+      } as AgentToolResultEvent,
+    ];
+    const messages = eventsToMessages(events);
+    const toolMsgs = messages.filter((m) => m.role === "tool");
+    const allImageBytes = toolMsgs
+      .flatMap((m) => (m.content as any[]).flatMap((p) =>
+        Array.isArray(p.output?.value) ? (p.output.value as any[]) : [],
+      ))
+      .filter((b) => b.type === "image-data")
+      .map((b) => b.data);
+    expect(allImageBytes).toEqual([PNG_1X1_BASE64, altPng]);
+  });
+
+  it("compaction summary elides images stably (no per-derive churn)", () => {
+    // Boundary summary contains an image block; serializeSummaryAsText
+    // collapses it to "[image elided]". Output bytes must be stable.
+    const events: SessionEvent[] = [
+      { type: "user.message", content: [{ type: "text", text: "q1" }] },
+      { type: "agent.message", content: [{ type: "text", text: "a1" }] },
+      {
+        type: "agent.thread_context_compacted",
+        original_message_count: 2,
+        compacted_message_count: 1,
+        summary: [
+          { type: "text", text: "earlier we generated a chart" },
+          { type: "image", source: { type: "base64", media_type: "image/png", data: PNG_1X1_BASE64 } },
+        ],
+      } as any,
+      { type: "user.message", content: [{ type: "text", text: "q2" }] },
+    ];
+    const a = eventsToMessages(events);
+    const b = eventsToMessages(events);
+    expect(JSON.stringify(a)).toBe(JSON.stringify(b));
+    const summaryText = (a[0].content as any[])[0].text as string;
+    expect(summaryText).toContain("<conversation-summary>");
+    expect(summaryText).toContain("earlier we generated a chart");
+    expect(summaryText).toContain("[image elided]");
+    // Image base64 must NOT leak into the summary text — compaction's whole
+    // point is shrinking the prefix, and serializing 50KB of base64 here
+    // would defeat that.
+    expect(summaryText).not.toContain(PNG_1X1_BASE64);
+  });
+});


### PR DESCRIPTION
Closes [OPE-13](https://linear.app/boai/issue/OPE-13/probe-coverage-for-sub-agent-multimodal-compaction-paths).

Follow-up to the bijection + CC-style compaction refactor. Two prefix-byte risk paths weren't covered by the existing probe; this PR adds end-to-end probe coverage and deterministic byte-roundtrip tests so future drift is visible.

## Why
Anthropic's prompt cache invalidates on the slightest prefix-byte drift. Two paths were unverified:

- **Sub-agent.** `SessionDO.runSubAgent` broadcasts each sub-session event into the parent log tagged with `session_thread_id` but the same `type`. `eventsToMessages` doesn't filter by tag, so every `call_agent_*` return adds unrelated `tool_use` / `tool_result` blocks to the parent's prefix → `cache_read` collapses on the next turn.
- **Multimodal.** `tool_result` blocks containing base64 images must round-trip exactly through `normalizeToolOutputForWire` ↔ `wireContentToToolOutput`. Any whitespace/padding/key-order drift busts the cache for every turn that has an image. Compaction's summary serializer must also elide images stably (and not leak the raw bytes back into the prefix).

## Summary
- `scripts/probe-harness-cache.ts`: add `PROBE_MODE=text|sub-agent|multimodal|all`. Sub-agent mode plugs a `call_agent_researcher` stub that injects tagged thread events into the parent runtime exactly the way `runSubAgent` does. Multimodal mode plugs `render_chart` returning a constant 1x1 PNG. Per-turn line tags `[post-call_agent]` / `[post-image-result]` so cache regressions are easy to spot, and reports the count of tagged sub-session events so prefix pollution shows up at a glance.
- `test/unit/bijection-invariants.test.ts`: 8 new deterministic tests (no API key needed). Pin down tagged-event flow-through, byte-stable derives, image base64 byte-perfect round-trip, sequential image preservation, and stable image elision in compaction summaries.

## Test plan
- [x] `npx vitest run test/unit/bijection-invariants.test.ts` — 17 pass (the 2 failures in `context_boundary handling` are pre-existing on `origin/main`, unrelated to this PR — stale assertions from before the CC-style tail preservation landed)
- [x] `npx vitest run test/unit/history-conversion.test.ts test/unit/harness.test.ts` — 61 pass, no regressions in adjacent suites
- [x] `PROBE_MODE=invalid npx tsx scripts/probe-harness-cache.ts` — rejects unknown modes
- [x] `PROBE_MODE=sub-agent npx tsx scripts/probe-harness-cache.ts` — imports cleanly, bails on missing `ANTHROPIC_API_KEY`
- [ ] End-to-end run with API key: `ANTHROPIC_API_KEY=sk-ant-... PROBE_MODE=all npx tsx scripts/probe-harness-cache.ts` (deferred — requires live billable call)

🤖 Generated with [Claude Code](https://claude.com/claude-code)