### PR TITLE
OPE-13: probe coverage + CC/OpenCode compaction strategies + scrubs

### DIFF
--- a/apps/agent/src/harness/compaction.ts
+++ b/apps/agent/src/harness/compaction.ts
@@ -86,12 +86,11 @@ function estimateMessagesTokens(messages: ModelMessage[]): number {
 }
 
 // Trigger fraction: shouldCompact fires when estimated tokens exceed
-// `triggerFraction * contextWindowTokens`. CC uses ~0.85 effective (after
-// the 13K AUTOCOMPACT_BUFFER reservation); 0.75 gives more headroom for
-// long single turns to flush tool results before the trigger.
+// `triggerFraction * contextWindowTokens`. We pick 0.75 to give headroom
+// for long single turns to flush tool results before the trigger.
 //
 // Tail preservation lives entirely in derive (history.ts) — it walks
-// pre-boundary events using CC-style estimateMessageTokens and renders the
+// pre-boundary events using the same per-message estimate and renders the
 // last K messages verbatim alongside the summary. Strategy doesn't need to
 // coordinate; it just produces the summary covering everything.
 const TRIGGER_FRACTION = 0.75;

--- a/apps/agent/src/harness/compaction.ts
+++ b/apps/agent/src/harness/compaction.ts
@@ -218,6 +218,350 @@ const DEFAULT_SUMMARIZE_PROMPT =
   "Summarize the entire conversation above. Preserve key decisions, file paths, tool results (commands run + their output), in-flight tasks, and explicit Next Steps. If the conversation already contains a <conversation-summary> block, produce an updated summary that supersedes it (combining prior summary + new activity). Be concise but specific. Output only the summary text, no preamble.";
 
 // ============================================================
+// Image stripping helper
+// ============================================================
+//
+// Walk a message list and replace every image content block (top-level user
+// images, image-data/image-url tool_result outputs, raw image parts) with a
+// short placeholder. Used by the isolated strategies below to keep the
+// summarize call cheap — the summarizer doesn't need to "see" the image
+// bytes to know they were rendered, just that an image existed at that
+// position.
+//
+// Pure function: same input → same output bytes. Doesn't mutate input.
+
+const IMAGE_PLACEHOLDER = "[image stripped for compaction]";
+
+function stripImagesFromMessages(messages: ModelMessage[]): ModelMessage[] {
+  return messages.map((m): ModelMessage => {
+    if (typeof m.content === "string") return m;
+    if (!Array.isArray(m.content)) return m;
+    const filtered = m.content.map((part) => {
+      if (!part || typeof part !== "object" || !("type" in part)) return part;
+      const p = part as { type: string; output?: unknown };
+      // Top-level image part on a user message
+      if (p.type === "image" || p.type === "file") {
+        return { type: "text" as const, text: IMAGE_PLACEHOLDER };
+      }
+      // Tool-result with content[] where individual items can be image-data / image-url
+      if (p.type === "tool-result") {
+        const out = p.output as { type?: string; value?: unknown } | undefined;
+        if (out?.type === "content" && Array.isArray(out.value)) {
+          const cleaned = out.value.map((b: { type?: string }) => {
+            if (
+              b?.type === "image-data" ||
+              b?.type === "image-url" ||
+              b?.type === "file-data" ||
+              b?.type === "file-url"
+            ) {
+              return { type: "text", text: IMAGE_PLACEHOLDER };
+            }
+            return b;
+          });
+          return { ...part, output: { ...out, value: cleaned } };
+        }
+      }
+      return part;
+    });
+    return { ...m, content: filtered as typeof m.content } as ModelMessage;
+  });
+}
+
+// ============================================================
+// CCStyleCompactionStrategy
+// ============================================================
+//
+// Mirrors what Claude Code does in `compact.ts`: an isolated summarize
+// call that does NOT try to reuse the main agent's prompt cache. Concretely:
+//
+//   - system: hardcoded one-liner ("You are a helpful AI assistant tasked
+//     with summarizing conversations.") — NOT the main agent's full system
+//   - tools:  empty (or a tiny fixed subset like just `read`) — NOT the
+//     main agent's full toolset
+//   - toolChoice: undefined — relies on the prompt to keep the model in
+//     summarize mode rather than trying to "do work"
+//   - messages: stripped of images and post-boundary slice (iterative
+//     summarization happens via the existing boundary mechanism in
+//     eventsToMessages — prior summary becomes the leading user message)
+//   - thinking: not enabled (we don't pass providerOptions for thinking)
+//
+// Trade-off vs the original SummarizeCompactionStrategy:
+//   + Robust across providers — does NOT rely on `tool_choice: "none"`,
+//     which ai-sdk silently translates to "drop tools" for Anthropic and
+//     which MiniMax doesn't honor reliably either way.
+//   + Cheaper per call — short system, empty tools, no images to encode.
+//   + Predictable empty-summary behavior — we skip writing the boundary
+//     when text is empty so the model doesn't lose the entire history.
+//   – Cache miss every time — the request prefix is fundamentally different
+//     from the main agent's last call. Summary calls cost full input price.
+//     Compaction is rare enough on real workloads that this is acceptable;
+//     the original "share the prefix, hit cache" approach was empirically
+//     not landing because of provider/SDK quirks anyway.
+
+export class CCStyleCompactionStrategy implements CompactionStrategy {
+  readonly name = "cc-style";
+
+  constructor(
+    private opts: {
+      tailMinTokens?: number;
+      tailMaxTokens?: number;
+      tailMinMessages?: number;
+      triggerFraction?: number;
+      summarySystemPrompt?: string;
+      maxSummaryTokens?: number;
+    } = {},
+  ) {}
+
+  shouldCompact(events: SessionEvent[], { contextWindowTokens }: { contextWindowTokens: number }): boolean {
+    const messages = eventsToMessages(events);
+    const tokens = estimateMessagesTokens(messages);
+    return tokens > contextWindowTokens * (this.opts.triggerFraction ?? TRIGGER_FRACTION);
+  }
+
+  async compact(
+    events: SessionEvent[],
+    { model, runtime }: {
+      model: LanguageModel;
+      contextWindowTokens: number;
+      systemPrompt: string;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      tools: Record<string, any>;
+      applyCacheStrategy: (
+        systemPrompt: string,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        tools: Record<string, any>,
+        messages: ModelMessage[],
+      ) => CacheStrategyApplied;
+      runtime?: HarnessRuntime;
+    },
+  ): Promise<CompactionResult | null> {
+    const allMessages = eventsToMessages(events);
+    if (allMessages.length < 4) return null;
+
+    // Strip image bytes from the messages we send to the summarizer. The
+    // summarizer doesn't need to see pixel data to summarize what happened —
+    // it sees the placeholder and produces text like "the agent rendered a
+    // chart showing X". Saves ~2K tokens per image in the conversation.
+    const cleanedMessages = stripImagesFromMessages(allMessages);
+
+    const summarizeRequest: ModelMessage = {
+      role: "user",
+      content: this.opts.summarySystemPrompt ?? CC_STYLE_SUMMARIZE_PROMPT,
+    };
+
+    const modelId = (model as { modelId?: string })?.modelId ?? "unknown";
+    runtime?.broadcast({ type: "span.compaction_summarize_start", model: modelId });
+
+    // Note what we are NOT passing:
+    //   - The main agent's system prompt (we use our own short one)
+    //   - The main agent's tools (we pass nothing)
+    //   - toolChoice (we don't try to constrain — relies on the prompt)
+    //   - applyCacheStrategy (we're not optimizing for cache reuse here)
+    const result = await generateText({
+      model,
+      system: CC_STYLE_SYSTEM_PROMPT,
+      messages: [...cleanedMessages, summarizeRequest],
+      maxOutputTokens: this.opts.maxSummaryTokens ?? 2000,
+    });
+
+    runtime?.broadcast({
+      type: "span.compaction_summarize_end",
+      model: modelId,
+      model_usage: result.usage ? {
+        input_tokens: result.usage.inputTokens ?? 0,
+        output_tokens: result.usage.outputTokens ?? 0,
+        cache_read_input_tokens: result.usage.inputTokenDetails?.cacheReadTokens ?? 0,
+        cache_creation_input_tokens: result.usage.inputTokenDetails?.cacheWriteTokens ?? 0,
+      } : undefined,
+      finish_reason: result.finishReason,
+      final_text_length: typeof result.text === "string" ? result.text.length : 0,
+    });
+
+    // Empty-summary defense: if the model returned no text (provider quirk,
+    // policy refusal, or the conversation was too short to summarize), do
+    // NOT write a boundary event. Otherwise downstream eventsToMessages
+    // would honor the empty-summary boundary and silently drop the entire
+    // pre-boundary history. Caller will retry on the next turn.
+    if (typeof result.text !== "string" || result.text.trim().length === 0) {
+      return null;
+    }
+
+    return {
+      summary: [{ type: "text", text: result.text }],
+      pre_tokens: estimateMessagesTokens(allMessages),
+      original_message_count: allMessages.length,
+      compacted_message_count: 1,
+    };
+  }
+}
+
+const CC_STYLE_SYSTEM_PROMPT =
+  "You are a helpful AI assistant tasked with summarizing conversations.";
+
+const CC_STYLE_SUMMARIZE_PROMPT =
+  "Provide a detailed but concise summary of the older conversation history. The most recent turns may be preserved verbatim outside your summary, so focus on information that would still be needed to continue the work with that recent context available. Cover: what was done, what is currently being worked on, which files are being modified, what needs to be done next, key user requests/constraints/preferences that should persist, and important technical decisions and why they were made. Do not respond to any questions in the conversation, only output the summary.";
+
+// ============================================================
+// OpenCodeStyleCompactionStrategy
+// ============================================================
+//
+// Same isolation idea as CCStyleCompactionStrategy, with OpenCode's
+// preferred summary template (Goal / Instructions / Discoveries /
+// Accomplished / Relevant files). The difference vs CC-style is purely
+// the prompt text — the structural choices (own system, no tools, no
+// toolChoice, image stripped) are identical.
+//
+// Pick this one when you want summaries that downstream agents or humans
+// can scan structurally rather than narratively.
+
+export class OpenCodeStyleCompactionStrategy implements CompactionStrategy {
+  readonly name = "opencode-style";
+
+  constructor(
+    private opts: {
+      tailMinTokens?: number;
+      tailMaxTokens?: number;
+      tailMinMessages?: number;
+      triggerFraction?: number;
+      summarySystemPrompt?: string;
+      maxSummaryTokens?: number;
+    } = {},
+  ) {}
+
+  shouldCompact(events: SessionEvent[], { contextWindowTokens }: { contextWindowTokens: number }): boolean {
+    const messages = eventsToMessages(events);
+    const tokens = estimateMessagesTokens(messages);
+    return tokens > contextWindowTokens * (this.opts.triggerFraction ?? TRIGGER_FRACTION);
+  }
+
+  async compact(
+    events: SessionEvent[],
+    { model, runtime }: {
+      model: LanguageModel;
+      contextWindowTokens: number;
+      systemPrompt: string;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      tools: Record<string, any>;
+      applyCacheStrategy: (
+        systemPrompt: string,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        tools: Record<string, any>,
+        messages: ModelMessage[],
+      ) => CacheStrategyApplied;
+      runtime?: HarnessRuntime;
+    },
+  ): Promise<CompactionResult | null> {
+    const allMessages = eventsToMessages(events);
+    if (allMessages.length < 4) return null;
+
+    const cleanedMessages = stripImagesFromMessages(allMessages);
+
+    const summarizeRequest: ModelMessage = {
+      role: "user",
+      content: this.opts.summarySystemPrompt ?? OPENCODE_STYLE_SUMMARIZE_PROMPT,
+    };
+
+    const modelId = (model as { modelId?: string })?.modelId ?? "unknown";
+    runtime?.broadcast({ type: "span.compaction_summarize_start", model: modelId });
+
+    const result = await generateText({
+      model,
+      system: OPENCODE_STYLE_SYSTEM_PROMPT,
+      messages: [...cleanedMessages, summarizeRequest],
+      maxOutputTokens: this.opts.maxSummaryTokens ?? 2000,
+    });
+
+    runtime?.broadcast({
+      type: "span.compaction_summarize_end",
+      model: modelId,
+      model_usage: result.usage ? {
+        input_tokens: result.usage.inputTokens ?? 0,
+        output_tokens: result.usage.outputTokens ?? 0,
+        cache_read_input_tokens: result.usage.inputTokenDetails?.cacheReadTokens ?? 0,
+        cache_creation_input_tokens: result.usage.inputTokenDetails?.cacheWriteTokens ?? 0,
+      } : undefined,
+      finish_reason: result.finishReason,
+      final_text_length: typeof result.text === "string" ? result.text.length : 0,
+    });
+
+    if (typeof result.text !== "string" || result.text.trim().length === 0) {
+      return null;
+    }
+
+    return {
+      summary: [{ type: "text", text: result.text }],
+      pre_tokens: estimateMessagesTokens(allMessages),
+      original_message_count: allMessages.length,
+      compacted_message_count: 1,
+    };
+  }
+}
+
+const OPENCODE_STYLE_SYSTEM_PROMPT =
+  "You are a helpful AI assistant tasked with summarizing conversations. Output only the summary text, no preamble.";
+
+const OPENCODE_STYLE_SUMMARIZE_PROMPT = `When constructing the summary, try to stick to this template:
+---
+## Goal
+
+[What goal(s) is the user trying to accomplish?]
+
+## Instructions
+
+- [What important instructions did the user give you that are relevant]
+- [If there is a plan or spec, include information about it so next agent can continue using it]
+
+## Discoveries
+
+[What notable things were learned during this conversation that would be useful for the next agent to know when continuing the work]
+
+## Accomplished
+
+[What work has been completed, what work is still in progress, and what work is left?]
+
+## Relevant files / directories
+
+[Construct a structured list of relevant files that have been read, edited, or created that pertain to the task at hand. If all the files in a directory are relevant, include the path to the directory.]
+---`;
+
+// ============================================================
+// Strategy registry
+// ============================================================
+//
+// Used by DefaultHarness to resolve `agent.metadata.compaction_strategy`.
+// Names match the `name` field on each strategy class.
+
+export type CompactionStrategyName = "summarize" | "cc-style" | "opencode-style";
+
+export function resolveCompactionStrategy(
+  name: string | undefined,
+  opts: {
+    headProtectMsgs?: number;
+    tailMinTokens?: number;
+    tailMaxTokens?: number;
+    tailMinMessages?: number;
+    triggerFraction?: number;
+    summarySystemPrompt?: string;
+    maxSummaryTokens?: number;
+  } = {},
+): CompactionStrategy {
+  switch (name) {
+    case "cc-style":
+      return new CCStyleCompactionStrategy(opts);
+    case "opencode-style":
+      return new OpenCodeStyleCompactionStrategy(opts);
+    case "summarize":
+    case undefined:
+      return new SummarizeCompactionStrategy(opts);
+    default:
+      // Unknown name → fall back to default. Don't throw — agent metadata
+      // is user-controlled and a typo shouldn't crash the harness.
+      console.warn(`[compaction] unknown strategy "${name}", falling back to "summarize"`);
+      return new SummarizeCompactionStrategy(opts);
+  }
+}
+
+// ============================================================
 // Backwards-compatible adapter (deprecated)
 // ============================================================
 // Old API used by anything still importing { SummarizeCompaction } from

--- a/apps/agent/src/harness/compaction.ts
+++ b/apps/agent/src/harness/compaction.ts
@@ -232,7 +232,9 @@ const DEFAULT_SUMMARIZE_PROMPT =
 
 const IMAGE_PLACEHOLDER = "[image stripped for compaction]";
 
-function stripImagesFromMessages(messages: ModelMessage[]): ModelMessage[] {
+// Exported so tests can probe edge cases directly. Production callers use
+// it through the strategy classes below.
+export function stripImagesFromMessages(messages: ModelMessage[]): ModelMessage[] {
   return messages.map((m): ModelMessage => {
     if (typeof m.content === "string") return m;
     if (!Array.isArray(m.content)) return m;

--- a/apps/agent/src/harness/default-loop.ts
+++ b/apps/agent/src/harness/default-loop.ts
@@ -3,7 +3,7 @@ import type { ContentPart, ModelMessage, LanguageModel, SystemModelMessage } fro
 import type { HarnessInterface, HarnessContext, HarnessRuntime } from "./interface";
 import type { SessionEvent, ContentBlock, AgentToolUseEvent } from "@open-managed-agents/shared";
 import { eventsToMessages } from "../runtime/history";
-import { SummarizeCompactionStrategy } from "./compaction";
+import { SummarizeCompactionStrategy, resolveCompactionStrategy } from "./compaction";
 import type { CompactionStrategy } from "./compaction";
 
 const BUILTIN_TOOLS = new Set(["bash", "read", "write", "edit", "glob", "grep", "web_fetch", "web_search"]);
@@ -276,9 +276,10 @@ export class DefaultHarness implements HarnessInterface {
   async run(ctx: HarnessContext): Promise<void> {
     const { agent, userMessage, runtime, tools, model, systemPrompt } = ctx;
 
-    // Resolve compaction params from agent config. One strategy
-    // (SummarizeCompactionStrategy) with CC-aligned tail defaults — opt-in
-    // overrides via agent.metadata for tuning per-agent if needed.
+    // Resolve compaction params from agent config. Strategy class is
+    // selectable via `agent.metadata.compaction_strategy` (defaults to
+    // "summarize" for backward compat); shared knobs (tail, trigger
+    // fraction) apply to whichever strategy is picked.
     const meta = (agent.metadata ?? {}) as Record<string, unknown>;
     const triggerFraction = typeof meta.compaction_trigger_fraction === "number"
       ? meta.compaction_trigger_fraction as number
@@ -292,7 +293,10 @@ export class DefaultHarness implements HarnessInterface {
     const tailMinMessages = typeof meta.compaction_tail_min_messages === "number"
       ? meta.compaction_tail_min_messages as number
       : undefined;
-    this.compactionStrategy = new SummarizeCompactionStrategy({
+    const strategyName = typeof meta.compaction_strategy === "string"
+      ? meta.compaction_strategy as string
+      : undefined;
+    this.compactionStrategy = resolveCompactionStrategy(strategyName, {
       tailMinTokens,
       tailMaxTokens,
       tailMinMessages,

--- a/apps/agent/src/harness/default-loop.ts
+++ b/apps/agent/src/harness/default-loop.ts
@@ -500,6 +500,29 @@ export class DefaultHarness implements HarnessInterface {
       runtime,
     });
     if (!result) return;
+
+    // Empty-summary defense (upstream layer). If a strategy returns a
+    // result whose summary contains no actual text, do NOT broadcast the
+    // boundary event. Otherwise eventsToMessages would later "honor" the
+    // empty boundary and silently drop the entire pre-boundary history.
+    //
+    // Observed in the wild on MiniMax: model returns finish_reason="tool-calls"
+    // with empty text → SummarizeCompactionStrategy returns
+    // summary=[{type:"text", text:""}] → boundary written → next derive
+    // tosses 60 turns of conversation. The new cc-style / opencode-style
+    // strategies catch this themselves (return null) but the legacy
+    // `summarize` strategy does not, so this layer is the safety net for
+    // any strategy that doesn't self-defend.
+    const hasContent = result.summary?.some(
+      (b) => (b.type === "text" && b.text.trim().length > 0)
+        || b.type === "image"
+        || b.type === "document",
+    );
+    if (!hasContent) {
+      console.warn("[compact] strategy produced empty summary — skipping boundary write");
+      return;
+    }
+
     runtime.broadcast({
       type: "agent.thread_context_compacted",
       original_message_count: result.original_message_count,

--- a/apps/agent/src/runtime/history.ts
+++ b/apps/agent/src/runtime/history.ts
@@ -203,19 +203,19 @@ function buildMessages(
   return messages;
 }
 
-// CC-style tail preservation params (sessionMemoryCompact.ts
-// DEFAULT_SM_COMPACT_CONFIG):
+// Tail preservation params (Claude Code-style defaults — observed values
+// that work well for multi-turn coding sessions):
 //   minTokens: 10_000  maxTokens: 40_000  minTextMessages: 5
 const TAIL_MIN_TOKENS = 10_000;
 const TAIL_MAX_TOKENS = 40_000;
 const TAIL_MIN_MESSAGES = 5;
-// CC's microCompact.IMAGE_MAX_TOKEN_SIZE — images bill at a flat 2K each.
+// Industry-standard heuristic: image blocks bill at a flat ~2K tokens each.
 const IMAGE_TOKEN_SIZE = 2_000;
 
 /**
- * CC-style per-content-part token estimate (microCompact.ts:164). Text uses
- * length/4; image/file blocks use a flat 2K; tool-use counts name + JSON
- * input but not the id; reasoning counts the text but not the signature.
+ * Per-content-part token estimate. Text uses length/4; image/file blocks
+ * use a flat 2K; tool-use counts name + JSON input but not the id;
+ * reasoning counts the text but not the signature.
  */
 function estimateContentPartTokens(part: unknown): number {
   if (typeof part === "string") return Math.round(part.length / 4);
@@ -225,7 +225,7 @@ function estimateContentPartTokens(part: unknown): number {
     case "text":
       return Math.round(((p.text as string) ?? "").length / 4);
     case "reasoning":
-      // Match CC: count thinking text only; signature is metadata, not tokenized.
+      // Count thinking text only; signature is metadata, not tokenized.
       return Math.round(((p.text as string) ?? "").length / 4);
     case "tool-call":
       return Math.round((((p.toolName as string) ?? "") + JSON.stringify(p.input ?? {})).length / 4);
@@ -259,9 +259,9 @@ function estimateToolResultTokens(output: unknown): number {
 }
 
 /**
- * Per-message estimate, mirroring CC's `estimateMessageTokens`
- * (microCompact.ts:164). Final result is padded by 4/3 to be conservative —
- * matches CC's behavior so our tail-picking budget aligns with theirs.
+ * Per-message estimate. Final result is padded by 4/3 to be conservative,
+ * matching the heuristic Claude Code uses so our tail-picking budget aligns
+ * with what users have come to expect from CC sessions.
  */
 function estimateMessageTokensCC(m: ModelMessage): number {
   let total = 0;

--- a/apps/agent/src/runtime/history.ts
+++ b/apps/agent/src/runtime/history.ts
@@ -60,13 +60,26 @@ export function eventsToMessages(events: SessionEvent[]): ModelMessage[] {
 
   // Find the last compaction boundary that actually carries a summary —
   // that's the one we honor. Earlier boundaries get superseded.
+  //
+  // "Carries a summary" means: at least one block contains real content.
+  // A bare array-length check (`summary.length > 0`) is NOT sufficient —
+  // a strategy that returns `[{type:"text", text:""}]` would still pass
+  // it and silently drop the entire pre-boundary history downstream.
+  // This is the downstream half of the empty-summary defense; the
+  // upstream half lives in DefaultHarness.compact() where the boundary
+  // event is written.
   let boundaryIdx = -1;
   let boundarySummary: ContentBlock[] | undefined;
   for (let i = events.length - 1; i >= 0; i--) {
     const e = events[i];
     if (e.type === "agent.thread_context_compacted") {
       const ce = e as AgentThreadContextCompactedEvent;
-      if (ce.summary && ce.summary.length > 0) {
+      const hasContent = ce.summary?.some(
+        (b) => (b.type === "text" && b.text.trim().length > 0)
+          || b.type === "image"
+          || b.type === "document",
+      );
+      if (hasContent) {
         boundaryIdx = i;
         boundarySummary = ce.summary;
         break;

--- a/apps/agent/src/runtime/session-do.ts
+++ b/apps/agent/src/runtime/session-do.ts
@@ -1305,7 +1305,7 @@ export class SessionDO extends Agent<Env, SessionState> {
    * Register a background task for completion tracking.
    * Starts a setInterval poller that checks process status every 2s.
    * When complete, injects a task_notification event and re-triggers harness.
-   * Like CC's shellCommand.result.then() — but poll-based since we can't
+   * Event-driven completion notification — but poll-based since we can't
    * get exit events from container processes.
    */
   /**

--- a/scripts/probe-harness-cache.ts
+++ b/scripts/probe-harness-cache.ts
@@ -9,7 +9,32 @@
 // Run from repo root:
 //   ANTHROPIC_API_KEY=sk-ant-... npx tsx scripts/probe-harness-cache.ts
 //
-// What "good" looks like:
+// Modes (PROBE_MODE env var; default = text):
+//   text       — current behavior: bash + mcp tool stubs only.
+//   sub-agent  — adds a `call_agent_researcher` stub that injects
+//                thread-tagged sub-session events (agent.message,
+//                agent.tool_use, agent.tool_result) into the parent's
+//                runtime BEFORE returning the response text. Faithfully
+//                simulates SessionDO.runSubAgent: the parent's getEvents()
+//                ends up with sub-session internal events, which derive()
+//                walks unless the bijection filters them out.
+//                Verdict signal: if cache_read drops to 0 on the turn
+//                AFTER each call_agent_* return, the sub-session events
+//                are polluting the parent's prefix.
+//   multimodal — every other tool result is an `agent.tool_result` whose
+//                content is a `ContentBlock[]` containing one TextBlock
+//                and one base64 PNG image. Same probe loop; the goal is
+//                that image bytes round-trip exactly through
+//                normalizeToolOutputForWire ↔ wireContentToToolOutput so
+//                cache_read keeps growing turn over turn.
+//                Also exercises the cacheControl-on-image-tail edge case:
+//                the last message of some turns ends with a tool_result
+//                whose final block is an image.
+//   all        — runs text → sub-agent → multimodal sequentially with
+//                a fresh DefaultHarness + InMemoryHistory between each
+//                so the per-mode totals are independent.
+//
+// What "good" looks like (per mode):
 //   Turn 1: cache_create > 0  (writes the prefix)
 //           cache_read   = 0
 //   Turn 2: cache_create small  (just the new tail)
@@ -30,7 +55,17 @@ import type {
   SessionEvent,
   SpanModelRequestEndEvent,
   AgentConfig,
+  ContentBlock,
 } from "@open-managed-agents/shared";
+
+// ---- mode ----
+type ProbeMode = "text" | "sub-agent" | "multimodal" | "all";
+const RAW_MODE = (process.env.PROBE_MODE ?? "text").toLowerCase();
+if (!["text", "sub-agent", "multimodal", "all"].includes(RAW_MODE)) {
+  console.error(`Unknown PROBE_MODE=${RAW_MODE}. Choose: text | sub-agent | multimodal | all`);
+  process.exit(1);
+}
+const MODE = RAW_MODE as ProbeMode;
 
 // ---- env ----
 // Two auth modes:
@@ -178,6 +213,94 @@ const mcpGithubCall = tool({
 
 const tools = { bash, mcp_github_call: mcpGithubCall };
 
+// ---- multimodal fixture ----
+// Smallest valid PNG: 1x1 transparent pixel. Constant bytes — used as the
+// image payload in multimodal-mode tool results so cache reuse across turns
+// requires byte-perfect round-trip through normalize/wireContent.
+const PNG_1X1_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkAAIAAAoAAv/lxKUAAAAASUVORK5CYII=";
+
+// ---- sub-agent fixture ----
+// Stub `call_agent_researcher` that simulates SessionDO.runSubAgent: tags a
+// sequence of sub-session events into the parent's runtime BEFORE returning.
+// If the parent's eventsToMessages walks tagged events, every call here will
+// add an unrelated assistant turn + tool round-trip to the parent's prefix
+// → cache_read collapses on the next turn.
+//
+// `runtime` is bound at construction time so the tool can broadcast directly.
+function makeCallAgentTool(rt: HarnessRuntime, threadCounter: { n: number }) {
+  return tool({
+    description:
+      "Delegate a research question to the researcher sub-agent (probe stub).",
+    inputSchema: z.object({
+      message: z.string().describe("question to send to the sub-agent"),
+    }),
+    execute: async ({ message }) => {
+      const threadId = `thread_probe_${threadCounter.n++}`;
+      const tag = (e: SessionEvent) => ({ ...e, session_thread_id: threadId } as SessionEvent);
+      // Mirrors SessionDO.runSubAgent (apps/agent/src/runtime/session-do.ts:1414):
+      // sub-agent's broadcasts append a tagged copy of the same event into the
+      // parent's history. Each event is the same `type` as a normal event —
+      // only the extra `session_thread_id` field distinguishes it.
+      rt.broadcast(tag({
+        type: "session.thread_created",
+        session_thread_id: threadId,
+        agent_id: "researcher",
+        agent_name: "researcher",
+      } as any));
+      rt.broadcast(tag({
+        type: "agent.message",
+        content: [{ type: "text", text: `[sub-agent] working on: ${message.slice(0, 80)}` }],
+      }));
+      rt.broadcast(tag({
+        type: "agent.tool_use",
+        id: `${threadId}_tc_grep`,
+        name: "grep",
+        input: { pattern: "TODO", path: "src/" },
+      } as any));
+      rt.broadcast(tag({
+        type: "agent.tool_result",
+        tool_use_id: `${threadId}_tc_grep`,
+        content: FAKE_GREP_OUTPUT,
+      } as any));
+      rt.broadcast(tag({
+        type: "agent.message",
+        content: [{ type: "text", text: `[sub-agent] done. Found ${80} matches across files.` }],
+      }));
+      rt.broadcast(tag({
+        type: "session.thread_idle",
+        session_thread_id: threadId,
+      } as any));
+      // Return the response text — what the parent sees as the tool result.
+      return `Researcher returned: 80 matches across the handlers tree (sample matches in trace).`;
+    },
+  });
+}
+
+// ---- multimodal fixture ----
+// Tool stub that returns a `ContentBlock[]` with a text block + a base64 PNG.
+// Built once per mode so the bytes are stable across turns. Default-loop's
+// normalizeToolOutputForWire detects the pre-shaped ContentBlock[] and
+// passes it through verbatim → wireContentToToolOutput on derive must
+// reconstruct the same bytes for cache reuse.
+function makeImageTool() {
+  const imageBlock: ContentBlock = {
+    type: "image",
+    source: { type: "base64", media_type: "image/png", data: PNG_1X1_BASE64 },
+  };
+  return tool({
+    description: "Render a chart and return [text-summary, image] (probe stub).",
+    inputSchema: z.object({ caption: z.string().describe("short caption for the chart") }),
+    // ai-sdk's strict typing forbids ContentBlock[] in `execute`'s declared
+    // return; cast to any since default-loop normalizes via the wire shape.
+    execute: async ({ caption }) =>
+      [
+        { type: "text", text: `Chart caption: ${caption}. Rendered 1x1 PNG below.` },
+        imageBlock,
+      ] as any,
+  });
+}
+
 // ---- platformReminders (simulate skill metadata + memory) ----
 const platformReminders = [
   {
@@ -194,26 +317,7 @@ const platformReminders = [
   },
 ];
 
-// ---- runtime ----
-const history = new InMemoryHistory();
-const eventLog: SessionEvent[] = [];
-
-const runtime: HarnessRuntime = {
-  history: history as any,
-  sandbox: {
-    exec: async (cmd: string) => `[probe stub exec] ${cmd}`,
-    readFile: async () => "",
-    writeFile: async () => "",
-  } as any,
-  broadcast: (event: SessionEvent) => {
-    history.append(event);
-    eventLog.push(event);
-  },
-  reportUsage: async () => {},
-  pendingConfirmations: [],
-};
-
-// ---- ctx ----
+// ---- agent + systemPrompt (shared across modes; baked into cached prefix) ----
 const agent: Partial<AgentConfig> = {
   id: "probe",
   name: "probe-agent",
@@ -237,24 +341,58 @@ const SYSTEM_AUTHENTICATED_GUIDANCE =
   "For commands that may require authentication, prefer issuing a single command instead of a chained shell command. If an authenticated chained command fails, retry with a simpler single-command form.";
 const systemPrompt = `${agent.system}\n\n${SYSTEM_AUTHENTICATED_GUIDANCE}`;
 
-const baseCtx: Omit<HarnessContext, "userMessage"> = {
-  agent: agent as AgentConfig,
-  tools,
-  model,
-  systemPrompt,
-  rawSystemPrompt: agent.system!,
-  platformReminders,
-  env: {
-    ANTHROPIC_API_KEY: apiKey ?? probeToken ?? "",
-  } as any,
-  runtime,
-};
+// ---- runtime + ctx (per mode) ----
+// Each mode gets a fresh history, runtime, and tool set so the per-mode
+// cache stats are independent. Module-level state used to be unique;
+// supporting "all" mode forced extracting this into a builder.
+function buildRunFor(mode: Exclude<ProbeMode, "all">) {
+  const history = new InMemoryHistory();
+  const eventLog: SessionEvent[] = [];
+  const runtime: HarnessRuntime = {
+    history: history as any,
+    sandbox: {
+      exec: async (cmd: string) => `[probe stub exec] ${cmd}`,
+      readFile: async () => "",
+      writeFile: async () => "",
+    } as any,
+    broadcast: (event: SessionEvent) => {
+      history.append(event);
+      eventLog.push(event);
+    },
+    reportUsage: async () => {},
+    pendingConfirmations: [],
+  };
 
-// ---- run ----
+  const threadCounter = { n: 0 };
+  const modeTools: Record<string, any> = { bash, mcp_github_call: mcpGithubCall };
+  if (mode === "sub-agent") {
+    modeTools.call_agent_researcher = makeCallAgentTool(runtime, threadCounter);
+  }
+  if (mode === "multimodal") {
+    modeTools.render_chart = makeImageTool();
+  }
+
+  const baseCtx: Omit<HarnessContext, "userMessage"> = {
+    agent: agent as AgentConfig,
+    tools: modeTools,
+    model,
+    systemPrompt,
+    rawSystemPrompt: agent.system!,
+    platformReminders,
+    env: {
+      ANTHROPIC_API_KEY: apiKey ?? probeToken ?? "",
+    } as any,
+    runtime,
+  };
+
+  return { history, eventLog, runtime, modeTools, baseCtx };
+}
+
+// ---- prompts (per mode) ----
 // Tool-driving questions: each prompt explicitly forces a bash or
 // mcp_github_call invocation so the ~5KB stub outputs accumulate fast and
 // we hit the 0.10 trigger fraction before turn 16.
-const QUESTIONS = [
+const QUESTIONS_TEXT = [
   "Run `ls -la src/` and tell me what you see in one sentence.",
   "Now grep for 'export async function handle' under src/handlers and report the top 3 matches.",
   "Use mcp_github_call to list_issues; then summarize the most common label in one sentence.",
@@ -273,12 +411,68 @@ const QUESTIONS = [
   "Final summary: which tool did you use most, in one sentence.",
 ];
 
-async function main() {
-  const harness = new DefaultHarness();
+// Sub-agent mode: alternate normal tool calls with `call_agent_researcher`
+// so we can compare cache_read on turns AFTER a sub-agent return vs
+// turns AFTER a normal tool. If the parent's prefix gets polluted by
+// sub-session events, cache_read will reset on every post-call_agent turn.
+const QUESTIONS_SUBAGENT = [
+  "Run `ls -la src/` and tell me what you see in one sentence.",
+  "Use call_agent_researcher to investigate `TODO usage in src/`. Then in one sentence relay what they said.",
+  "Now grep for 'export async function handle' under src/handlers; top 3 matches.",
+  "Use call_agent_researcher to look up `routes registered in src/handlers/`. One-sentence relay.",
+  "Use mcp_github_call to list_issues; the most common label in one sentence.",
+  "Use call_agent_researcher to summarize `auth bug history`. One-sentence relay.",
+  "Run `find . -name '*.ts'` and pick one interesting filename.",
+  "Use call_agent_researcher to look at `class definitions in src/`. One sentence.",
+  "Grep for 'import' in src/ and tell me how many imports total (one number).",
+  "Use call_agent_researcher to research `latency reports`. One sentence.",
+  "Use mcp_github_call to list_prs; one PR title.",
+  "Use call_agent_researcher to scan `error handling patterns`. One sentence.",
+  "Run `ls /etc` and pick one config file name.",
+  "Use call_agent_researcher to look at `TODO under src/handlers/`. One sentence.",
+  "Grep for 'function' under src/handlers and report top 3.",
+  "Final summary: which tool did you use most often?",
+];
 
+// Multimodal mode: drive `render_chart` on alternating turns so half the
+// turns end with a tool_result whose final block is a base64 image.
+// Tests both: image-byte preservation (between turns) AND cache_control
+// landing on a tail block that happens to be an image.
+const QUESTIONS_MULTIMODAL = [
+  "Run `ls -la src/` and tell me what you see in one sentence.",
+  "Use render_chart with caption `latency p99 over 7d` and tell me one observation.",
+  "Now grep for 'export async function handle' under src/handlers; top 3 matches.",
+  "Use render_chart with caption `error rate vs deploy times` and one observation.",
+  "Use mcp_github_call to list_issues; the most common label in one sentence.",
+  "Use render_chart with caption `RPS by region` and tell me one observation.",
+  "Run `find . -name '*.ts'` and pick one interesting filename.",
+  "Use render_chart with caption `memory usage over hours` and one observation.",
+  "Grep for 'import' in src/ and tell me how many imports total (one number).",
+  "Use render_chart with caption `queue depth weekly` and one observation.",
+  "Use mcp_github_call to list_prs; one PR title.",
+  "Use render_chart with caption `cold-start ms by hour` and one observation.",
+  "Run `ls /etc` and pick one config file name.",
+  "Use render_chart with caption `cache hit ratio by route` and one observation.",
+  "Grep for 'function' under src/handlers and report top 3.",
+  "Final summary: what was the most informative chart, in one sentence.",
+];
+
+function questionsFor(mode: Exclude<ProbeMode, "all">): string[] {
+  if (mode === "sub-agent") return QUESTIONS_SUBAGENT;
+  if (mode === "multimodal") return QUESTIONS_MULTIMODAL;
+  return QUESTIONS_TEXT;
+}
+
+// ---- per-mode runner ----
+async function runMode(mode: Exclude<ProbeMode, "all">) {
+  const { history, eventLog, runtime, modeTools, baseCtx } = buildRunFor(mode);
+  const harness = new DefaultHarness();
+  const questions = questionsFor(mode);
+
+  console.log(`\n=== mode=${mode} ===`);
   console.log(`Model: ${(model as any).modelId}`);
   console.log(`System prompt: ${systemPrompt.length} chars`);
-  console.log(`Tools: ${Object.keys(tools).join(", ")}`);
+  console.log(`Tools: ${Object.keys(modeTools).join(", ")}`);
   console.log(`Skill reminders: ${platformReminders.length}`);
   console.log("---");
 
@@ -286,11 +480,27 @@ async function main() {
   await harness.onSessionInit?.(baseCtx as HarnessContext, runtime);
 
   let totalIn = 0, totalOut = 0, totalRead = 0, totalCreate = 0;
+  // Per-turn tool/sub-agent markers — we annotate each turn with what kind
+  // of return preceded it, so post-call_agent_* and post-image turns are
+  // visually distinguishable in the per-turn cache log.
+  const turnMarker = (ev: SessionEvent | undefined): string => {
+    if (!ev) return "";
+    if (ev.type === "agent.tool_use" && (ev as any).name?.startsWith?.("call_agent_")) {
+      return " [post-call_agent]";
+    }
+    if (ev.type === "agent.tool_result") {
+      const c = (ev as any).content;
+      if (Array.isArray(c) && c.some((b: any) => b?.type === "image")) {
+        return " [post-image-result]";
+      }
+    }
+    return "";
+  };
 
-  for (let i = 0; i < QUESTIONS.length; i++) {
+  for (let i = 0; i < questions.length; i++) {
     const userEvent: SessionEvent = {
       type: "user.message",
-      content: [{ type: "text", text: QUESTIONS[i] }],
+      content: [{ type: "text", text: questions[i] }],
     };
     history.append(userEvent);
     eventLog.push(userEvent);
@@ -315,20 +525,28 @@ async function main() {
     const cacheCreate = u?.cache_creation_input_tokens ?? 0;
     totalIn += inp; totalOut += out; totalRead += cacheRead; totalCreate += cacheCreate;
 
+    // Look one event back for the LAST tool-related event in this turn.
+    const lastTurnEvent = [...eventLog].reverse().find(
+      (e) => e.type === "agent.tool_use" || e.type === "agent.tool_result" || e.type === "agent.mcp_tool_result",
+    );
+
     const tools_used = eventLog
       .filter((e) => e.type === "agent.tool_use" || e.type === "agent.mcp_tool_use" || e.type === "agent.custom_tool_use")
       .length;
     const compactions = eventLog.filter((e) => e.type === "agent.thread_context_compacted");
+    const subThreadEvents = eventLog.filter((e) => (e as any).session_thread_id != null);
 
     console.log(
-      `Turn ${i + 1} (${elapsed}ms): in=${inp} out=${out} cache_read=${cacheRead} cache_create=${cacheCreate}  tools_called_so_far=${tools_used} compactions=${compactions.length}`,
+      `Turn ${i + 1} (${elapsed}ms): in=${inp} out=${out} cache_read=${cacheRead} cache_create=${cacheCreate}` +
+      `  tools_called_so_far=${tools_used} sub_thread_evts=${subThreadEvents.length} compactions=${compactions.length}` +
+      turnMarker(lastTurnEvent),
     );
   }
 
   console.log("---");
-  console.log(`TOTAL: in=${totalIn} out=${totalOut} cache_read=${totalRead} cache_create=${totalCreate}`);
-  const reuseRatio = totalIn > 0 ? (totalRead / totalIn).toFixed(2) : "n/a";
-  console.log(`Cache reuse ratio: ${reuseRatio} (cache_read / input_tokens — higher is better)`);
+  console.log(`TOTAL[${mode}]: in=${totalIn} out=${totalOut} cache_read=${totalRead} cache_create=${totalCreate}`);
+  const reuseRatio = totalIn + totalRead > 0 ? (totalRead / (totalIn + totalRead)).toFixed(2) : "n/a";
+  console.log(`Cache reuse ratio: ${reuseRatio} (cache_read / (input_tokens + cache_read) — higher is better)`);
   console.log(`Total events captured: ${eventLog.length}`);
 
   // Quick verdict
@@ -338,6 +556,43 @@ async function main() {
     console.log("\nVERDICT: cache reuse > cache writes. Cache is working.");
   } else {
     console.log("\nVERDICT: some cache reuse but lower than write. Could be a short prefix; try more turns.");
+  }
+
+  // Mode-specific extra checks
+  if (mode === "sub-agent") {
+    // Identify the per-turn cache_read on the turn AFTER each call_agent_*.
+    // If the parent's prefix gets polluted by sub-session events, those
+    // post-call_agent turns will have cache_read collapse to ~0 while
+    // non-sub-agent turns keep growing.
+    const spanEvents = eventLog.filter((e) => e.type === "span.model_request_end") as SpanModelRequestEndEvent[];
+    const callAgentEvents = eventLog.filter(
+      (e) => e.type === "agent.tool_use" && (e as any).name?.startsWith?.("call_agent_"),
+    );
+    console.log(`\nSub-agent diagnostics:`);
+    console.log(`  call_agent_* invocations: ${callAgentEvents.length}`);
+    console.log(`  total tagged sub-session events injected: ${eventLog.filter((e) => (e as any).session_thread_id != null).length}`);
+    if (spanEvents.length >= 2) {
+      const last = spanEvents[spanEvents.length - 1].model_usage;
+      const first = spanEvents[0].model_usage;
+      console.log(`  first turn cache_read: ${first?.cache_read_input_tokens ?? 0}`);
+      console.log(`  last turn cache_read:  ${last?.cache_read_input_tokens ?? 0}`);
+      const lastReadIsZero = (last?.cache_read_input_tokens ?? 0) === 0;
+      if (lastReadIsZero && callAgentEvents.length > 0) {
+        console.log(`  WARNING: cache_read=0 on the last turn after sub-agent activity — check whether tagged events are polluting the parent's prefix.`);
+      }
+    }
+  }
+
+  if (mode === "multimodal") {
+    const imageResults = eventLog.filter(
+      (e) => e.type === "agent.tool_result" && Array.isArray((e as any).content) && (e as any).content.some((b: any) => b?.type === "image"),
+    );
+    console.log(`\nMultimodal diagnostics:`);
+    console.log(`  image-bearing tool_result events: ${imageResults.length}`);
+    console.log(`  PNG payload bytes per image: ${PNG_1X1_BASE64.length} chars (base64)`);
+    if (imageResults.length === 0) {
+      console.log(`  NOTE: model never invoked render_chart — probe didn't exercise image path. Try forcing it via prompt.`);
+    }
   }
 
   // Compaction summary
@@ -374,6 +629,14 @@ async function main() {
     }
   } else {
     console.log("\nNo compactions fired (didn't cross trigger threshold).");
+  }
+}
+
+async function main() {
+  const modes: Array<Exclude<ProbeMode, "all">> =
+    MODE === "all" ? ["text", "sub-agent", "multimodal"] : [MODE];
+  for (const m of modes) {
+    await runMode(m);
   }
 }
 

--- a/scripts/probe-harness-cache.ts
+++ b/scripts/probe-harness-cache.ts
@@ -70,13 +70,14 @@ const MODE = RAW_MODE as ProbeMode;
 // ---- env ----
 // Two auth modes:
 //   1. ANTHROPIC_API_KEY (sk-ant-...) → standard x-api-key against api.anthropic.com
-//   2. PROBE_AUTH_TOKEN + PROBE_BASE_URL → bearer auth against a custom proxy
+//   2. PROBE_AUTH_TOKEN + PROBE_BASE_URL → bearer auth against any
+//      Anthropic-Messages-compatible endpoint
 //
 // We deliberately ignore inherited ANTHROPIC_AUTH_TOKEN/BASE_URL because
-// Claude Code's defaults point at platform-api.xaminim.com, which speaks a
-// different protocol than Anthropic's Messages API and returns "Invalid
-// JSON response" on direct ai-sdk calls. To probe through that proxy,
-// re-export them as PROBE_* explicitly.
+// some local setups point at a proxy that doesn't speak Anthropic's
+// Messages API directly (returns "Invalid JSON response" on raw ai-sdk
+// calls). To probe through that kind of endpoint, re-export the auth as
+// PROBE_AUTH_TOKEN + PROBE_BASE_URL explicitly.
 const apiKey = process.env.ANTHROPIC_API_KEY;
 const probeToken = process.env.PROBE_AUTH_TOKEN;
 const probeBase = process.env.PROBE_BASE_URL;
@@ -106,10 +107,12 @@ function parseHeaders(raw: string | undefined): Record<string, string> | undefin
   }
 }
 
-// Empty — direct providers (api.minimaxi.com, api.anthropic.com) don't
-// require any X-Sub-Module or X-From routing headers. Only the company
-// proxy (platform-api.xaminim.com) does.
-const PROBE_HEADERS: Record<string, string> = {};
+// Routing headers for the proxy. Empty by default — direct providers
+// (api.anthropic.com and most Messages-API-compatible endpoints) don't
+// require routing headers. Set PROBE_HEADERS env var (JSON object or
+// `Header: Value\nHeader2: Value2` lines) to inject — required by some
+// internal proxies that route on custom headers.
+const PROBE_HEADERS: Record<string, string> = parseHeaders(process.env.PROBE_HEADERS) ?? {};
 
 let reqIdx = 0;
 const debugFetch: typeof fetch = async (input, init) => {

--- a/scripts/probe-harness-cache.ts
+++ b/scripts/probe-harness-cache.ts
@@ -34,6 +34,20 @@
 //                a fresh DefaultHarness + InMemoryHistory between each
 //                so the per-mode totals are independent.
 //
+// Compaction strategy (PROBE_COMPACTION_STRATEGY env var; default = "summarize"):
+//   summarize       — original strategy that reuses main agent's prefix
+//                     (system + tools) on the summarize call. Cache-aware
+//                     in design, but ai-sdk strips tools when toolChoice="none"
+//                     so cache_read on the summarize call ends up at 0%.
+//   cc-style        — Claude-Code-inspired isolated summarize call. Own
+//                     short system, empty tools, no toolChoice, images
+//                     stripped. Pays full input price on summarize but is
+//                     robust across providers (no toolChoice quirks).
+//   opencode-style  — OpenCode-inspired isolated summarize call. Same
+//                     structure as cc-style with a Goal/Instructions/
+//                     Discoveries/Accomplished/Files template instead of
+//                     a free-form summary.
+//
 // What "good" looks like (per mode):
 //   Turn 1: cache_create > 0  (writes the prefix)
 //           cache_read   = 0
@@ -337,6 +351,14 @@ const agent: Partial<AgentConfig> = {
     compaction_trigger_fraction: process.env.PROBE_COMPACTION_TRIGGER
       ? Number(process.env.PROBE_COMPACTION_TRIGGER)
       : 0.04,
+    // PROBE_COMPACTION_STRATEGY = "summarize" (default) | "cc-style"
+    // | "opencode-style". DefaultHarness reads this from agent.metadata
+    // and resolves the matching strategy class. Use this knob to A/B
+    // the legacy cache-prefix-sharing strategy against the isolated
+    // CC/OpenCode-style strategies.
+    ...(process.env.PROBE_COMPACTION_STRATEGY
+      ? { compaction_strategy: process.env.PROBE_COMPACTION_STRATEGY }
+      : {}),
   } as Record<string, unknown>,
 };
 
@@ -477,6 +499,7 @@ async function runMode(mode: Exclude<ProbeMode, "all">) {
   console.log(`System prompt: ${systemPrompt.length} chars`);
   console.log(`Tools: ${Object.keys(modeTools).join(", ")}`);
   console.log(`Skill reminders: ${platformReminders.length}`);
+  console.log(`Compaction strategy: ${process.env.PROBE_COMPACTION_STRATEGY ?? "summarize (default)"}`);
   console.log("---");
 
   // session-init: write skill/memory reminders into history (cached prefix)

--- a/test/unit/bijection-invariants.test.ts
+++ b/test/unit/bijection-invariants.test.ts
@@ -282,3 +282,265 @@ describe("eventsToMessages — context_boundary handling", () => {
     );
   });
 });
+
+// ============================================================
+// Sub-agent / thread-tagged events
+// ============================================================
+//
+// SessionDO.runSubAgent broadcasts each sub-session event into the parent
+// history with an extra `session_thread_id` field but the same `type`.
+// These tests pin down whether the parent's eventsToMessages walks those
+// tagged events or filters them — in either case, the contract MUST be
+// byte-stable so the prompt cache survives.
+//
+// If the spec changes to filter tagged events, only the assertion changes;
+// the byte-stability invariant stays.
+
+describe("eventsToMessages — sub-agent thread tagging", () => {
+  const buildParentWithSubThread = (): SessionEvent[] => [
+    { type: "user.message", content: [{ type: "text", text: "delegate it" }] },
+    {
+      type: "agent.tool_use",
+      id: "tc_call_agent",
+      name: "call_agent_researcher",
+      input: { message: "investigate X" },
+    } as AgentToolUseEvent,
+    // --- sub-session events tagged into the parent log ---
+    {
+      type: "session.thread_created",
+      session_thread_id: "thread_1",
+      agent_id: "researcher",
+      agent_name: "researcher",
+    } as any,
+    {
+      type: "agent.message",
+      session_thread_id: "thread_1",
+      content: [{ type: "text", text: "[sub] working" }],
+    } as any,
+    {
+      type: "agent.tool_use",
+      session_thread_id: "thread_1",
+      id: "thread_1_grep",
+      name: "grep",
+      input: { pattern: "TODO" },
+    } as any,
+    {
+      type: "agent.tool_result",
+      session_thread_id: "thread_1",
+      tool_use_id: "thread_1_grep",
+      content: "matches: 80",
+    } as any,
+    {
+      type: "agent.message",
+      session_thread_id: "thread_1",
+      content: [{ type: "text", text: "[sub] done" }],
+    } as any,
+    {
+      type: "session.thread_idle",
+      session_thread_id: "thread_1",
+    } as any,
+    // --- back to the parent: tool_result for the call_agent_* call ---
+    {
+      type: "agent.tool_result",
+      tool_use_id: "tc_call_agent",
+      content: "Researcher returned: 80 matches.",
+    } as AgentToolResultEvent,
+  ];
+
+  it("byte-stable across repeated derives (with tagged events present)", () => {
+    const events = buildParentWithSubThread();
+    expect(JSON.stringify(eventsToMessages(events))).toBe(
+      JSON.stringify(eventsToMessages(events)),
+    );
+  });
+
+  it("documents current shape: tagged events flow through (every type is walked)", () => {
+    // Pin the current behavior: tagged events are NOT filtered by type, so
+    // sub-session agent.tool_use / agent.tool_result events appear in the
+    // parent's projected messages alongside the parent's own tool round-trip.
+    //
+    // If a future change adds a "skip events with session_thread_id" branch
+    // to eventsToMessages, this test should be flipped (or the polluting
+    // events removed from the expected message stream). Either way it
+    // serves as a pin-down for the chosen contract.
+    const events = buildParentWithSubThread();
+    const messages = eventsToMessages(events);
+
+    // Find the assistant message holding the call_agent_* tool-call.
+    const assistantWithCall = messages.find((m) =>
+      m.role === "assistant" &&
+      Array.isArray(m.content) &&
+      (m.content as any[]).some(
+        (p) => p.type === "tool-call" && p.toolName === "call_agent_researcher",
+      ),
+    );
+    expect(assistantWithCall).toBeDefined();
+
+    // Tagged sub-session tool_use is currently surfaced as a normal tool-call.
+    const allToolCalls = messages
+      .filter((m) => m.role === "assistant")
+      .flatMap((m) => (Array.isArray(m.content) ? (m.content as any[]) : []))
+      .filter((p) => p.type === "tool-call");
+    const toolNames = allToolCalls.map((p) => p.toolName).sort();
+    expect(toolNames).toContain("call_agent_researcher");
+    // The sub-session's grep call is currently in there too — pin it down so
+    // a regression that "accidentally fixes" this without updating tests
+    // gets noticed and forces an explicit decision.
+    expect(toolNames).toContain("grep");
+  });
+
+  it("tagged events do not duplicate parent's own tool_result", () => {
+    // The parent's own agent.tool_result for tc_call_agent should still be
+    // exactly one tool message, regardless of how many sub-session events
+    // sit between the call and the result.
+    const events = buildParentWithSubThread();
+    const messages = eventsToMessages(events);
+    const toolMsgs = messages.filter((m) => m.role === "tool");
+    const callAgentResults = toolMsgs.flatMap((m) =>
+      (m.content as any[]).filter(
+        (p) => p.toolCallId === "tc_call_agent",
+      ),
+    );
+    expect(callAgentResults).toHaveLength(1);
+    expect(callAgentResults[0].toolName).toBe("call_agent_researcher");
+  });
+});
+
+// ============================================================
+// Multimodal — image bytes in tool_result content
+// ============================================================
+//
+// Anthropic's prompt cache hashes the wire bytes of every block. For
+// images that means the base64 payload must round-trip through
+// normalizeToolOutputForWire (write side) ↔ wireContentToToolOutput
+// (read side) without re-encoding, key reordering, or padding drift.
+// These tests pin down byte-perfect equality for the image path that the
+// multimodal probe exercises end-to-end.
+
+describe("eventsToMessages — multimodal image roundtrip", () => {
+  // 1×1 transparent PNG. Constant bytes — same fixture as the probe.
+  const PNG_1X1_BASE64 =
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkAAIAAAoAAv/lxKUAAAAASUVORK5CYII=";
+
+  const buildEventsWithImage = (data: string = PNG_1X1_BASE64): SessionEvent[] => [
+    { type: "user.message", content: [{ type: "text", text: "render it" }] },
+    {
+      type: "agent.tool_use",
+      id: "tc_chart",
+      name: "render_chart",
+      input: { caption: "p99" },
+    } as AgentToolUseEvent,
+    {
+      type: "agent.tool_result",
+      tool_use_id: "tc_chart",
+      content: [
+        { type: "text", text: "Chart caption: p99." },
+        { type: "image", source: { type: "base64", media_type: "image/png", data } },
+      ],
+    } as AgentToolResultEvent,
+  ];
+
+  it("base64 bytes survive verbatim through the wire shape", () => {
+    const events = buildEventsWithImage();
+    const messages = eventsToMessages(events);
+    const tool = messages.find((m) => m.role === "tool")!;
+    const trPart = (tool.content as any[])[0];
+    expect(trPart.output.type).toBe("content");
+    const parts = trPart.output.value as any[];
+    expect(parts).toHaveLength(2);
+    expect(parts[0]).toEqual({ type: "text", text: "Chart caption: p99." });
+    expect(parts[1].type).toBe("image-data");
+    expect(parts[1].mediaType).toBe("image/png");
+    // Byte-perfect: any whitespace/padding drift here busts cache.
+    expect(parts[1].data).toBe(PNG_1X1_BASE64);
+    expect(parts[1].data.length).toBe(PNG_1X1_BASE64.length);
+  });
+
+  it("two derives produce identical bytes for image-bearing tool_results", () => {
+    const events = buildEventsWithImage();
+    expect(JSON.stringify(eventsToMessages(events))).toBe(
+      JSON.stringify(eventsToMessages(events)),
+    );
+  });
+
+  it("two distinct image payloads project to distinct bytes (no cross-contamination)", () => {
+    const altPng =
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGNgYAAAAAQAAcngHTwAAAAASUVORK5CYII=";
+    const a = JSON.stringify(eventsToMessages(buildEventsWithImage(PNG_1X1_BASE64)));
+    const b = JSON.stringify(eventsToMessages(buildEventsWithImage(altPng)));
+    expect(a).not.toBe(b);
+  });
+
+  it("two image-bearing tool_results in sequence each preserve their own bytes", () => {
+    const altPng =
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGNgYAAAAAQAAcngHTwAAAAASUVORK5CYII=";
+    const events: SessionEvent[] = [
+      { type: "user.message", content: [{ type: "text", text: "render two" }] },
+      {
+        type: "agent.tool_use",
+        id: "tc_chart_a",
+        name: "render_chart",
+        input: { caption: "a" },
+      } as AgentToolUseEvent,
+      {
+        type: "agent.tool_result",
+        tool_use_id: "tc_chart_a",
+        content: [
+          { type: "image", source: { type: "base64", media_type: "image/png", data: PNG_1X1_BASE64 } },
+        ],
+      } as AgentToolResultEvent,
+      {
+        type: "agent.tool_use",
+        id: "tc_chart_b",
+        name: "render_chart",
+        input: { caption: "b" },
+      } as AgentToolUseEvent,
+      {
+        type: "agent.tool_result",
+        tool_use_id: "tc_chart_b",
+        content: [
+          { type: "image", source: { type: "base64", media_type: "image/png", data: altPng } },
+        ],
+      } as AgentToolResultEvent,
+    ];
+    const messages = eventsToMessages(events);
+    const toolMsgs = messages.filter((m) => m.role === "tool");
+    const allImageBytes = toolMsgs
+      .flatMap((m) => (m.content as any[]).flatMap((p) =>
+        Array.isArray(p.output?.value) ? (p.output.value as any[]) : [],
+      ))
+      .filter((b) => b.type === "image-data")
+      .map((b) => b.data);
+    expect(allImageBytes).toEqual([PNG_1X1_BASE64, altPng]);
+  });
+
+  it("compaction summary elides images stably (no per-derive churn)", () => {
+    // Boundary summary contains an image block; serializeSummaryAsText
+    // collapses it to "[image elided]". Output bytes must be stable.
+    const events: SessionEvent[] = [
+      { type: "user.message", content: [{ type: "text", text: "q1" }] },
+      { type: "agent.message", content: [{ type: "text", text: "a1" }] },
+      {
+        type: "agent.thread_context_compacted",
+        original_message_count: 2,
+        compacted_message_count: 1,
+        summary: [
+          { type: "text", text: "earlier we generated a chart" },
+          { type: "image", source: { type: "base64", media_type: "image/png", data: PNG_1X1_BASE64 } },
+        ],
+      } as any,
+      { type: "user.message", content: [{ type: "text", text: "q2" }] },
+    ];
+    const a = eventsToMessages(events);
+    const b = eventsToMessages(events);
+    expect(JSON.stringify(a)).toBe(JSON.stringify(b));
+    const summaryText = (a[0].content as any[])[0].text as string;
+    expect(summaryText).toContain("<conversation-summary>");
+    expect(summaryText).toContain("earlier we generated a chart");
+    expect(summaryText).toContain("[image elided]");
+    // Image base64 must NOT leak into the summary text — compaction's whole
+    // point is shrinking the prefix, and serializing 50KB of base64 here
+    // would defeat that.
+    expect(summaryText).not.toContain(PNG_1X1_BASE64);
+  });
+});

--- a/test/unit/bijection-invariants.test.ts
+++ b/test/unit/bijection-invariants.test.ts
@@ -211,7 +211,7 @@ describe("eventsToMessages — context_boundary handling", () => {
     expect(messages).toHaveLength(5);
   });
 
-  it("boundary WITH summary drops pre-boundary model_io and injects summary", () => {
+  it("boundary WITH summary injects summary and preserves a tail of pre-boundary messages", () => {
     const events: SessionEvent[] = [
       ...eventsBefore,
       {
@@ -224,15 +224,20 @@ describe("eventsToMessages — context_boundary handling", () => {
       { type: "agent.message", content: [{ type: "text", text: "third answer" }] },
     ];
     const messages = eventsToMessages(events);
-    // [synthesized summary user] + [user "third"] + [assistant "third answer"]
-    expect(messages).toHaveLength(3);
+    // [synthesized summary user] + [tail of pre-boundary] + [user "third"] +
+    // [assistant "third answer"]. Tail-preservation (CC-style) keeps the
+    // last K messages of the pre-boundary range alongside the summary so the
+    // model has recent context. With only 4 short pre-boundary messages, the
+    // picker keeps all of them (minimums not met for trimming).
+    expect(messages.length).toBeGreaterThanOrEqual(3);
     expect(messages[0].role).toBe("user");
     const sumContent = messages[0].content as any[];
     expect(sumContent[0].type).toBe("text");
     expect(sumContent[0].text).toContain("<conversation-summary>");
     expect(sumContent[0].text).toContain("Earlier the user asked X");
-    expect(messages[1].role).toBe("user");
-    expect(messages[2].role).toBe("assistant");
+    // Last two messages are the post-boundary user "third" + agent reply.
+    expect(messages[messages.length - 2].role).toBe("user");
+    expect(messages[messages.length - 1].role).toBe("assistant");
   });
 
   it("only the LAST boundary with summary is honored (iterative compaction)", () => {
@@ -260,10 +265,15 @@ describe("eventsToMessages — context_boundary handling", () => {
       { type: "user.message", content: [{ type: "text", text: "q3" }] },
     ];
     const messages = eventsToMessages(events);
-    expect(messages).toHaveLength(2); // [v2 summary, q3]
+    // First message is the v2 summary user message; v1 was superseded.
+    // Tail preservation may include some pre-v2-boundary messages; the
+    // post-boundary q3 is always at the end.
+    expect(messages.length).toBeGreaterThanOrEqual(2);
     const sumText = (messages[0].content as any[])[0].text;
     expect(sumText).toContain("summary v2");
     expect(sumText).not.toContain("summary v1");
+    expect(messages[messages.length - 1].role).toBe("user");
+    expect((messages[messages.length - 1].content as any[])[0].text).toBe("q3");
   });
 
   it("boundary handling stays byte-stable", () => {
@@ -282,6 +292,119 @@ describe("eventsToMessages — context_boundary handling", () => {
     );
   });
 });
+
+// ============================================================
+// Empty-summary defense (downstream layer)
+// ============================================================
+//
+// A boundary event with an array summary that contains only empty / whitespace
+// text MUST be ignored. Otherwise a strategy that returned `[{type:"text", text:""}]`
+// would silently drop the entire pre-boundary history.
+//
+// Symptom in the wild: MiniMax sometimes returns finish_reason="tool-calls"
+// with empty text on summarize; SummarizeCompactionStrategy passes that
+// through verbatim into the boundary event. This test pins down that
+// eventsToMessages no longer trusts such boundaries.
+
+describe("eventsToMessages — empty-summary defense", () => {
+  const baseHistory: SessionEvent[] = [
+    { type: "user.message", content: [{ type: "text", text: "q1" }] },
+    { type: "agent.message", content: [{ type: "text", text: "a1" }] },
+    { type: "user.message", content: [{ type: "text", text: "q2" }] },
+    { type: "agent.message", content: [{ type: "text", text: "a2" }] },
+  ];
+
+  it("boundary with empty-text summary is ignored (history NOT dropped)", () => {
+    const events: SessionEvent[] = [
+      ...baseHistory,
+      {
+        type: "agent.thread_context_compacted",
+        original_message_count: 4,
+        compacted_message_count: 1,
+        summary: [{ type: "text", text: "" }],
+      } as any,
+      { type: "user.message", content: [{ type: "text", text: "q3" }] },
+    ];
+    const messages = eventsToMessages(events);
+    // Pre-boundary 4 messages + post-boundary q3 — boundary is treated as
+    // a no-op because its summary text is empty.
+    expect(messages).toHaveLength(5);
+    expect(messages[0].role).toBe("user");
+    expect((messages[0].content as any[])[0].text).toBe("q1");
+    expect(messages[messages.length - 1].role).toBe("user");
+    expect((messages[messages.length - 1].content as any[])[0].text).toBe("q3");
+  });
+
+  it("boundary with whitespace-only summary is ignored", () => {
+    const events: SessionEvent[] = [
+      ...baseHistory,
+      {
+        type: "agent.thread_context_compacted",
+        original_message_count: 4,
+        compacted_message_count: 1,
+        summary: [{ type: "text", text: "   \n\t  " }],
+      } as any,
+      { type: "user.message", content: [{ type: "text", text: "q3" }] },
+    ];
+    const messages = eventsToMessages(events);
+    expect(messages).toHaveLength(5);
+  });
+
+  it("boundary with image-only summary IS honored (multimodal escape)", () => {
+    // Edge case: a strategy that produces a summary consisting only of an
+    // image block (no text). Rare but legal — it counts as "carries content"
+    // so the boundary takes effect.
+    const events: SessionEvent[] = [
+      ...baseHistory,
+      {
+        type: "agent.thread_context_compacted",
+        original_message_count: 4,
+        compacted_message_count: 1,
+        summary: [
+          {
+            type: "image",
+            source: { type: "base64", media_type: "image/png", data: "AAA=" },
+          },
+        ],
+      } as any,
+      { type: "user.message", content: [{ type: "text", text: "q3" }] },
+    ];
+    const messages = eventsToMessages(events);
+    // Honored: synthesized summary at index 0, post-boundary q3 at end.
+    // Tail preservation may add some pre-boundary messages between them.
+    expect(messages.length).toBeGreaterThanOrEqual(2);
+    expect(messages[0].role).toBe("user");
+    expect((messages[0].content as any[])[0].text).toContain("[image elided]");
+  });
+
+  it("when latest boundary is empty but earlier boundary has real summary, fall through to earlier", () => {
+    // Two boundaries; the most recent is empty (defense rejects it). The
+    // earlier one has a real summary and should be the one honored.
+    const events: SessionEvent[] = [
+      { type: "user.message", content: [{ type: "text", text: "q1" }] },
+      { type: "agent.message", content: [{ type: "text", text: "a1" }] },
+      {
+        type: "agent.thread_context_compacted",
+        original_message_count: 2,
+        compacted_message_count: 1,
+        summary: [{ type: "text", text: "real summary v1" }],
+      } as any,
+      { type: "user.message", content: [{ type: "text", text: "q2" }] },
+      { type: "agent.message", content: [{ type: "text", text: "a2" }] },
+      {
+        type: "agent.thread_context_compacted",
+        original_message_count: 4,
+        compacted_message_count: 1,
+        summary: [{ type: "text", text: "" }], // empty — skipped
+      } as any,
+      { type: "user.message", content: [{ type: "text", text: "q3" }] },
+    ];
+    const messages = eventsToMessages(events);
+    const sumText = (messages[0].content as any[])[0].text;
+    expect(sumText).toContain("real summary v1");
+  });
+});
+
 
 // ============================================================
 // Sub-agent / thread-tagged events

--- a/test/unit/compaction-strategies.test.ts
+++ b/test/unit/compaction-strategies.test.ts
@@ -1,12 +1,26 @@
 // @ts-nocheck
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
   CCStyleCompactionStrategy,
   OpenCodeStyleCompactionStrategy,
   SummarizeCompactionStrategy,
   resolveCompactionStrategy,
+  stripImagesFromMessages,
 } from "../../apps/agent/src/harness/compaction";
 import type { SessionEvent } from "@open-managed-agents/shared";
+
+// Mock ai-sdk's generateText so iterative-compaction tests can drive the
+// strategy's full code path without hitting a real LLM. Spread original
+// exports so tools(), z, etc. still work.
+vi.mock("ai", async (importOriginal) => {
+  const orig = await importOriginal<typeof import("ai")>();
+  return {
+    ...orig,
+    generateText: vi.fn(),
+  };
+});
+
+import { generateText } from "ai";
 
 // ============================================================
 // resolveCompactionStrategy — name → class registry
@@ -224,5 +238,430 @@ describe("strategy classes are distinct", () => {
     const oc = new OpenCodeStyleCompactionStrategy();
     expect(cc).not.toBeInstanceOf(SummarizeCompactionStrategy);
     expect(oc).not.toBeInstanceOf(SummarizeCompactionStrategy);
+  });
+});
+
+// ============================================================
+// Upstream empty-summary defense in DefaultHarness.compact()
+// ============================================================
+//
+// The downstream layer (eventsToMessages skipping empty boundaries) has
+// its own tests in bijection-invariants.test.ts. This file pins the
+// upstream layer: even if a (legacy) strategy returns a result whose
+// summary text is empty, DefaultHarness.compact must NOT broadcast a
+// boundary event.
+//
+// We use a fake CompactionStrategy that returns a hand-crafted result
+// instead of mocking generateText.
+
+import { DefaultHarness } from "../../apps/agent/src/harness/default-loop";
+import type { CompactionStrategy, CompactionResult } from "../../apps/agent/src/harness/compaction";
+import type { HarnessRuntime } from "../../apps/agent/src/harness/interface";
+
+class FakeStrategy implements CompactionStrategy {
+  readonly name = "fake";
+  constructor(private result: CompactionResult | null) {}
+  shouldCompact() {
+    return true;
+  }
+  async compact() {
+    return this.result;
+  }
+}
+
+function buildHarnessWithStrategy(strategy: CompactionStrategy): {
+  harness: DefaultHarness;
+  broadcasts: SessionEvent[];
+} {
+  const harness = new DefaultHarness();
+  // Inject our fake strategy via the private field. compactionStrategy is
+  // re-set inside run() based on agent.metadata, but compact() (the method
+  // we're testing here) reads from the field directly.
+  (harness as any).compactionStrategy = strategy;
+  const broadcasts: SessionEvent[] = [];
+  const runtime = {
+    history: { append() {}, getEvents: () => [], getMessages: () => [] } as any,
+    sandbox: {} as any,
+    broadcast: (e: SessionEvent) => broadcasts.push(e),
+    reportUsage: async () => {},
+    pendingConfirmations: [],
+  } as HarnessRuntime;
+  return { harness, broadcasts, runtime } as any;
+}
+
+describe("DefaultHarness.compact() — empty-summary defense (upstream)", () => {
+  const ctx = {
+    model: { modelId: "stub" } as any,
+    systemPrompt: "stub",
+    tools: {},
+  };
+
+  it("does NOT broadcast boundary when strategy returns empty-text summary", async () => {
+    const fake = new FakeStrategy({
+      summary: [{ type: "text", text: "" }],
+      pre_tokens: 1000,
+      original_message_count: 10,
+      compacted_message_count: 1,
+    });
+    const { harness, broadcasts, runtime } = buildHarnessWithStrategy(fake) as any;
+    await harness.compact([], runtime, ctx);
+    const boundaries = broadcasts.filter((e) => e.type === "agent.thread_context_compacted");
+    expect(boundaries).toHaveLength(0);
+  });
+
+  it("does NOT broadcast boundary when summary is whitespace-only", async () => {
+    const fake = new FakeStrategy({
+      summary: [{ type: "text", text: "   \n\t  " }],
+      pre_tokens: 1000,
+      original_message_count: 10,
+      compacted_message_count: 1,
+    });
+    const { harness, broadcasts, runtime } = buildHarnessWithStrategy(fake) as any;
+    await harness.compact([], runtime, ctx);
+    expect(broadcasts.filter((e) => e.type === "agent.thread_context_compacted")).toHaveLength(0);
+  });
+
+  it("DOES broadcast boundary when summary has real text", async () => {
+    const fake = new FakeStrategy({
+      summary: [{ type: "text", text: "real summary content" }],
+      pre_tokens: 1000,
+      original_message_count: 10,
+      compacted_message_count: 1,
+    });
+    const { harness, broadcasts, runtime } = buildHarnessWithStrategy(fake) as any;
+    await harness.compact([], runtime, ctx);
+    const boundaries = broadcasts.filter((e) => e.type === "agent.thread_context_compacted");
+    expect(boundaries).toHaveLength(1);
+    expect((boundaries[0] as any).summary[0].text).toBe("real summary content");
+  });
+
+  it("does NOT broadcast when strategy returns null (e.g. too few messages)", async () => {
+    const fake = new FakeStrategy(null);
+    const { harness, broadcasts, runtime } = buildHarnessWithStrategy(fake) as any;
+    await harness.compact([], runtime, ctx);
+    expect(broadcasts).toHaveLength(0);
+  });
+});
+
+// ============================================================
+// Iterative compaction (with mocked generateText)
+// ============================================================
+//
+// When events already contain a prior boundary with a real summary, the
+// next compaction call should:
+//   1. See that prior summary as the leading user message in its derived
+//      messages (eventsToMessages handles this — it injects the
+//      <conversation-summary> block).
+//   2. Send those messages to the model alongside its own summarize prompt.
+//   3. Produce a new summary that supersedes (or extends) the prior one.
+//
+// We verify (1) and (2) by inspecting the actual messages handed to
+// generateText. (3) is purely up to the model and can't be tested without
+// a real LLM, but the input shape being correct guarantees the prior-
+// summary content is in the model's view.
+
+describe("iterative compaction (mocked generateText)", () => {
+  beforeEach(() => {
+    (generateText as any).mockReset();
+  });
+
+  const eventsWithPriorBoundary: SessionEvent[] = [
+    { type: "user.message", content: [{ type: "text", text: "early question" }] },
+    { type: "agent.message", content: [{ type: "text", text: "early answer" }] },
+    {
+      type: "agent.thread_context_compacted",
+      original_message_count: 2,
+      compacted_message_count: 1,
+      summary: [{ type: "text", text: "Earlier: user asked about X, agent did Y." }],
+    } as any,
+    { type: "user.message", content: [{ type: "text", text: "follow-up question" }] },
+    { type: "agent.message", content: [{ type: "text", text: "follow-up answer" }] },
+    { type: "user.message", content: [{ type: "text", text: "another question" }] },
+    { type: "agent.message", content: [{ type: "text", text: "another answer" }] },
+  ];
+
+  const stubArgs = {
+    model: { modelId: "stub" } as any,
+    contextWindowTokens: 1_000_000,
+    systemPrompt: "main-agent-system",
+    tools: { bash: {} },
+    applyCacheStrategy: (sys: string, tools: any, msgs: any[]) => ({ system: sys, tools, messages: msgs }),
+  };
+
+  for (const [name, Strategy] of [
+    ["cc-style", CCStyleCompactionStrategy],
+    ["opencode-style", OpenCodeStyleCompactionStrategy],
+  ] as const) {
+    it(`${name}: includes prior summary as leading user message in the summarize call`, async () => {
+      (generateText as any).mockResolvedValue({
+        text: "v2: covers earlier work + follow-up + another exchange.",
+        usage: { inputTokens: 100, outputTokens: 50 },
+        finishReason: "stop",
+      });
+
+      const s = new Strategy();
+      const result = await s.compact(eventsWithPriorBoundary, stubArgs);
+
+      // Strategy returned a non-null result with the new summary text.
+      expect(result).not.toBeNull();
+      expect(result!.summary[0].text).toContain("v2");
+
+      // generateText was called once. Its messages payload starts with the
+      // <conversation-summary> block (the prior summary, surfaced by
+      // eventsToMessages as a synthesized user message).
+      expect((generateText as any)).toHaveBeenCalledTimes(1);
+      const call = (generateText as any).mock.calls[0][0];
+      const firstMsg = call.messages[0];
+      expect(firstMsg.role).toBe("user");
+      const firstText = Array.isArray(firstMsg.content)
+        ? firstMsg.content[0].text
+        : firstMsg.content;
+      expect(firstText).toContain("<conversation-summary>");
+      expect(firstText).toContain("Earlier: user asked about X");
+
+      // Last message is the strategy's own "please summarize" prompt.
+      const lastMsg = call.messages[call.messages.length - 1];
+      expect(lastMsg.role).toBe("user");
+      const lastText = typeof lastMsg.content === "string"
+        ? lastMsg.content
+        : lastMsg.content[0].text;
+      // CC style talks about "older conversation history"; OpenCode style
+      // talks about "## Goal". Both are unambiguous summarize-ish prompts.
+      expect(
+        lastText.includes("summary") || lastText.includes("summarize") || lastText.includes("Goal"),
+      ).toBe(true);
+    });
+
+    it(`${name}: returns null on empty model output (defense)`, async () => {
+      (generateText as any).mockResolvedValue({
+        text: "",
+        usage: { inputTokens: 100, outputTokens: 0 },
+        finishReason: "stop",
+      });
+
+      const s = new Strategy();
+      const result = await s.compact(eventsWithPriorBoundary, stubArgs);
+      expect(result).toBeNull();
+    });
+
+    it(`${name}: returns null on whitespace-only model output`, async () => {
+      (generateText as any).mockResolvedValue({
+        text: "   \n\t   ",
+        usage: { inputTokens: 100, outputTokens: 5 },
+        finishReason: "stop",
+      });
+
+      const s = new Strategy();
+      const result = await s.compact(eventsWithPriorBoundary, stubArgs);
+      expect(result).toBeNull();
+    });
+
+    it(`${name}: does NOT pass main agent's system prompt or tools`, async () => {
+      (generateText as any).mockResolvedValue({
+        text: "summary",
+        usage: { inputTokens: 100, outputTokens: 5 },
+        finishReason: "stop",
+      });
+
+      const s = new Strategy();
+      await s.compact(eventsWithPriorBoundary, stubArgs);
+      const call = (generateText as any).mock.calls[0][0];
+      // The strategies use their own short system prompt, NOT the caller's.
+      expect(call.system).not.toBe("main-agent-system");
+      expect(typeof call.system).toBe("string");
+      expect(call.system.length).toBeLessThan(1000);
+      // No tools field passed → ai-sdk treats as undefined.
+      expect(call.tools).toBeUndefined();
+      // No toolChoice passed.
+      expect(call.toolChoice).toBeUndefined();
+    });
+  }
+});
+
+// ============================================================
+// stripImagesFromMessages — direct edge-case tests
+// ============================================================
+//
+// Replaces every image / file content block with a short text placeholder,
+// across all the shapes the codebase currently produces. Pure function;
+// must not mutate input.
+
+describe("stripImagesFromMessages", () => {
+  const PNG = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkAAIAAAoAAv/lxKUAAAAASUVORK5CYII=";
+
+  it("passes through messages with string content unchanged", () => {
+    const input = [
+      { role: "user" as const, content: "hello" },
+      { role: "assistant" as const, content: "hi" },
+    ];
+    const result = stripImagesFromMessages(input);
+    expect(result).toEqual(input);
+  });
+
+  it("passes through messages with no images unchanged", () => {
+    const input = [
+      {
+        role: "user" as const,
+        content: [{ type: "text" as const, text: "no images here" }],
+      },
+    ];
+    const result = stripImagesFromMessages(input);
+    // Same shape, same text.
+    expect((result[0].content as any)[0].text).toBe("no images here");
+  });
+
+  it("strips top-level image part on user message", () => {
+    const input = [
+      {
+        role: "user" as const,
+        content: [
+          { type: "text" as const, text: "look at this:" },
+          { type: "image" as const, image: PNG, mediaType: "image/png" },
+        ],
+      },
+    ];
+    const result = stripImagesFromMessages(input);
+    const parts = result[0].content as any[];
+    expect(parts).toHaveLength(2);
+    expect(parts[0]).toEqual({ type: "text", text: "look at this:" });
+    expect(parts[1].type).toBe("text");
+    expect(parts[1].text).toContain("image");
+    expect(parts[1].text).not.toContain(PNG);
+  });
+
+  it("strips top-level file part (e.g. PDF) on user message", () => {
+    const input = [
+      {
+        role: "user" as const,
+        content: [
+          { type: "text" as const, text: "see attached:" },
+          { type: "file" as const, data: "BASE64DATA", mediaType: "application/pdf" },
+        ],
+      },
+    ];
+    const result = stripImagesFromMessages(input);
+    const parts = result[0].content as any[];
+    expect(parts[1].type).toBe("text");
+    expect(parts[1].text).not.toContain("BASE64DATA");
+  });
+
+  it("strips image-data inside tool_result content", () => {
+    const input = [
+      {
+        role: "tool" as const,
+        content: [
+          {
+            type: "tool-result" as const,
+            toolCallId: "tc1",
+            toolName: "render_chart",
+            output: {
+              type: "content",
+              value: [
+                { type: "text", text: "Chart text:" },
+                { type: "image-data", data: PNG, mediaType: "image/png" },
+              ],
+            },
+          },
+        ],
+      },
+    ];
+    const result = stripImagesFromMessages(input);
+    const trPart = (result[0].content as any[])[0];
+    const innerParts = trPart.output.value;
+    expect(innerParts).toHaveLength(2);
+    expect(innerParts[0]).toEqual({ type: "text", text: "Chart text:" });
+    expect(innerParts[1].type).toBe("text");
+    expect(innerParts[1].text).not.toContain(PNG);
+    // Surrounding tool-result envelope preserved
+    expect(trPart.toolCallId).toBe("tc1");
+    expect(trPart.toolName).toBe("render_chart");
+    expect(trPart.output.type).toBe("content");
+  });
+
+  it("strips image-url, file-data, file-url inside tool_result content", () => {
+    const input = [
+      {
+        role: "tool" as const,
+        content: [
+          {
+            type: "tool-result" as const,
+            toolCallId: "tc1",
+            toolName: "fetch",
+            output: {
+              type: "content",
+              value: [
+                { type: "image-url", url: "https://example.com/x.png", mediaType: "image/png" },
+                { type: "file-data", data: "PDFBYTES", mediaType: "application/pdf" },
+                { type: "file-url", url: "https://example.com/x.pdf", mediaType: "application/pdf" },
+              ],
+            },
+          },
+        ],
+      },
+    ];
+    const result = stripImagesFromMessages(input);
+    const innerParts = (result[0].content as any[])[0].output.value;
+    expect(innerParts).toHaveLength(3);
+    for (const p of innerParts) {
+      expect(p.type).toBe("text");
+      expect(p.text).not.toContain("example.com");
+      expect(p.text).not.toContain("PDFBYTES");
+    }
+  });
+
+  it("does NOT touch tool_result with text-only output", () => {
+    const input = [
+      {
+        role: "tool" as const,
+        content: [
+          {
+            type: "tool-result" as const,
+            toolCallId: "tc1",
+            toolName: "bash",
+            output: { type: "text", value: "command output" },
+          },
+        ],
+      },
+    ];
+    const result = stripImagesFromMessages(input);
+    expect(result[0]).toEqual(input[0]);
+  });
+
+  it("preserves system messages with string content", () => {
+    const input = [
+      { role: "system" as const, content: "you are helpful" },
+      {
+        role: "user" as const,
+        content: [{ type: "image" as const, image: PNG, mediaType: "image/png" }],
+      },
+    ];
+    const result = stripImagesFromMessages(input);
+    expect(result[0]).toEqual({ role: "system", content: "you are helpful" });
+    expect((result[1].content as any[])[0].type).toBe("text");
+  });
+
+  it("does not mutate input array or nested objects", () => {
+    const original = [
+      {
+        role: "user" as const,
+        content: [
+          { type: "text" as const, text: "look:" },
+          { type: "image" as const, image: PNG, mediaType: "image/png" },
+        ],
+      },
+    ];
+    const beforeJson = JSON.stringify(original);
+    stripImagesFromMessages(original);
+    expect(JSON.stringify(original)).toBe(beforeJson);
+  });
+
+  it("handles empty messages array", () => {
+    expect(stripImagesFromMessages([])).toEqual([]);
+  });
+
+  it("handles message with empty content array", () => {
+    const input = [{ role: "user" as const, content: [] }];
+    const result = stripImagesFromMessages(input);
+    expect((result[0].content as any[]).length).toBe(0);
   });
 });

--- a/test/unit/compaction-strategies.test.ts
+++ b/test/unit/compaction-strategies.test.ts
@@ -1,0 +1,228 @@
+// @ts-nocheck
+import { describe, it, expect } from "vitest";
+import {
+  CCStyleCompactionStrategy,
+  OpenCodeStyleCompactionStrategy,
+  SummarizeCompactionStrategy,
+  resolveCompactionStrategy,
+} from "../../apps/agent/src/harness/compaction";
+import type { SessionEvent } from "@open-managed-agents/shared";
+
+// ============================================================
+// resolveCompactionStrategy — name → class registry
+// ============================================================
+
+describe("resolveCompactionStrategy", () => {
+  it("returns SummarizeCompactionStrategy for undefined", () => {
+    expect(resolveCompactionStrategy(undefined).name).toBe("summarize");
+  });
+
+  it("returns SummarizeCompactionStrategy for 'summarize'", () => {
+    const s = resolveCompactionStrategy("summarize");
+    expect(s).toBeInstanceOf(SummarizeCompactionStrategy);
+    expect(s.name).toBe("summarize");
+  });
+
+  it("returns CCStyleCompactionStrategy for 'cc-style'", () => {
+    const s = resolveCompactionStrategy("cc-style");
+    expect(s).toBeInstanceOf(CCStyleCompactionStrategy);
+    expect(s.name).toBe("cc-style");
+  });
+
+  it("returns OpenCodeStyleCompactionStrategy for 'opencode-style'", () => {
+    const s = resolveCompactionStrategy("opencode-style");
+    expect(s).toBeInstanceOf(OpenCodeStyleCompactionStrategy);
+    expect(s.name).toBe("opencode-style");
+  });
+
+  it("falls back to summarize on unknown name (no throw)", () => {
+    // Should warn but not throw — agent metadata is user-controlled and a
+    // typo shouldn't crash the harness.
+    const s = resolveCompactionStrategy("typo-style");
+    expect(s).toBeInstanceOf(SummarizeCompactionStrategy);
+  });
+
+  it("propagates options to the resolved strategy", () => {
+    // shouldCompact uses triggerFraction → cheapest way to verify the
+    // option threaded through.
+    const events: SessionEvent[] = Array.from({ length: 8 }, (_, i) =>
+      i % 2 === 0
+        ? { type: "user.message", content: [{ type: "text", text: "x".repeat(2000) }] }
+        : { type: "agent.message", content: [{ type: "text", text: "y".repeat(2000) }] },
+    );
+    const tight = resolveCompactionStrategy("cc-style", { triggerFraction: 0.001 });
+    const loose = resolveCompactionStrategy("cc-style", { triggerFraction: 0.99 });
+    expect(tight.shouldCompact(events, { contextWindowTokens: 1_000_000 })).toBe(true);
+    expect(loose.shouldCompact(events, { contextWindowTokens: 1_000_000 })).toBe(false);
+  });
+});
+
+// ============================================================
+// shouldCompact — trigger fraction threshold
+// ============================================================
+//
+// All three strategies share the same shouldCompact logic. Verify each
+// fires above its threshold and stays quiet below.
+
+describe("shouldCompact (all strategies)", () => {
+  // Build a conversation big enough that estimateMessagesTokens crosses
+  // typical thresholds. ~50KB of text ≈ ~12K tokens at 4 chars/token.
+  const bigEvents: SessionEvent[] = Array.from({ length: 12 }, (_, i) =>
+    i % 2 === 0
+      ? { type: "user.message", content: [{ type: "text", text: "x".repeat(4000) }] }
+      : { type: "agent.message", content: [{ type: "text", text: "y".repeat(4000) }] },
+  );
+
+  for (const [name, Strategy] of [
+    ["summarize", SummarizeCompactionStrategy],
+    ["cc-style", CCStyleCompactionStrategy],
+    ["opencode-style", OpenCodeStyleCompactionStrategy],
+  ] as const) {
+    it(`${name}: fires when estimated tokens exceed contextWindow * triggerFraction`, () => {
+      const tight = new Strategy({ triggerFraction: 0.005 });
+      expect(tight.shouldCompact(bigEvents, { contextWindowTokens: 1_000_000 })).toBe(true);
+    });
+
+    it(`${name}: stays quiet when below threshold`, () => {
+      const loose = new Strategy({ triggerFraction: 0.99 });
+      expect(loose.shouldCompact(bigEvents, { contextWindowTokens: 1_000_000 })).toBe(false);
+    });
+  }
+});
+
+// ============================================================
+// compact() early-return: too few messages
+// ============================================================
+//
+// All isolated strategies (cc-style, opencode-style) return null when
+// the derived message list is shorter than 4. Below that threshold there's
+// nothing meaningful to summarize and we'd just lose information. Verify
+// without making any API calls.
+
+describe("compact() — early return for short conversations", () => {
+  const tinyEvents: SessionEvent[] = [
+    { type: "user.message", content: [{ type: "text", text: "hi" }] },
+    { type: "agent.message", content: [{ type: "text", text: "hello" }] },
+  ];
+
+  // Stub LanguageModel — never invoked because the early return triggers
+  // before generateText is called. Cast to any to satisfy the type.
+  const stubModel = { modelId: "stub" } as any;
+
+  const stubArgs = {
+    model: stubModel,
+    contextWindowTokens: 1_000_000,
+    systemPrompt: "stub-system",
+    tools: {},
+    applyCacheStrategy: (sys: string, tools: any, msgs: any[]) => ({
+      system: sys,
+      tools,
+      messages: msgs,
+    }),
+  };
+
+  it("CCStyleCompactionStrategy: returns null for < 4 messages", async () => {
+    const s = new CCStyleCompactionStrategy();
+    const result = await s.compact(tinyEvents, stubArgs);
+    expect(result).toBeNull();
+  });
+
+  it("OpenCodeStyleCompactionStrategy: returns null for < 4 messages", async () => {
+    const s = new OpenCodeStyleCompactionStrategy();
+    const result = await s.compact(tinyEvents, stubArgs);
+    expect(result).toBeNull();
+  });
+});
+
+// ============================================================
+// stripImagesFromMessages helper (via compact() integration)
+// ============================================================
+//
+// stripImagesFromMessages is private to compaction.ts. Test it indirectly
+// by having the strategy operate on events that contain images, then
+// reading the messages it would emit via eventsToMessages and asserting
+// the strip behavior on equivalent fixtures via the ToolResult roundtrip.
+//
+// Direct shape tests live in bijection-invariants.test.ts (image base64
+// roundtrip). Here we focus on the strip semantics: image bytes go away
+// AND get replaced by the placeholder text, AND the surrounding text
+// blocks survive.
+
+import { eventsToMessages } from "../../apps/agent/src/runtime/history";
+
+describe("stripImagesFromMessages semantics (via eventsToMessages fixture)", () => {
+  const PNG =
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkAAIAAAoAAv/lxKUAAAAASUVORK5CYII=";
+
+  const events: SessionEvent[] = [
+    { type: "user.message", content: [{ type: "text", text: "render it" }] },
+    {
+      type: "agent.tool_use",
+      id: "tc_chart",
+      name: "render_chart",
+      input: { caption: "p99" },
+    } as any,
+    {
+      type: "agent.tool_result",
+      tool_use_id: "tc_chart",
+      content: [
+        { type: "text", text: "Chart caption: p99." },
+        { type: "image", source: { type: "base64", media_type: "image/png", data: PNG } },
+      ],
+    } as any,
+  ];
+
+  it("derived messages contain the raw image data BEFORE strip", () => {
+    const messages = eventsToMessages(events);
+    const tool = messages.find((m) => m.role === "tool")!;
+    const trPart = (tool.content as any[])[0];
+    const imageBlock = trPart.output.value.find((b: any) => b.type === "image-data");
+    expect(imageBlock).toBeDefined();
+    expect(imageBlock.data).toBe(PNG);
+  });
+
+  // The actual strip happens inside compact() before sending to generateText.
+  // We can't easily snapshot that without mocking generateText, but we can
+  // assert the helper's behavior via the resolver + a manual integration
+  // probe: call compact on a tiny conversation, expect early-return (so no
+  // model call is made even with images present).
+  it("strategies don't crash on image-bearing fixtures (early return path)", async () => {
+    const cc = new CCStyleCompactionStrategy();
+    const oc = new OpenCodeStyleCompactionStrategy();
+    const stubArgs = {
+      model: { modelId: "stub" } as any,
+      contextWindowTokens: 1_000_000,
+      systemPrompt: "stub",
+      tools: {},
+      applyCacheStrategy: (sys: string, tools: any, msgs: any[]) => ({ system: sys, tools, messages: msgs }),
+    };
+    // 3 messages → below the 4-message threshold → early return null
+    expect(await cc.compact(events, stubArgs)).toBeNull();
+    expect(await oc.compact(events, stubArgs)).toBeNull();
+  });
+});
+
+// ============================================================
+// Strategy distinctness
+// ============================================================
+//
+// The two new strategies are intentionally separate classes (not just
+// different prompt strings) so future divergence is cheap. Pin that they
+// are NOT the same class.
+
+describe("strategy classes are distinct", () => {
+  it("CCStyleCompactionStrategy and OpenCodeStyleCompactionStrategy are different classes", () => {
+    const cc = new CCStyleCompactionStrategy();
+    const oc = new OpenCodeStyleCompactionStrategy();
+    expect(cc).not.toBeInstanceOf(OpenCodeStyleCompactionStrategy);
+    expect(oc).not.toBeInstanceOf(CCStyleCompactionStrategy);
+    expect(cc.name).not.toBe(oc.name);
+  });
+
+  it("neither extends SummarizeCompactionStrategy (they are not cache-prefix-sharing)", () => {
+    const cc = new CCStyleCompactionStrategy();
+    const oc = new OpenCodeStyleCompactionStrategy();
+    expect(cc).not.toBeInstanceOf(SummarizeCompactionStrategy);
+    expect(oc).not.toBeInstanceOf(SummarizeCompactionStrategy);
+  });
+});


### PR DESCRIPTION
Closes [OPE-13](https://linear.app/boai/issue/OPE-13/probe-coverage-for-sub-agent-multimodal-compaction-paths). Bundles three previously-separate PRs (#6, #7, #9) into one merge.

## Why one PR

Originally split as #6 (OPE-13 probe), #7 (scrub internal Anthropic symbol leaks), #9 (new compaction strategies + defense). All three touch the same compaction surface area and the splits were creating review overhead. Consolidated here; old PRs to be closed.

## What changed

### 1. OPE-13: probe coverage for sub-agent + multimodal paths

- `scripts/probe-harness-cache.ts` gains `PROBE_MODE=text|sub-agent|multimodal|all`. Sub-agent mode plugs a `call_agent_researcher` stub that injects tagged thread events into the parent runtime exactly the way `SessionDO.runSubAgent` does. Multimodal mode plugs `render_chart` returning a constant 1×1 PNG.
- Per-turn line tags `[post-call_agent]` / `[post-image-result]` so cache regressions are easy to spot.
- `test/unit/bijection-invariants.test.ts` gains 8 deterministic byte-roundtrip tests (sub-agent thread tagging, multimodal image roundtrip, compaction summary image elision).
- Probe also gains `PROBE_COMPACTION_STRATEGY` env var (used in test plan below).

### 2. Internal-source-leak scrub

- `scripts/probe-harness-cache.ts` no longer mentions an internal proxy hostname; routing headers now come from `PROBE_HEADERS` env var.
- `apps/agent/src/{harness/compaction.ts, runtime/history.ts, runtime/session-do.ts}` had 7 comment leaks of internal Anthropic symbols (`microCompact.ts:164`, `IMAGE_MAX_TOKEN_SIZE`, `AUTOCOMPACT_BUFFER`, `DEFAULT_SM_COMPACT_CONFIG`, `shellCommand.result.then`, `sessionMemoryCompact.ts`). Replaced with generic descriptions of the heuristic / pattern itself. Behavior unchanged.

### 3. CC-style + OpenCode-style compaction strategies + two-layer defense

End-to-end probe revealed the existing `SummarizeCompactionStrategy` was based on broken assumptions:

- `@ai-sdk/anthropic` translates `toolChoice: "none"` into "drop tools entirely" before sending — so the summarize-call prefix never matches the main call's prefix and `cache_read = 0%` on summarize through Anthropic.
- MiniMax sporadically returns `finish_reason="tool-calls"` with empty text — and the boundary-write logic was happily persisting an empty-text summary, silently dropping the entire pre-boundary history on the next derive.

Two new strategies modeled after how Claude Code and OpenCode actually do compaction (verified by reading both projects' source):

- **`CCStyleCompactionStrategy`** — short hardcoded system prompt, empty tools, no `toolChoice`, images stripped, empty-summary defense (returns `null` instead of writing an empty boundary).
- **`OpenCodeStyleCompactionStrategy`** — same structure, OpenCode's Goal / Instructions / Discoveries / Accomplished / Files template.

Two-layer defense (helps even agents that stay on the legacy `summarize` strategy):

- **Upstream** in `DefaultHarness.compact()`: skip the boundary write if the summary contains only empty/whitespace text. Caller will retry next turn.
- **Downstream** in `eventsToMessages`: boundary detection now requires real text/image/document content. A stale or buggy upstream that wrote an empty boundary won't drop history.

Plus exported `stripImagesFromMessages` helper and `resolveCompactionStrategy(name, opts)` registry. Strategy is selectable per-agent via `metadata.compaction_strategy = "cc-style" | "opencode-style"`. Default stays `"summarize"` for backward compat.

Updated 2 stale boundary-handling tests in `bijection-invariants.test.ts` that pre-date the bijection refactor's tail preservation.

## Test plan

- [x] `npx vitest run test/unit/{bijection-invariants,compaction-strategies,history-conversion,harness}.test.ts` — **125/125 pass**, no regressions, the 2 stale failures from main are now fixed.
- [x] `npx tsc --noEmit -p tsconfig.json` — no new errors.
- [x] **Live probe across 4 new (strategy × provider) combinations**:

| strategy | provider/model | compactions | summary text_len | finish_reason | empty summaries |
|---|---|---|---|---|---|
| **summarize** (baseline) | MiniMax-M2.7 | several | ~939 chars | mostly `stop`; sporadic `tool-calls text_len=0` | yes — boundary written, history dropped |
| **summarize** (baseline) | Anthropic Haiku | several | ~2400 chars | `stop` | no |
| **cc-style** (new) | MiniMax-M2.7 | 13+ | 1295–1431 chars | `stop` every time | **none** ✓ |
| **cc-style** (new) | Anthropic Haiku | several | 1840–1947 chars | `stop` | none |
| **opencode-style** (new) | MiniMax-M2.7 | several | ~1650 chars structured | `stop` | none |
| **opencode-style** (new) | Anthropic Haiku | several | 1146–1688 chars structured | `stop` | none |

Key wins:

- **MiniMax `finish=tool-calls text_len=0` no longer happens** under the new strategies — confirmed across 13+ compactions.
- Cache_read on summarize call is 0% (expected — these strategies intentionally don't share prefix; the original "share prefix to hit cache" approach was empirically not landing because of provider/SDK quirks anyway).
- Summary content quality is good. cc-style produces narrative summaries; opencode-style produces structural sections.

## Migration notes

To opt an agent into the new behavior:

```json
{
  "metadata": { "compaction_strategy": "cc-style" }
}
```

No change required for agents that don't set `compaction_strategy` — they keep the existing `SummarizeCompactionStrategy`, but now ALSO benefit from the empty-summary defense as a safety net.

## Out of scope (follow-ups)

- OpenAI-compatible cross-provider live probe (no creds in current dev env).
- The original `SummarizeCompactionStrategy` is left in place but its design assumption (cache prefix sharing) is empirically broken; consider deprecating in a future PR after agents migrate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)