### PR TITLE
feat(harness): CC-style and OpenCode-style compaction strategies

### DIFF
--- a/apps/agent/src/harness/compaction.ts
+++ b/apps/agent/src/harness/compaction.ts
@@ -219,6 +219,350 @@ const DEFAULT_SUMMARIZE_PROMPT =
   "Summarize the entire conversation above. Preserve key decisions, file paths, tool results (commands run + their output), in-flight tasks, and explicit Next Steps. If the conversation already contains a <conversation-summary> block, produce an updated summary that supersedes it (combining prior summary + new activity). Be concise but specific. Output only the summary text, no preamble.";
 
 // ============================================================
+// Image stripping helper
+// ============================================================
+//
+// Walk a message list and replace every image content block (top-level user
+// images, image-data/image-url tool_result outputs, raw image parts) with a
+// short placeholder. Used by the isolated strategies below to keep the
+// summarize call cheap — the summarizer doesn't need to "see" the image
+// bytes to know they were rendered, just that an image existed at that
+// position.
+//
+// Pure function: same input → same output bytes. Doesn't mutate input.
+
+const IMAGE_PLACEHOLDER = "[image stripped for compaction]";
+
+function stripImagesFromMessages(messages: ModelMessage[]): ModelMessage[] {
+  return messages.map((m): ModelMessage => {
+    if (typeof m.content === "string") return m;
+    if (!Array.isArray(m.content)) return m;
+    const filtered = m.content.map((part) => {
+      if (!part || typeof part !== "object" || !("type" in part)) return part;
+      const p = part as { type: string; output?: unknown };
+      // Top-level image part on a user message
+      if (p.type === "image" || p.type === "file") {
+        return { type: "text" as const, text: IMAGE_PLACEHOLDER };
+      }
+      // Tool-result with content[] where individual items can be image-data / image-url
+      if (p.type === "tool-result") {
+        const out = p.output as { type?: string; value?: unknown } | undefined;
+        if (out?.type === "content" && Array.isArray(out.value)) {
+          const cleaned = out.value.map((b: { type?: string }) => {
+            if (
+              b?.type === "image-data" ||
+              b?.type === "image-url" ||
+              b?.type === "file-data" ||
+              b?.type === "file-url"
+            ) {
+              return { type: "text", text: IMAGE_PLACEHOLDER };
+            }
+            return b;
+          });
+          return { ...part, output: { ...out, value: cleaned } };
+        }
+      }
+      return part;
+    });
+    return { ...m, content: filtered as typeof m.content } as ModelMessage;
+  });
+}
+
+// ============================================================
+// CCStyleCompactionStrategy
+// ============================================================
+//
+// Mirrors what Claude Code does in `compact.ts`: an isolated summarize
+// call that does NOT try to reuse the main agent's prompt cache. Concretely:
+//
+//   - system: hardcoded one-liner ("You are a helpful AI assistant tasked
+//     with summarizing conversations.") — NOT the main agent's full system
+//   - tools:  empty (or a tiny fixed subset like just `read`) — NOT the
+//     main agent's full toolset
+//   - toolChoice: undefined — relies on the prompt to keep the model in
+//     summarize mode rather than trying to "do work"
+//   - messages: stripped of images and post-boundary slice (iterative
+//     summarization happens via the existing boundary mechanism in
+//     eventsToMessages — prior summary becomes the leading user message)
+//   - thinking: not enabled (we don't pass providerOptions for thinking)
+//
+// Trade-off vs the original SummarizeCompactionStrategy:
+//   + Robust across providers — does NOT rely on `tool_choice: "none"`,
+//     which ai-sdk silently translates to "drop tools" for Anthropic and
+//     which MiniMax doesn't honor reliably either way.
+//   + Cheaper per call — short system, empty tools, no images to encode.
+//   + Predictable empty-summary behavior — we skip writing the boundary
+//     when text is empty so the model doesn't lose the entire history.
+//   – Cache miss every time — the request prefix is fundamentally different
+//     from the main agent's last call. Summary calls cost full input price.
+//     Compaction is rare enough on real workloads that this is acceptable;
+//     the original "share the prefix, hit cache" approach was empirically
+//     not landing because of provider/SDK quirks anyway.
+
+export class CCStyleCompactionStrategy implements CompactionStrategy {
+  readonly name = "cc-style";
+
+  constructor(
+    private opts: {
+      tailMinTokens?: number;
+      tailMaxTokens?: number;
+      tailMinMessages?: number;
+      triggerFraction?: number;
+      summarySystemPrompt?: string;
+      maxSummaryTokens?: number;
+    } = {},
+  ) {}
+
+  shouldCompact(events: SessionEvent[], { contextWindowTokens }: { contextWindowTokens: number }): boolean {
+    const messages = eventsToMessages(events);
+    const tokens = estimateMessagesTokens(messages);
+    return tokens > contextWindowTokens * (this.opts.triggerFraction ?? TRIGGER_FRACTION);
+  }
+
+  async compact(
+    events: SessionEvent[],
+    { model, runtime }: {
+      model: LanguageModel;
+      contextWindowTokens: number;
+      systemPrompt: string;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      tools: Record<string, any>;
+      applyCacheStrategy: (
+        systemPrompt: string,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        tools: Record<string, any>,
+        messages: ModelMessage[],
+      ) => CacheStrategyApplied;
+      runtime?: HarnessRuntime;
+    },
+  ): Promise<CompactionResult | null> {
+    const allMessages = eventsToMessages(events);
+    if (allMessages.length < 4) return null;
+
+    // Strip image bytes from the messages we send to the summarizer. The
+    // summarizer doesn't need to see pixel data to summarize what happened —
+    // it sees the placeholder and produces text like "the agent rendered a
+    // chart showing X". Saves ~2K tokens per image in the conversation.
+    const cleanedMessages = stripImagesFromMessages(allMessages);
+
+    const summarizeRequest: ModelMessage = {
+      role: "user",
+      content: this.opts.summarySystemPrompt ?? CC_STYLE_SUMMARIZE_PROMPT,
+    };
+
+    const modelId = (model as { modelId?: string })?.modelId ?? "unknown";
+    runtime?.broadcast({ type: "span.compaction_summarize_start", model: modelId });
+
+    // Note what we are NOT passing:
+    //   - The main agent's system prompt (we use our own short one)
+    //   - The main agent's tools (we pass nothing)
+    //   - toolChoice (we don't try to constrain — relies on the prompt)
+    //   - applyCacheStrategy (we're not optimizing for cache reuse here)
+    const result = await generateText({
+      model,
+      system: CC_STYLE_SYSTEM_PROMPT,
+      messages: [...cleanedMessages, summarizeRequest],
+      maxOutputTokens: this.opts.maxSummaryTokens ?? 2000,
+    });
+
+    runtime?.broadcast({
+      type: "span.compaction_summarize_end",
+      model: modelId,
+      model_usage: result.usage ? {
+        input_tokens: result.usage.inputTokens ?? 0,
+        output_tokens: result.usage.outputTokens ?? 0,
+        cache_read_input_tokens: result.usage.inputTokenDetails?.cacheReadTokens ?? 0,
+        cache_creation_input_tokens: result.usage.inputTokenDetails?.cacheWriteTokens ?? 0,
+      } : undefined,
+      finish_reason: result.finishReason,
+      final_text_length: typeof result.text === "string" ? result.text.length : 0,
+    });
+
+    // Empty-summary defense: if the model returned no text (provider quirk,
+    // policy refusal, or the conversation was too short to summarize), do
+    // NOT write a boundary event. Otherwise downstream eventsToMessages
+    // would honor the empty-summary boundary and silently drop the entire
+    // pre-boundary history. Caller will retry on the next turn.
+    if (typeof result.text !== "string" || result.text.trim().length === 0) {
+      return null;
+    }
+
+    return {
+      summary: [{ type: "text", text: result.text }],
+      pre_tokens: estimateMessagesTokens(allMessages),
+      original_message_count: allMessages.length,
+      compacted_message_count: 1,
+    };
+  }
+}
+
+const CC_STYLE_SYSTEM_PROMPT =
+  "You are a helpful AI assistant tasked with summarizing conversations.";
+
+const CC_STYLE_SUMMARIZE_PROMPT =
+  "Provide a detailed but concise summary of the older conversation history. The most recent turns may be preserved verbatim outside your summary, so focus on information that would still be needed to continue the work with that recent context available. Cover: what was done, what is currently being worked on, which files are being modified, what needs to be done next, key user requests/constraints/preferences that should persist, and important technical decisions and why they were made. Do not respond to any questions in the conversation, only output the summary.";
+
+// ============================================================
+// OpenCodeStyleCompactionStrategy
+// ============================================================
+//
+// Same isolation idea as CCStyleCompactionStrategy, with OpenCode's
+// preferred summary template (Goal / Instructions / Discoveries /
+// Accomplished / Relevant files). The difference vs CC-style is purely
+// the prompt text — the structural choices (own system, no tools, no
+// toolChoice, image stripped) are identical.
+//
+// Pick this one when you want summaries that downstream agents or humans
+// can scan structurally rather than narratively.
+
+export class OpenCodeStyleCompactionStrategy implements CompactionStrategy {
+  readonly name = "opencode-style";
+
+  constructor(
+    private opts: {
+      tailMinTokens?: number;
+      tailMaxTokens?: number;
+      tailMinMessages?: number;
+      triggerFraction?: number;
+      summarySystemPrompt?: string;
+      maxSummaryTokens?: number;
+    } = {},
+  ) {}
+
+  shouldCompact(events: SessionEvent[], { contextWindowTokens }: { contextWindowTokens: number }): boolean {
+    const messages = eventsToMessages(events);
+    const tokens = estimateMessagesTokens(messages);
+    return tokens > contextWindowTokens * (this.opts.triggerFraction ?? TRIGGER_FRACTION);
+  }
+
+  async compact(
+    events: SessionEvent[],
+    { model, runtime }: {
+      model: LanguageModel;
+      contextWindowTokens: number;
+      systemPrompt: string;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      tools: Record<string, any>;
+      applyCacheStrategy: (
+        systemPrompt: string,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        tools: Record<string, any>,
+        messages: ModelMessage[],
+      ) => CacheStrategyApplied;
+      runtime?: HarnessRuntime;
+    },
+  ): Promise<CompactionResult | null> {
+    const allMessages = eventsToMessages(events);
+    if (allMessages.length < 4) return null;
+
+    const cleanedMessages = stripImagesFromMessages(allMessages);
+
+    const summarizeRequest: ModelMessage = {
+      role: "user",
+      content: this.opts.summarySystemPrompt ?? OPENCODE_STYLE_SUMMARIZE_PROMPT,
+    };
+
+    const modelId = (model as { modelId?: string })?.modelId ?? "unknown";
+    runtime?.broadcast({ type: "span.compaction_summarize_start", model: modelId });
+
+    const result = await generateText({
+      model,
+      system: OPENCODE_STYLE_SYSTEM_PROMPT,
+      messages: [...cleanedMessages, summarizeRequest],
+      maxOutputTokens: this.opts.maxSummaryTokens ?? 2000,
+    });
+
+    runtime?.broadcast({
+      type: "span.compaction_summarize_end",
+      model: modelId,
+      model_usage: result.usage ? {
+        input_tokens: result.usage.inputTokens ?? 0,
+        output_tokens: result.usage.outputTokens ?? 0,
+        cache_read_input_tokens: result.usage.inputTokenDetails?.cacheReadTokens ?? 0,
+        cache_creation_input_tokens: result.usage.inputTokenDetails?.cacheWriteTokens ?? 0,
+      } : undefined,
+      finish_reason: result.finishReason,
+      final_text_length: typeof result.text === "string" ? result.text.length : 0,
+    });
+
+    if (typeof result.text !== "string" || result.text.trim().length === 0) {
+      return null;
+    }
+
+    return {
+      summary: [{ type: "text", text: result.text }],
+      pre_tokens: estimateMessagesTokens(allMessages),
+      original_message_count: allMessages.length,
+      compacted_message_count: 1,
+    };
+  }
+}
+
+const OPENCODE_STYLE_SYSTEM_PROMPT =
+  "You are a helpful AI assistant tasked with summarizing conversations. Output only the summary text, no preamble.";
+
+const OPENCODE_STYLE_SUMMARIZE_PROMPT = `When constructing the summary, try to stick to this template:
+---
+## Goal
+
+[What goal(s) is the user trying to accomplish?]
+
+## Instructions
+
+- [What important instructions did the user give you that are relevant]
+- [If there is a plan or spec, include information about it so next agent can continue using it]
+
+## Discoveries
+
+[What notable things were learned during this conversation that would be useful for the next agent to know when continuing the work]
+
+## Accomplished
+
+[What work has been completed, what work is still in progress, and what work is left?]
+
+## Relevant files / directories
+
+[Construct a structured list of relevant files that have been read, edited, or created that pertain to the task at hand. If all the files in a directory are relevant, include the path to the directory.]
+---`;
+
+// ============================================================
+// Strategy registry
+// ============================================================
+//
+// Used by DefaultHarness to resolve `agent.metadata.compaction_strategy`.
+// Names match the `name` field on each strategy class.
+
+export type CompactionStrategyName = "summarize" | "cc-style" | "opencode-style";
+
+export function resolveCompactionStrategy(
+  name: string | undefined,
+  opts: {
+    headProtectMsgs?: number;
+    tailMinTokens?: number;
+    tailMaxTokens?: number;
+    tailMinMessages?: number;
+    triggerFraction?: number;
+    summarySystemPrompt?: string;
+    maxSummaryTokens?: number;
+  } = {},
+): CompactionStrategy {
+  switch (name) {
+    case "cc-style":
+      return new CCStyleCompactionStrategy(opts);
+    case "opencode-style":
+      return new OpenCodeStyleCompactionStrategy(opts);
+    case "summarize":
+    case undefined:
+      return new SummarizeCompactionStrategy(opts);
+    default:
+      // Unknown name → fall back to default. Don't throw — agent metadata
+      // is user-controlled and a typo shouldn't crash the harness.
+      console.warn(`[compaction] unknown strategy "${name}", falling back to "summarize"`);
+      return new SummarizeCompactionStrategy(opts);
+  }
+}
+
+// ============================================================
 // Backwards-compatible adapter (deprecated)
 // ============================================================
 // Old API used by anything still importing { SummarizeCompaction } from

--- a/apps/agent/src/harness/compaction.ts
+++ b/apps/agent/src/harness/compaction.ts
@@ -233,7 +233,9 @@ const DEFAULT_SUMMARIZE_PROMPT =
 
 const IMAGE_PLACEHOLDER = "[image stripped for compaction]";
 
-function stripImagesFromMessages(messages: ModelMessage[]): ModelMessage[] {
+// Exported so tests can probe edge cases directly. Production callers use
+// it through the strategy classes below.
+export function stripImagesFromMessages(messages: ModelMessage[]): ModelMessage[] {
   return messages.map((m): ModelMessage => {
     if (typeof m.content === "string") return m;
     if (!Array.isArray(m.content)) return m;

--- a/apps/agent/src/harness/default-loop.ts
+++ b/apps/agent/src/harness/default-loop.ts
@@ -3,7 +3,7 @@ import type { ContentPart, ModelMessage, LanguageModel, SystemModelMessage } fro
 import type { HarnessInterface, HarnessContext, HarnessRuntime } from "./interface";
 import type { SessionEvent, ContentBlock, AgentToolUseEvent } from "@open-managed-agents/shared";
 import { eventsToMessages } from "../runtime/history";
-import { SummarizeCompactionStrategy } from "./compaction";
+import { SummarizeCompactionStrategy, resolveCompactionStrategy } from "./compaction";
 import type { CompactionStrategy } from "./compaction";
 
 const BUILTIN_TOOLS = new Set(["bash", "read", "write", "edit", "glob", "grep", "web_fetch", "web_search"]);
@@ -276,9 +276,10 @@ export class DefaultHarness implements HarnessInterface {
   async run(ctx: HarnessContext): Promise<void> {
     const { agent, userMessage, runtime, tools, model, systemPrompt } = ctx;
 
-    // Resolve compaction params from agent config. One strategy
-    // (SummarizeCompactionStrategy) with CC-aligned tail defaults — opt-in
-    // overrides via agent.metadata for tuning per-agent if needed.
+    // Resolve compaction params from agent config. Strategy class is
+    // selectable via `agent.metadata.compaction_strategy` (defaults to
+    // "summarize" for backward compat); shared knobs (tail, trigger
+    // fraction) apply to whichever strategy is picked.
     const meta = (agent.metadata ?? {}) as Record<string, unknown>;
     const triggerFraction = typeof meta.compaction_trigger_fraction === "number"
       ? meta.compaction_trigger_fraction as number
@@ -292,7 +293,10 @@ export class DefaultHarness implements HarnessInterface {
     const tailMinMessages = typeof meta.compaction_tail_min_messages === "number"
       ? meta.compaction_tail_min_messages as number
       : undefined;
-    this.compactionStrategy = new SummarizeCompactionStrategy({
+    const strategyName = typeof meta.compaction_strategy === "string"
+      ? meta.compaction_strategy as string
+      : undefined;
+    this.compactionStrategy = resolveCompactionStrategy(strategyName, {
       tailMinTokens,
       tailMaxTokens,
       tailMinMessages,

--- a/apps/agent/src/harness/default-loop.ts
+++ b/apps/agent/src/harness/default-loop.ts
@@ -500,6 +500,29 @@ export class DefaultHarness implements HarnessInterface {
       runtime,
     });
     if (!result) return;
+
+    // Empty-summary defense (upstream layer). If a strategy returns a
+    // result whose summary contains no actual text, do NOT broadcast the
+    // boundary event. Otherwise eventsToMessages would later "honor" the
+    // empty boundary and silently drop the entire pre-boundary history.
+    //
+    // Observed in the wild on MiniMax: model returns finish_reason="tool-calls"
+    // with empty text → SummarizeCompactionStrategy returns
+    // summary=[{type:"text", text:""}] → boundary written → next derive
+    // tosses 60 turns of conversation. The new cc-style / opencode-style
+    // strategies catch this themselves (return null) but the legacy
+    // `summarize` strategy does not, so this layer is the safety net for
+    // any strategy that doesn't self-defend.
+    const hasContent = result.summary?.some(
+      (b) => (b.type === "text" && b.text.trim().length > 0)
+        || b.type === "image"
+        || b.type === "document",
+    );
+    if (!hasContent) {
+      console.warn("[compact] strategy produced empty summary — skipping boundary write");
+      return;
+    }
+
     runtime.broadcast({
       type: "agent.thread_context_compacted",
       original_message_count: result.original_message_count,

--- a/apps/agent/src/runtime/history.ts
+++ b/apps/agent/src/runtime/history.ts
@@ -60,13 +60,26 @@ export function eventsToMessages(events: SessionEvent[]): ModelMessage[] {
 
   // Find the last compaction boundary that actually carries a summary —
   // that's the one we honor. Earlier boundaries get superseded.
+  //
+  // "Carries a summary" means: at least one block contains real content.
+  // A bare array-length check (`summary.length > 0`) is NOT sufficient —
+  // a strategy that returns `[{type:"text", text:""}]` would still pass
+  // it and silently drop the entire pre-boundary history downstream.
+  // This is the downstream half of the empty-summary defense; the
+  // upstream half lives in DefaultHarness.compact() where the boundary
+  // event is written.
   let boundaryIdx = -1;
   let boundarySummary: ContentBlock[] | undefined;
   for (let i = events.length - 1; i >= 0; i--) {
     const e = events[i];
     if (e.type === "agent.thread_context_compacted") {
       const ce = e as AgentThreadContextCompactedEvent;
-      if (ce.summary && ce.summary.length > 0) {
+      const hasContent = ce.summary?.some(
+        (b) => (b.type === "text" && b.text.trim().length > 0)
+          || b.type === "image"
+          || b.type === "document",
+      );
+      if (hasContent) {
         boundaryIdx = i;
         boundarySummary = ce.summary;
         break;

--- a/test/unit/bijection-invariants.test.ts
+++ b/test/unit/bijection-invariants.test.ts
@@ -211,7 +211,7 @@ describe("eventsToMessages — context_boundary handling", () => {
     expect(messages).toHaveLength(5);
   });
 
-  it("boundary WITH summary drops pre-boundary model_io and injects summary", () => {
+  it("boundary WITH summary injects summary and preserves a tail of pre-boundary messages", () => {
     const events: SessionEvent[] = [
       ...eventsBefore,
       {
@@ -224,15 +224,20 @@ describe("eventsToMessages — context_boundary handling", () => {
       { type: "agent.message", content: [{ type: "text", text: "third answer" }] },
     ];
     const messages = eventsToMessages(events);
-    // [synthesized summary user] + [user "third"] + [assistant "third answer"]
-    expect(messages).toHaveLength(3);
+    // [synthesized summary user] + [tail of pre-boundary] + [user "third"] +
+    // [assistant "third answer"]. Tail-preservation (CC-style) keeps the
+    // last K messages of the pre-boundary range alongside the summary so the
+    // model has recent context. With only 4 short pre-boundary messages, the
+    // picker keeps all of them (minimums not met for trimming).
+    expect(messages.length).toBeGreaterThanOrEqual(3);
     expect(messages[0].role).toBe("user");
     const sumContent = messages[0].content as any[];
     expect(sumContent[0].type).toBe("text");
     expect(sumContent[0].text).toContain("<conversation-summary>");
     expect(sumContent[0].text).toContain("Earlier the user asked X");
-    expect(messages[1].role).toBe("user");
-    expect(messages[2].role).toBe("assistant");
+    // Last two messages are the post-boundary user "third" + agent reply.
+    expect(messages[messages.length - 2].role).toBe("user");
+    expect(messages[messages.length - 1].role).toBe("assistant");
   });
 
   it("only the LAST boundary with summary is honored (iterative compaction)", () => {
@@ -260,10 +265,15 @@ describe("eventsToMessages — context_boundary handling", () => {
       { type: "user.message", content: [{ type: "text", text: "q3" }] },
     ];
     const messages = eventsToMessages(events);
-    expect(messages).toHaveLength(2); // [v2 summary, q3]
+    // First message is the v2 summary user message; v1 was superseded.
+    // Tail preservation may include some pre-v2-boundary messages; the
+    // post-boundary q3 is always at the end.
+    expect(messages.length).toBeGreaterThanOrEqual(2);
     const sumText = (messages[0].content as any[])[0].text;
     expect(sumText).toContain("summary v2");
     expect(sumText).not.toContain("summary v1");
+    expect(messages[messages.length - 1].role).toBe("user");
+    expect((messages[messages.length - 1].content as any[])[0].text).toBe("q3");
   });
 
   it("boundary handling stays byte-stable", () => {
@@ -280,5 +290,117 @@ describe("eventsToMessages — context_boundary handling", () => {
     expect(JSON.stringify(eventsToMessages(events))).toBe(
       JSON.stringify(eventsToMessages(events)),
     );
+  });
+});
+
+// ============================================================
+// Empty-summary defense (downstream layer)
+// ============================================================
+//
+// A boundary event with an array summary that contains only empty / whitespace
+// text MUST be ignored. Otherwise a strategy that returned `[{type:"text", text:""}]`
+// would silently drop the entire pre-boundary history.
+//
+// Symptom in the wild: MiniMax sometimes returns finish_reason="tool-calls"
+// with empty text on summarize; SummarizeCompactionStrategy passes that
+// through verbatim into the boundary event. This test pins down that
+// eventsToMessages no longer trusts such boundaries.
+
+describe("eventsToMessages — empty-summary defense", () => {
+  const baseHistory: SessionEvent[] = [
+    { type: "user.message", content: [{ type: "text", text: "q1" }] },
+    { type: "agent.message", content: [{ type: "text", text: "a1" }] },
+    { type: "user.message", content: [{ type: "text", text: "q2" }] },
+    { type: "agent.message", content: [{ type: "text", text: "a2" }] },
+  ];
+
+  it("boundary with empty-text summary is ignored (history NOT dropped)", () => {
+    const events: SessionEvent[] = [
+      ...baseHistory,
+      {
+        type: "agent.thread_context_compacted",
+        original_message_count: 4,
+        compacted_message_count: 1,
+        summary: [{ type: "text", text: "" }],
+      } as any,
+      { type: "user.message", content: [{ type: "text", text: "q3" }] },
+    ];
+    const messages = eventsToMessages(events);
+    // Pre-boundary 4 messages + post-boundary q3 — boundary is treated as
+    // a no-op because its summary text is empty.
+    expect(messages).toHaveLength(5);
+    expect(messages[0].role).toBe("user");
+    expect((messages[0].content as any[])[0].text).toBe("q1");
+    expect(messages[messages.length - 1].role).toBe("user");
+    expect((messages[messages.length - 1].content as any[])[0].text).toBe("q3");
+  });
+
+  it("boundary with whitespace-only summary is ignored", () => {
+    const events: SessionEvent[] = [
+      ...baseHistory,
+      {
+        type: "agent.thread_context_compacted",
+        original_message_count: 4,
+        compacted_message_count: 1,
+        summary: [{ type: "text", text: "   \n\t  " }],
+      } as any,
+      { type: "user.message", content: [{ type: "text", text: "q3" }] },
+    ];
+    const messages = eventsToMessages(events);
+    expect(messages).toHaveLength(5);
+  });
+
+  it("boundary with image-only summary IS honored (multimodal escape)", () => {
+    // Edge case: a strategy that produces a summary consisting only of an
+    // image block (no text). Rare but legal — it counts as "carries content"
+    // so the boundary takes effect.
+    const events: SessionEvent[] = [
+      ...baseHistory,
+      {
+        type: "agent.thread_context_compacted",
+        original_message_count: 4,
+        compacted_message_count: 1,
+        summary: [
+          {
+            type: "image",
+            source: { type: "base64", media_type: "image/png", data: "AAA=" },
+          },
+        ],
+      } as any,
+      { type: "user.message", content: [{ type: "text", text: "q3" }] },
+    ];
+    const messages = eventsToMessages(events);
+    // Honored: synthesized summary at index 0, post-boundary q3 at end.
+    // Tail preservation may add some pre-boundary messages between them.
+    expect(messages.length).toBeGreaterThanOrEqual(2);
+    expect(messages[0].role).toBe("user");
+    expect((messages[0].content as any[])[0].text).toContain("[image elided]");
+  });
+
+  it("when latest boundary is empty but earlier boundary has real summary, fall through to earlier", () => {
+    // Two boundaries; the most recent is empty (defense rejects it). The
+    // earlier one has a real summary and should be the one honored.
+    const events: SessionEvent[] = [
+      { type: "user.message", content: [{ type: "text", text: "q1" }] },
+      { type: "agent.message", content: [{ type: "text", text: "a1" }] },
+      {
+        type: "agent.thread_context_compacted",
+        original_message_count: 2,
+        compacted_message_count: 1,
+        summary: [{ type: "text", text: "real summary v1" }],
+      } as any,
+      { type: "user.message", content: [{ type: "text", text: "q2" }] },
+      { type: "agent.message", content: [{ type: "text", text: "a2" }] },
+      {
+        type: "agent.thread_context_compacted",
+        original_message_count: 4,
+        compacted_message_count: 1,
+        summary: [{ type: "text", text: "" }], // empty — skipped
+      } as any,
+      { type: "user.message", content: [{ type: "text", text: "q3" }] },
+    ];
+    const messages = eventsToMessages(events);
+    const sumText = (messages[0].content as any[])[0].text;
+    expect(sumText).toContain("real summary v1");
   });
 });

--- a/test/unit/compaction-strategies.test.ts
+++ b/test/unit/compaction-strategies.test.ts
@@ -1,12 +1,26 @@
 // @ts-nocheck
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
   CCStyleCompactionStrategy,
   OpenCodeStyleCompactionStrategy,
   SummarizeCompactionStrategy,
   resolveCompactionStrategy,
+  stripImagesFromMessages,
 } from "../../apps/agent/src/harness/compaction";
 import type { SessionEvent } from "@open-managed-agents/shared";
+
+// Mock ai-sdk's generateText so iterative-compaction tests can drive the
+// strategy's full code path without hitting a real LLM. Spread original
+// exports so tools(), z, etc. still work.
+vi.mock("ai", async (importOriginal) => {
+  const orig = await importOriginal<typeof import("ai")>();
+  return {
+    ...orig,
+    generateText: vi.fn(),
+  };
+});
+
+import { generateText } from "ai";
 
 // ============================================================
 // resolveCompactionStrategy — name → class registry
@@ -224,5 +238,430 @@ describe("strategy classes are distinct", () => {
     const oc = new OpenCodeStyleCompactionStrategy();
     expect(cc).not.toBeInstanceOf(SummarizeCompactionStrategy);
     expect(oc).not.toBeInstanceOf(SummarizeCompactionStrategy);
+  });
+});
+
+// ============================================================
+// Upstream empty-summary defense in DefaultHarness.compact()
+// ============================================================
+//
+// The downstream layer (eventsToMessages skipping empty boundaries) has
+// its own tests in bijection-invariants.test.ts. This file pins the
+// upstream layer: even if a (legacy) strategy returns a result whose
+// summary text is empty, DefaultHarness.compact must NOT broadcast a
+// boundary event.
+//
+// We use a fake CompactionStrategy that returns a hand-crafted result
+// instead of mocking generateText.
+
+import { DefaultHarness } from "../../apps/agent/src/harness/default-loop";
+import type { CompactionStrategy, CompactionResult } from "../../apps/agent/src/harness/compaction";
+import type { HarnessRuntime } from "../../apps/agent/src/harness/interface";
+
+class FakeStrategy implements CompactionStrategy {
+  readonly name = "fake";
+  constructor(private result: CompactionResult | null) {}
+  shouldCompact() {
+    return true;
+  }
+  async compact() {
+    return this.result;
+  }
+}
+
+function buildHarnessWithStrategy(strategy: CompactionStrategy): {
+  harness: DefaultHarness;
+  broadcasts: SessionEvent[];
+} {
+  const harness = new DefaultHarness();
+  // Inject our fake strategy via the private field. compactionStrategy is
+  // re-set inside run() based on agent.metadata, but compact() (the method
+  // we're testing here) reads from the field directly.
+  (harness as any).compactionStrategy = strategy;
+  const broadcasts: SessionEvent[] = [];
+  const runtime = {
+    history: { append() {}, getEvents: () => [], getMessages: () => [] } as any,
+    sandbox: {} as any,
+    broadcast: (e: SessionEvent) => broadcasts.push(e),
+    reportUsage: async () => {},
+    pendingConfirmations: [],
+  } as HarnessRuntime;
+  return { harness, broadcasts, runtime } as any;
+}
+
+describe("DefaultHarness.compact() — empty-summary defense (upstream)", () => {
+  const ctx = {
+    model: { modelId: "stub" } as any,
+    systemPrompt: "stub",
+    tools: {},
+  };
+
+  it("does NOT broadcast boundary when strategy returns empty-text summary", async () => {
+    const fake = new FakeStrategy({
+      summary: [{ type: "text", text: "" }],
+      pre_tokens: 1000,
+      original_message_count: 10,
+      compacted_message_count: 1,
+    });
+    const { harness, broadcasts, runtime } = buildHarnessWithStrategy(fake) as any;
+    await harness.compact([], runtime, ctx);
+    const boundaries = broadcasts.filter((e) => e.type === "agent.thread_context_compacted");
+    expect(boundaries).toHaveLength(0);
+  });
+
+  it("does NOT broadcast boundary when summary is whitespace-only", async () => {
+    const fake = new FakeStrategy({
+      summary: [{ type: "text", text: "   \n\t  " }],
+      pre_tokens: 1000,
+      original_message_count: 10,
+      compacted_message_count: 1,
+    });
+    const { harness, broadcasts, runtime } = buildHarnessWithStrategy(fake) as any;
+    await harness.compact([], runtime, ctx);
+    expect(broadcasts.filter((e) => e.type === "agent.thread_context_compacted")).toHaveLength(0);
+  });
+
+  it("DOES broadcast boundary when summary has real text", async () => {
+    const fake = new FakeStrategy({
+      summary: [{ type: "text", text: "real summary content" }],
+      pre_tokens: 1000,
+      original_message_count: 10,
+      compacted_message_count: 1,
+    });
+    const { harness, broadcasts, runtime } = buildHarnessWithStrategy(fake) as any;
+    await harness.compact([], runtime, ctx);
+    const boundaries = broadcasts.filter((e) => e.type === "agent.thread_context_compacted");
+    expect(boundaries).toHaveLength(1);
+    expect((boundaries[0] as any).summary[0].text).toBe("real summary content");
+  });
+
+  it("does NOT broadcast when strategy returns null (e.g. too few messages)", async () => {
+    const fake = new FakeStrategy(null);
+    const { harness, broadcasts, runtime } = buildHarnessWithStrategy(fake) as any;
+    await harness.compact([], runtime, ctx);
+    expect(broadcasts).toHaveLength(0);
+  });
+});
+
+// ============================================================
+// Iterative compaction (with mocked generateText)
+// ============================================================
+//
+// When events already contain a prior boundary with a real summary, the
+// next compaction call should:
+//   1. See that prior summary as the leading user message in its derived
+//      messages (eventsToMessages handles this — it injects the
+//      <conversation-summary> block).
+//   2. Send those messages to the model alongside its own summarize prompt.
+//   3. Produce a new summary that supersedes (or extends) the prior one.
+//
+// We verify (1) and (2) by inspecting the actual messages handed to
+// generateText. (3) is purely up to the model and can't be tested without
+// a real LLM, but the input shape being correct guarantees the prior-
+// summary content is in the model's view.
+
+describe("iterative compaction (mocked generateText)", () => {
+  beforeEach(() => {
+    (generateText as any).mockReset();
+  });
+
+  const eventsWithPriorBoundary: SessionEvent[] = [
+    { type: "user.message", content: [{ type: "text", text: "early question" }] },
+    { type: "agent.message", content: [{ type: "text", text: "early answer" }] },
+    {
+      type: "agent.thread_context_compacted",
+      original_message_count: 2,
+      compacted_message_count: 1,
+      summary: [{ type: "text", text: "Earlier: user asked about X, agent did Y." }],
+    } as any,
+    { type: "user.message", content: [{ type: "text", text: "follow-up question" }] },
+    { type: "agent.message", content: [{ type: "text", text: "follow-up answer" }] },
+    { type: "user.message", content: [{ type: "text", text: "another question" }] },
+    { type: "agent.message", content: [{ type: "text", text: "another answer" }] },
+  ];
+
+  const stubArgs = {
+    model: { modelId: "stub" } as any,
+    contextWindowTokens: 1_000_000,
+    systemPrompt: "main-agent-system",
+    tools: { bash: {} },
+    applyCacheStrategy: (sys: string, tools: any, msgs: any[]) => ({ system: sys, tools, messages: msgs }),
+  };
+
+  for (const [name, Strategy] of [
+    ["cc-style", CCStyleCompactionStrategy],
+    ["opencode-style", OpenCodeStyleCompactionStrategy],
+  ] as const) {
+    it(`${name}: includes prior summary as leading user message in the summarize call`, async () => {
+      (generateText as any).mockResolvedValue({
+        text: "v2: covers earlier work + follow-up + another exchange.",
+        usage: { inputTokens: 100, outputTokens: 50 },
+        finishReason: "stop",
+      });
+
+      const s = new Strategy();
+      const result = await s.compact(eventsWithPriorBoundary, stubArgs);
+
+      // Strategy returned a non-null result with the new summary text.
+      expect(result).not.toBeNull();
+      expect(result!.summary[0].text).toContain("v2");
+
+      // generateText was called once. Its messages payload starts with the
+      // <conversation-summary> block (the prior summary, surfaced by
+      // eventsToMessages as a synthesized user message).
+      expect((generateText as any)).toHaveBeenCalledTimes(1);
+      const call = (generateText as any).mock.calls[0][0];
+      const firstMsg = call.messages[0];
+      expect(firstMsg.role).toBe("user");
+      const firstText = Array.isArray(firstMsg.content)
+        ? firstMsg.content[0].text
+        : firstMsg.content;
+      expect(firstText).toContain("<conversation-summary>");
+      expect(firstText).toContain("Earlier: user asked about X");
+
+      // Last message is the strategy's own "please summarize" prompt.
+      const lastMsg = call.messages[call.messages.length - 1];
+      expect(lastMsg.role).toBe("user");
+      const lastText = typeof lastMsg.content === "string"
+        ? lastMsg.content
+        : lastMsg.content[0].text;
+      // CC style talks about "older conversation history"; OpenCode style
+      // talks about "## Goal". Both are unambiguous summarize-ish prompts.
+      expect(
+        lastText.includes("summary") || lastText.includes("summarize") || lastText.includes("Goal"),
+      ).toBe(true);
+    });
+
+    it(`${name}: returns null on empty model output (defense)`, async () => {
+      (generateText as any).mockResolvedValue({
+        text: "",
+        usage: { inputTokens: 100, outputTokens: 0 },
+        finishReason: "stop",
+      });
+
+      const s = new Strategy();
+      const result = await s.compact(eventsWithPriorBoundary, stubArgs);
+      expect(result).toBeNull();
+    });
+
+    it(`${name}: returns null on whitespace-only model output`, async () => {
+      (generateText as any).mockResolvedValue({
+        text: "   \n\t   ",
+        usage: { inputTokens: 100, outputTokens: 5 },
+        finishReason: "stop",
+      });
+
+      const s = new Strategy();
+      const result = await s.compact(eventsWithPriorBoundary, stubArgs);
+      expect(result).toBeNull();
+    });
+
+    it(`${name}: does NOT pass main agent's system prompt or tools`, async () => {
+      (generateText as any).mockResolvedValue({
+        text: "summary",
+        usage: { inputTokens: 100, outputTokens: 5 },
+        finishReason: "stop",
+      });
+
+      const s = new Strategy();
+      await s.compact(eventsWithPriorBoundary, stubArgs);
+      const call = (generateText as any).mock.calls[0][0];
+      // The strategies use their own short system prompt, NOT the caller's.
+      expect(call.system).not.toBe("main-agent-system");
+      expect(typeof call.system).toBe("string");
+      expect(call.system.length).toBeLessThan(1000);
+      // No tools field passed → ai-sdk treats as undefined.
+      expect(call.tools).toBeUndefined();
+      // No toolChoice passed.
+      expect(call.toolChoice).toBeUndefined();
+    });
+  }
+});
+
+// ============================================================
+// stripImagesFromMessages — direct edge-case tests
+// ============================================================
+//
+// Replaces every image / file content block with a short text placeholder,
+// across all the shapes the codebase currently produces. Pure function;
+// must not mutate input.
+
+describe("stripImagesFromMessages", () => {
+  const PNG = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkAAIAAAoAAv/lxKUAAAAASUVORK5CYII=";
+
+  it("passes through messages with string content unchanged", () => {
+    const input = [
+      { role: "user" as const, content: "hello" },
+      { role: "assistant" as const, content: "hi" },
+    ];
+    const result = stripImagesFromMessages(input);
+    expect(result).toEqual(input);
+  });
+
+  it("passes through messages with no images unchanged", () => {
+    const input = [
+      {
+        role: "user" as const,
+        content: [{ type: "text" as const, text: "no images here" }],
+      },
+    ];
+    const result = stripImagesFromMessages(input);
+    // Same shape, same text.
+    expect((result[0].content as any)[0].text).toBe("no images here");
+  });
+
+  it("strips top-level image part on user message", () => {
+    const input = [
+      {
+        role: "user" as const,
+        content: [
+          { type: "text" as const, text: "look at this:" },
+          { type: "image" as const, image: PNG, mediaType: "image/png" },
+        ],
+      },
+    ];
+    const result = stripImagesFromMessages(input);
+    const parts = result[0].content as any[];
+    expect(parts).toHaveLength(2);
+    expect(parts[0]).toEqual({ type: "text", text: "look at this:" });
+    expect(parts[1].type).toBe("text");
+    expect(parts[1].text).toContain("image");
+    expect(parts[1].text).not.toContain(PNG);
+  });
+
+  it("strips top-level file part (e.g. PDF) on user message", () => {
+    const input = [
+      {
+        role: "user" as const,
+        content: [
+          { type: "text" as const, text: "see attached:" },
+          { type: "file" as const, data: "BASE64DATA", mediaType: "application/pdf" },
+        ],
+      },
+    ];
+    const result = stripImagesFromMessages(input);
+    const parts = result[0].content as any[];
+    expect(parts[1].type).toBe("text");
+    expect(parts[1].text).not.toContain("BASE64DATA");
+  });
+
+  it("strips image-data inside tool_result content", () => {
+    const input = [
+      {
+        role: "tool" as const,
+        content: [
+          {
+            type: "tool-result" as const,
+            toolCallId: "tc1",
+            toolName: "render_chart",
+            output: {
+              type: "content",
+              value: [
+                { type: "text", text: "Chart text:" },
+                { type: "image-data", data: PNG, mediaType: "image/png" },
+              ],
+            },
+          },
+        ],
+      },
+    ];
+    const result = stripImagesFromMessages(input);
+    const trPart = (result[0].content as any[])[0];
+    const innerParts = trPart.output.value;
+    expect(innerParts).toHaveLength(2);
+    expect(innerParts[0]).toEqual({ type: "text", text: "Chart text:" });
+    expect(innerParts[1].type).toBe("text");
+    expect(innerParts[1].text).not.toContain(PNG);
+    // Surrounding tool-result envelope preserved
+    expect(trPart.toolCallId).toBe("tc1");
+    expect(trPart.toolName).toBe("render_chart");
+    expect(trPart.output.type).toBe("content");
+  });
+
+  it("strips image-url, file-data, file-url inside tool_result content", () => {
+    const input = [
+      {
+        role: "tool" as const,
+        content: [
+          {
+            type: "tool-result" as const,
+            toolCallId: "tc1",
+            toolName: "fetch",
+            output: {
+              type: "content",
+              value: [
+                { type: "image-url", url: "https://example.com/x.png", mediaType: "image/png" },
+                { type: "file-data", data: "PDFBYTES", mediaType: "application/pdf" },
+                { type: "file-url", url: "https://example.com/x.pdf", mediaType: "application/pdf" },
+              ],
+            },
+          },
+        ],
+      },
+    ];
+    const result = stripImagesFromMessages(input);
+    const innerParts = (result[0].content as any[])[0].output.value;
+    expect(innerParts).toHaveLength(3);
+    for (const p of innerParts) {
+      expect(p.type).toBe("text");
+      expect(p.text).not.toContain("example.com");
+      expect(p.text).not.toContain("PDFBYTES");
+    }
+  });
+
+  it("does NOT touch tool_result with text-only output", () => {
+    const input = [
+      {
+        role: "tool" as const,
+        content: [
+          {
+            type: "tool-result" as const,
+            toolCallId: "tc1",
+            toolName: "bash",
+            output: { type: "text", value: "command output" },
+          },
+        ],
+      },
+    ];
+    const result = stripImagesFromMessages(input);
+    expect(result[0]).toEqual(input[0]);
+  });
+
+  it("preserves system messages with string content", () => {
+    const input = [
+      { role: "system" as const, content: "you are helpful" },
+      {
+        role: "user" as const,
+        content: [{ type: "image" as const, image: PNG, mediaType: "image/png" }],
+      },
+    ];
+    const result = stripImagesFromMessages(input);
+    expect(result[0]).toEqual({ role: "system", content: "you are helpful" });
+    expect((result[1].content as any[])[0].type).toBe("text");
+  });
+
+  it("does not mutate input array or nested objects", () => {
+    const original = [
+      {
+        role: "user" as const,
+        content: [
+          { type: "text" as const, text: "look:" },
+          { type: "image" as const, image: PNG, mediaType: "image/png" },
+        ],
+      },
+    ];
+    const beforeJson = JSON.stringify(original);
+    stripImagesFromMessages(original);
+    expect(JSON.stringify(original)).toBe(beforeJson);
+  });
+
+  it("handles empty messages array", () => {
+    expect(stripImagesFromMessages([])).toEqual([]);
+  });
+
+  it("handles message with empty content array", () => {
+    const input = [{ role: "user" as const, content: [] }];
+    const result = stripImagesFromMessages(input);
+    expect((result[0].content as any[]).length).toBe(0);
   });
 });

--- a/test/unit/compaction-strategies.test.ts
+++ b/test/unit/compaction-strategies.test.ts
@@ -1,0 +1,228 @@
+// @ts-nocheck
+import { describe, it, expect } from "vitest";
+import {
+  CCStyleCompactionStrategy,
+  OpenCodeStyleCompactionStrategy,
+  SummarizeCompactionStrategy,
+  resolveCompactionStrategy,
+} from "../../apps/agent/src/harness/compaction";
+import type { SessionEvent } from "@open-managed-agents/shared";
+
+// ============================================================
+// resolveCompactionStrategy — name → class registry
+// ============================================================
+
+describe("resolveCompactionStrategy", () => {
+  it("returns SummarizeCompactionStrategy for undefined", () => {
+    expect(resolveCompactionStrategy(undefined).name).toBe("summarize");
+  });
+
+  it("returns SummarizeCompactionStrategy for 'summarize'", () => {
+    const s = resolveCompactionStrategy("summarize");
+    expect(s).toBeInstanceOf(SummarizeCompactionStrategy);
+    expect(s.name).toBe("summarize");
+  });
+
+  it("returns CCStyleCompactionStrategy for 'cc-style'", () => {
+    const s = resolveCompactionStrategy("cc-style");
+    expect(s).toBeInstanceOf(CCStyleCompactionStrategy);
+    expect(s.name).toBe("cc-style");
+  });
+
+  it("returns OpenCodeStyleCompactionStrategy for 'opencode-style'", () => {
+    const s = resolveCompactionStrategy("opencode-style");
+    expect(s).toBeInstanceOf(OpenCodeStyleCompactionStrategy);
+    expect(s.name).toBe("opencode-style");
+  });
+
+  it("falls back to summarize on unknown name (no throw)", () => {
+    // Should warn but not throw — agent metadata is user-controlled and a
+    // typo shouldn't crash the harness.
+    const s = resolveCompactionStrategy("typo-style");
+    expect(s).toBeInstanceOf(SummarizeCompactionStrategy);
+  });
+
+  it("propagates options to the resolved strategy", () => {
+    // shouldCompact uses triggerFraction → cheapest way to verify the
+    // option threaded through.
+    const events: SessionEvent[] = Array.from({ length: 8 }, (_, i) =>
+      i % 2 === 0
+        ? { type: "user.message", content: [{ type: "text", text: "x".repeat(2000) }] }
+        : { type: "agent.message", content: [{ type: "text", text: "y".repeat(2000) }] },
+    );
+    const tight = resolveCompactionStrategy("cc-style", { triggerFraction: 0.001 });
+    const loose = resolveCompactionStrategy("cc-style", { triggerFraction: 0.99 });
+    expect(tight.shouldCompact(events, { contextWindowTokens: 1_000_000 })).toBe(true);
+    expect(loose.shouldCompact(events, { contextWindowTokens: 1_000_000 })).toBe(false);
+  });
+});
+
+// ============================================================
+// shouldCompact — trigger fraction threshold
+// ============================================================
+//
+// All three strategies share the same shouldCompact logic. Verify each
+// fires above its threshold and stays quiet below.
+
+describe("shouldCompact (all strategies)", () => {
+  // Build a conversation big enough that estimateMessagesTokens crosses
+  // typical thresholds. ~50KB of text ≈ ~12K tokens at 4 chars/token.
+  const bigEvents: SessionEvent[] = Array.from({ length: 12 }, (_, i) =>
+    i % 2 === 0
+      ? { type: "user.message", content: [{ type: "text", text: "x".repeat(4000) }] }
+      : { type: "agent.message", content: [{ type: "text", text: "y".repeat(4000) }] },
+  );
+
+  for (const [name, Strategy] of [
+    ["summarize", SummarizeCompactionStrategy],
+    ["cc-style", CCStyleCompactionStrategy],
+    ["opencode-style", OpenCodeStyleCompactionStrategy],
+  ] as const) {
+    it(`${name}: fires when estimated tokens exceed contextWindow * triggerFraction`, () => {
+      const tight = new Strategy({ triggerFraction: 0.005 });
+      expect(tight.shouldCompact(bigEvents, { contextWindowTokens: 1_000_000 })).toBe(true);
+    });
+
+    it(`${name}: stays quiet when below threshold`, () => {
+      const loose = new Strategy({ triggerFraction: 0.99 });
+      expect(loose.shouldCompact(bigEvents, { contextWindowTokens: 1_000_000 })).toBe(false);
+    });
+  }
+});
+
+// ============================================================
+// compact() early-return: too few messages
+// ============================================================
+//
+// All isolated strategies (cc-style, opencode-style) return null when
+// the derived message list is shorter than 4. Below that threshold there's
+// nothing meaningful to summarize and we'd just lose information. Verify
+// without making any API calls.
+
+describe("compact() — early return for short conversations", () => {
+  const tinyEvents: SessionEvent[] = [
+    { type: "user.message", content: [{ type: "text", text: "hi" }] },
+    { type: "agent.message", content: [{ type: "text", text: "hello" }] },
+  ];
+
+  // Stub LanguageModel — never invoked because the early return triggers
+  // before generateText is called. Cast to any to satisfy the type.
+  const stubModel = { modelId: "stub" } as any;
+
+  const stubArgs = {
+    model: stubModel,
+    contextWindowTokens: 1_000_000,
+    systemPrompt: "stub-system",
+    tools: {},
+    applyCacheStrategy: (sys: string, tools: any, msgs: any[]) => ({
+      system: sys,
+      tools,
+      messages: msgs,
+    }),
+  };
+
+  it("CCStyleCompactionStrategy: returns null for < 4 messages", async () => {
+    const s = new CCStyleCompactionStrategy();
+    const result = await s.compact(tinyEvents, stubArgs);
+    expect(result).toBeNull();
+  });
+
+  it("OpenCodeStyleCompactionStrategy: returns null for < 4 messages", async () => {
+    const s = new OpenCodeStyleCompactionStrategy();
+    const result = await s.compact(tinyEvents, stubArgs);
+    expect(result).toBeNull();
+  });
+});
+
+// ============================================================
+// stripImagesFromMessages helper (via compact() integration)
+// ============================================================
+//
+// stripImagesFromMessages is private to compaction.ts. Test it indirectly
+// by having the strategy operate on events that contain images, then
+// reading the messages it would emit via eventsToMessages and asserting
+// the strip behavior on equivalent fixtures via the ToolResult roundtrip.
+//
+// Direct shape tests live in bijection-invariants.test.ts (image base64
+// roundtrip). Here we focus on the strip semantics: image bytes go away
+// AND get replaced by the placeholder text, AND the surrounding text
+// blocks survive.
+
+import { eventsToMessages } from "../../apps/agent/src/runtime/history";
+
+describe("stripImagesFromMessages semantics (via eventsToMessages fixture)", () => {
+  const PNG =
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkAAIAAAoAAv/lxKUAAAAASUVORK5CYII=";
+
+  const events: SessionEvent[] = [
+    { type: "user.message", content: [{ type: "text", text: "render it" }] },
+    {
+      type: "agent.tool_use",
+      id: "tc_chart",
+      name: "render_chart",
+      input: { caption: "p99" },
+    } as any,
+    {
+      type: "agent.tool_result",
+      tool_use_id: "tc_chart",
+      content: [
+        { type: "text", text: "Chart caption: p99." },
+        { type: "image", source: { type: "base64", media_type: "image/png", data: PNG } },
+      ],
+    } as any,
+  ];
+
+  it("derived messages contain the raw image data BEFORE strip", () => {
+    const messages = eventsToMessages(events);
+    const tool = messages.find((m) => m.role === "tool")!;
+    const trPart = (tool.content as any[])[0];
+    const imageBlock = trPart.output.value.find((b: any) => b.type === "image-data");
+    expect(imageBlock).toBeDefined();
+    expect(imageBlock.data).toBe(PNG);
+  });
+
+  // The actual strip happens inside compact() before sending to generateText.
+  // We can't easily snapshot that without mocking generateText, but we can
+  // assert the helper's behavior via the resolver + a manual integration
+  // probe: call compact on a tiny conversation, expect early-return (so no
+  // model call is made even with images present).
+  it("strategies don't crash on image-bearing fixtures (early return path)", async () => {
+    const cc = new CCStyleCompactionStrategy();
+    const oc = new OpenCodeStyleCompactionStrategy();
+    const stubArgs = {
+      model: { modelId: "stub" } as any,
+      contextWindowTokens: 1_000_000,
+      systemPrompt: "stub",
+      tools: {},
+      applyCacheStrategy: (sys: string, tools: any, msgs: any[]) => ({ system: sys, tools, messages: msgs }),
+    };
+    // 3 messages → below the 4-message threshold → early return null
+    expect(await cc.compact(events, stubArgs)).toBeNull();
+    expect(await oc.compact(events, stubArgs)).toBeNull();
+  });
+});
+
+// ============================================================
+// Strategy distinctness
+// ============================================================
+//
+// The two new strategies are intentionally separate classes (not just
+// different prompt strings) so future divergence is cheap. Pin that they
+// are NOT the same class.
+
+describe("strategy classes are distinct", () => {
+  it("CCStyleCompactionStrategy and OpenCodeStyleCompactionStrategy are different classes", () => {
+    const cc = new CCStyleCompactionStrategy();
+    const oc = new OpenCodeStyleCompactionStrategy();
+    expect(cc).not.toBeInstanceOf(OpenCodeStyleCompactionStrategy);
+    expect(oc).not.toBeInstanceOf(CCStyleCompactionStrategy);
+    expect(cc.name).not.toBe(oc.name);
+  });
+
+  it("neither extends SummarizeCompactionStrategy (they are not cache-prefix-sharing)", () => {
+    const cc = new CCStyleCompactionStrategy();
+    const oc = new OpenCodeStyleCompactionStrategy();
+    expect(cc).not.toBeInstanceOf(SummarizeCompactionStrategy);
+    expect(oc).not.toBeInstanceOf(SummarizeCompactionStrategy);
+  });
+});


### PR DESCRIPTION
## Why

The existing `SummarizeCompactionStrategy` was designed to share the main agent's prompt cache prefix on the summarize call (same model + same system + same tools + same messages prefix + `toolChoice: "none"` to forbid tool use). End-to-end probes proved this doesn't work in practice:

1. **`@ai-sdk/anthropic` strips tools when `toolChoice: "none"`** — verified by dumping the actual request body. The summarize call sends `tools: []`, `tool_choice: null`. So the prefix doesn't match the main call's prefix and `cache_read = 0` on the summarize call (33% reuse on main → 0% on summarize through Anthropic).
2. **MiniMax sporadically returns `finish_reason="tool-calls"` with empty text** — likely because the conversation history primes it. The empty-summary then gets written into the boundary event, and `eventsToMessages` honors a `summary.length > 0` (array length, not text length) boundary, silently dropping the entire pre-boundary history.

Looking at how Claude Code and OpenCode actually do this: **neither tries to share cache**. CC's compact path uses a hardcoded one-line system prompt, only `[FileReadTool]`, `toolChoice: undefined`, and `stripImagesFromMessages`. OpenCode does `tools: {}` + `system: []` + `stripMedia: true`. Both pay full input on the summarize call and bet that compaction is rare enough on real workloads that it's fine.

## What changed

Two new `CompactionStrategy` implementations alongside the existing `SummarizeCompactionStrategy` (which stays as the default for backward compat):

- **`CCStyleCompactionStrategy`** — short hardcoded system, empty tools, no `toolChoice`, images stripped, empty-summary defense (returns `null` instead of writing an empty boundary).
- **`OpenCodeStyleCompactionStrategy`** — same structure, OpenCode's Goal / Instructions / Discoveries / Accomplished / Files template for scannable structural summaries.

Two-layer empty-summary defense:

- **Upstream** (`DefaultHarness.compact()`): if a strategy returns a result whose summary contains only empty/whitespace text, skip the boundary write. Caller will retry next turn.
- **Downstream** (`eventsToMessages`): boundary detection now requires real text/image/document content, not just a non-empty array. A stale or buggy upstream that wrote an empty boundary won't drop history downstream.

Plus:

- **`stripImagesFromMessages`** helper, exported. Walks messages and replaces image / file content (top-level user images, `tool_result` `image-data` / `image-url` / `file-data` / `file-url` parts) with a short placeholder. Pure function, doesn't mutate input.
- **`resolveCompactionStrategy(name, opts)`** registry — picks a class by name with a clear "unknown name → fallback + warn" path so a typo in agent metadata doesn't crash the harness.
- **`default-loop.ts` reads `agent.metadata.compaction_strategy`** (`"summarize"` | `"cc-style"` | `"opencode-style"`) to pick the strategy. Defaults to `"summarize"` so existing agents are unaffected.
- Updated 2 stale boundary-handling tests in `bijection-invariants.test.ts` that pre-date the bijection refactor's tail preservation.

## Test plan

- [x] `npx vitest run test/unit/compaction-strategies.test.ts` — **41 tests pass** covering: registry resolution, options pass-through, `shouldCompact` threshold across all 3 strategies, early-return for short conversations, image-bearing fixtures don't crash the strip path, class distinctness, **iterative compaction with mocked `generateText`** (verifies prior summary appears as leading user message in the summarize call, no main-system / no tools / no toolChoice passed, empty-output handling), **upstream empty-summary defense**, **direct stripImagesFromMessages edge cases** (string content, top-level image / file blocks, image-data / image-url / file-data / file-url inside tool_result, system message preservation, no-mutation invariant, empty input).
- [x] `npx vitest run test/unit/bijection-invariants.test.ts` — **23 tests pass** including 4 new **downstream empty-summary defense** tests (empty text, whitespace-only, image-only edge that IS honored, fall-through to earlier real boundary). The 2 previously-failing `context_boundary handling` tests are now updated to reflect tail-preservation behavior and pass.
- [x] `npx tsc --noEmit -p tsconfig.json` — no new errors.
- [x] **Live probe across 4 new (strategy × provider) combinations** using PR #6's probe with `PROBE_COMPACTION_STRATEGY` env var (added to PR #6 in a follow-up commit). Results below.

### Live probe results

Triggered aggressive compaction (`PROBE_COMPACTION_TRIGGER=0.005`) so multiple compactions fire per run.

| strategy | provider/model | compactions | summary text_len | finish_reason | empty summaries |
|---|---|---|---|---|---|
| **summarize** (baseline) | MiniMax-M2.7 | several | ~939 chars typical | mostly `stop`; `tool-calls text_len=0` sporadically | yes — boundary written, history dropped |
| **summarize** (baseline) | Anthropic Haiku | several | ~2400 chars | `stop` | no |
| **cc-style** (NEW) | MiniMax-M2.7 | 13+ | 1295–1431 chars consistently | `stop` every time | **none** ✓ |
| **cc-style** (NEW) | Anthropic Haiku | several | 1840–1947 chars (and one 103-char short summary that the defense correctly accepted as non-empty) | `stop` | none |
| **opencode-style** (NEW) | MiniMax-M2.7 | several | ~1650 chars structured | `stop` | none |
| **opencode-style** (NEW) | Anthropic Haiku | several | 1146–1688 chars structured | `stop` | none |

Key wins:

- **MiniMax `finish=tool-calls text_len=0` no longer happens** under the new strategies — confirmed across 13+ compactions on cc-style and several on opencode-style. The model has no tools to call, so it just produces text.
- Summary content quality is good. cc-style produces narrative summaries; opencode-style produces structural Goal/Instructions/Discoveries/Accomplished/Files sections.
- Cache_read on summarize call is 0% (expected — these strategies intentionally don't share prefix).

## Migration notes

To opt an agent into the new behavior:

```json
{
  "metadata": { "compaction_strategy": "cc-style" }
}
```

No change required for agents that don't set `compaction_strategy` — they keep the existing `SummarizeCompactionStrategy`, but now ALSO benefit from the empty-summary defense as a safety net.

## Follow-ups (out of scope for this PR)

- OpenAI-compatible cross-provider live probe (no creds handy in this environment) — open as separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)