### PR TITLE
feat(storage): tenant→shard router + 8-table tenant_id schema fix

### DIFF
--- a/apps/agent/src/outbound.ts
+++ b/apps/agent/src/outbound.ts
@@ -1,5 +1,5 @@
 import type { Env } from "@open-managed-agents/shared";
-import { buildCfServices } from "@open-managed-agents/services";
+import { buildCfServices, getCfServicesForTenant } from "@open-managed-agents/services";
 import type { OutboundSnapshot } from "@open-managed-agents/outbound-snapshots-store";
 
 /**
@@ -121,7 +121,9 @@ async function findCredentialForHost(
 }
 
 async function loadSnapshot(env: Env, sessionId: string): Promise<OutboundSnapshot | null> {
-  return buildCfServices(env).outboundSnapshots.get({ sessionId });
+  // outboundSnapshots is KV-backed; the D1 binding doesn't matter here.
+  // Pass AUTH_DB to satisfy the factory signature.
+  return buildCfServices(env, env.AUTH_DB).outboundSnapshots.get({ sessionId });
 }
 
 /**
@@ -177,7 +179,7 @@ async function tryRefreshToken(
     // refreshing the snapshot resets the lifetime, which is what we want:
     // an active session should keep its credentials live; an idle one
     // ages out within the same 24h window.
-    await buildCfServices(env).outboundSnapshots.publish({ sessionId, snapshot });
+    await buildCfServices(env, env.AUTH_DB).outboundSnapshots.publish({ sessionId, snapshot });
 
     // Best-effort: also update the canonical D1 row so future sessions
     // inherit the refreshed token. The snapshot remains the source of truth
@@ -185,7 +187,8 @@ async function tryRefreshToken(
     // fresh token, just future sessions may take one extra refresh.
     if (snapshot.tenant_id && env.AUTH_DB) {
       try {
-        await buildCfServices(env).credentials.refreshAuth({
+        const services = await getCfServicesForTenant(env, snapshot.tenant_id);
+        await services.credentials.refreshAuth({
           tenantId: snapshot.tenant_id,
           vaultId,
           credentialId,

--- a/apps/agent/src/runtime/session-do.ts
+++ b/apps/agent/src/runtime/session-do.ts
@@ -22,7 +22,7 @@ import type { LanguageModel } from "ai";
 import { evaluateOutcome } from "../harness/outcome-evaluator";
 import { buildTools, buildMemoryTools } from "../harness/tools";
 import { MemoryStoreService } from "@open-managed-agents/memory-store";
-import { buildCfServices } from "@open-managed-agents/services";
+import { buildCfServices, getCfServicesForTenant } from "@open-managed-agents/services";
 import { toEnvironmentConfig } from "@open-managed-agents/environments-store";
 import { resolveSkills, resolveCustomSkills, getSkillFiles } from "../harness/skills";
 import { resolveAppendablePrompts } from "./appendable-prompts";
@@ -177,7 +177,12 @@ export class SessionDO extends Agent<Env, SessionState> {
       return this.state.agent_snapshot;
     }
     // Cross-tenant lookup — DO has no tenant scope here. Trusts the caller.
-    const row = await buildCfServices(this.env).agents.getById({ agentId });
+    // Phase 1: still queries against the shared AUTH_DB. Phase 4: per-tenant
+    // DB will scope this naturally — `WHERE id = ?` in the tenant's DB only
+    // returns the tenant's row. Either way, this.state.tenant_id is the
+    // right routing key.
+    const services = await getCfServicesForTenant(this.env, this.state.tenant_id);
+    const row = await services.agents.getById({ agentId });
     if (!row) return null;
     const { tenant_id: _t, ...config } = row;
     return config;
@@ -188,7 +193,8 @@ export class SessionDO extends Agent<Env, SessionState> {
     if (this.state.environment_snapshot && envId === this.state.environment_id) {
       return this.state.environment_snapshot;
     }
-    const row = await buildCfServices(this.env).environments.get({
+    const services = await getCfServicesForTenant(this.env, this.state.tenant_id);
+    const row = await services.environments.get({
       tenantId: this.state.tenant_id,
       environmentId: envId,
     });
@@ -467,7 +473,8 @@ export class SessionDO extends Agent<Env, SessionState> {
       // crash, force-terminate). The blob contains plaintext OAuth material
       // so we don't want it lingering beyond a realistic max session lifetime.
       if (params.session_id && (params.vault_credentials?.length ?? 0) > 0) {
-        await buildCfServices(this.env).outboundSnapshots.publish({
+        // outboundSnapshots is KV-backed; AUTH_DB is fine.
+        await buildCfServices(this.env, this.env.AUTH_DB).outboundSnapshots.publish({
           sessionId: params.session_id,
           snapshot: {
             tenant_id: params.tenant_id ?? "default",
@@ -519,7 +526,8 @@ export class SessionDO extends Agent<Env, SessionState> {
       // OAuth material.
       if (this.state.session_id) {
         try {
-          await buildCfServices(this.env).outboundSnapshots.delete({
+          // KV-backed; AUTH_DB is fine.
+          await buildCfServices(this.env, this.env.AUTH_DB).outboundSnapshots.delete({
             sessionId: this.state.session_id,
           });
         } catch {}
@@ -963,7 +971,7 @@ export class SessionDO extends Agent<Env, SessionState> {
         // Sessions-store reads via the session_id PRIMARY KEY index, no
         // tenant prefix needed — fixes the staging-kv namespace mismatch
         // the legacy CONFIG_KV.list path tripped over.
-        const services = buildCfServices(this.env);
+        const services = await getCfServicesForTenant(this.env, this.state.tenant_id);
         const rows = await services.sessions.listResourcesBySession({ sessionId });
         const resources: Array<Record<string, unknown>> = [];
         const secretStore = new Map<string, string>();
@@ -1120,7 +1128,7 @@ export class SessionDO extends Agent<Env, SessionState> {
 
     if (this.env.AUTH_DB) {
       try {
-        const services = buildCfServices(this.env);
+        const services = await getCfServicesForTenant(this.env, this.state.tenant_id);
         const tenantId = this.state.tenant_id;
         let card = cardId
           ? await services.modelCards.get({ tenantId, cardId })
@@ -1614,7 +1622,7 @@ export class SessionDO extends Agent<Env, SessionState> {
       // listResourcesBySession queries the session_id column directly — no
       // tenant-prefix mismatch, no JSON.parse loop. Replaces the prior
       // CONFIG_KV.list scan that tripped over staging KV namespaces.
-      const services = buildCfServices(this.env);
+      const services = await getCfServicesForTenant(this.env, this.state.tenant_id);
       const rows = await services.sessions.listResourcesBySession({ sessionId });
       for (const row of rows) {
         if (row.type === "memory_store" && row.resource.type === "memory_store" && row.resource.memory_store_id) {
@@ -1663,7 +1671,7 @@ export class SessionDO extends Agent<Env, SessionState> {
     // AUTH_DB to be present.
     let memoryStoreService: MemoryStoreService | null = null;
     if (memoryAttachments.length && this.env.AUTH_DB) {
-      memoryStoreService = buildCfServices(this.env).memory;
+      memoryStoreService = (await getCfServicesForTenant(this.env, this.state.tenant_id)).memory;
       const memTools = buildMemoryTools(
         memoryAttachments.map((a) => ({ store_id: a.store_id, access: a.access })),
         this.state.tenant_id,

--- a/apps/integrations/package.json
+++ b/apps/integrations/package.json
@@ -10,6 +10,8 @@
     "@open-managed-agents/integrations-core": "workspace:*",
     "@open-managed-agents/linear": "workspace:*",
     "@open-managed-agents/shared": "workspace:*",
+    "@open-managed-agents/tenant-db": "workspace:*",
+    "@open-managed-agents/tenant-dbs-store": "workspace:*",
     "hono": "^4.7.0"
   }
 }

--- a/apps/integrations/src/routes/linear/mcp.ts
+++ b/apps/integrations/src/routes/linear/mcp.ts
@@ -622,6 +622,7 @@ async function resolveSessionContext(
   }) => {
     await container.authoredComments.insert({
       commentId: input.commentId,
+      tenantId: pub.tenantId,
       omaSessionId: sessionId,
       issueId: input.issueId,
       createdAt: Date.now(),

--- a/apps/integrations/src/wire.ts
+++ b/apps/integrations/src/wire.ts
@@ -6,10 +6,23 @@
 //
 // To add a new provider: implement IntegrationProvider in its own package,
 // import here in providers.ts, and instantiate alongside LinearProvider.
+//
+// DB routing: integrations always run against env.AUTH_DB. Tenant sharding
+// (when enabled in apps/main) doesn't apply here — webhook entry can't
+// resolve tenant before signature verify, and integration data
+// (linear_apps/installations/etc) lives in the shared control-plane DB.
 
 import { buildCfContainer, type CfContainerEnv } from "@open-managed-agents/integrations-adapters-cf";
 import type { Container } from "@open-managed-agents/integrations-core";
+import type { Env } from "./env";
 
-export function buildContainer(env: CfContainerEnv): Container {
-  return buildCfContainer(env);
+export function buildContainer(env: Env): Container {
+  const cfEnv: CfContainerEnv = {
+    db: env.AUTH_DB,
+    controlPlaneDb: env.AUTH_DB,
+    MCP_SIGNING_KEY: env.MCP_SIGNING_KEY,
+    MAIN: env.MAIN,
+    INTEGRATIONS_INTERNAL_SECRET: env.INTEGRATIONS_INTERNAL_SECRET,
+  };
+  return buildCfContainer(cfEnv);
 }

--- a/apps/main/migrations/0002_integrations_tenant_id.sql
+++ b/apps/main/migrations/0002_integrations_tenant_id.sql
@@ -1,0 +1,250 @@
+-- Phase 0 of the per-tenant-D1 work: backfill tenant_id on the 8 integrations
+-- tables that today derive tenant ownership only via FK-shaped joins
+-- (user_id / publication_id / installation_id / oma_session_id), and pin
+-- the column to NOT NULL in one shot.
+--
+-- "One shot" because there are no orphan rows in production / staging — every
+-- existing row resolves to a tenant via its FK-shaped join. SQLite can't
+-- ALTER a column to NOT NULL in place, so each table goes through the
+-- standard CREATE __new / INSERT SELECT / DROP / RENAME swap.
+--
+-- The INSERT uses LEFT JOIN against the join source so that any row whose
+-- tenant can't be resolved (a hypothetical orphan we missed) trips the
+-- NOT NULL constraint and the whole migration rolls back. That's the
+-- desired behaviour: better to fail loudly than silently insert an empty
+-- tenant_id.
+--
+-- Code-side invariant added in this PR: every NewXxx adapter input has
+-- tenantId: string (not string | null), and every domain row type's
+-- tenantId is now string. There's no nullable transition to maintain.
+
+-- ─── linear_installations: tenant via user.tenantId ──────────────────────
+CREATE TABLE "linear_installations__new" (
+  "id"                    TEXT PRIMARY KEY NOT NULL,
+  "tenant_id"             TEXT NOT NULL,
+  "user_id"               TEXT NOT NULL,
+  "provider_id"           TEXT NOT NULL,
+  "workspace_id"          TEXT NOT NULL,
+  "workspace_name"        TEXT NOT NULL,
+  "install_kind"          TEXT NOT NULL,
+  "app_id"                TEXT,
+  "access_token_cipher"   TEXT NOT NULL,
+  "refresh_token_cipher"  TEXT,
+  "scopes"                TEXT NOT NULL,
+  "bot_user_id"           TEXT NOT NULL,
+  "created_at"            INTEGER NOT NULL,
+  "revoked_at"            INTEGER,
+  "vault_id"              TEXT
+);
+INSERT INTO "linear_installations__new" (
+  "id", "tenant_id", "user_id", "provider_id", "workspace_id", "workspace_name",
+  "install_kind", "app_id", "access_token_cipher", "refresh_token_cipher",
+  "scopes", "bot_user_id", "created_at", "revoked_at", "vault_id"
+)
+SELECT
+  x."id", u."tenantId", x."user_id", x."provider_id", x."workspace_id", x."workspace_name",
+  x."install_kind", x."app_id", x."access_token_cipher", x."refresh_token_cipher",
+  x."scopes", x."bot_user_id", x."created_at", x."revoked_at", x."vault_id"
+FROM "linear_installations" x
+LEFT JOIN "user" u ON u."id" = x."user_id";
+DROP TABLE "linear_installations";
+ALTER TABLE "linear_installations__new" RENAME TO "linear_installations";
+CREATE UNIQUE INDEX IF NOT EXISTS "idx_linear_installations_active"
+  ON "linear_installations" ("provider_id", "workspace_id", "install_kind", COALESCE("app_id", ''))
+  WHERE "revoked_at" IS NULL;
+CREATE INDEX IF NOT EXISTS "idx_linear_installations_user"
+  ON "linear_installations" ("user_id", "provider_id", "revoked_at");
+CREATE INDEX IF NOT EXISTS "idx_linear_installations_tenant"
+  ON "linear_installations" ("tenant_id", "created_at" DESC);
+
+-- ─── linear_publications: tenant via user.tenantId ───────────────────────
+-- Must run AFTER linear_installations swap (no FK either way, just clarity).
+CREATE TABLE "linear_publications__new" (
+  "id"                    TEXT PRIMARY KEY NOT NULL,
+  "tenant_id"             TEXT NOT NULL,
+  "user_id"               TEXT NOT NULL,
+  "agent_id"              TEXT NOT NULL,
+  "installation_id"       TEXT NOT NULL,
+  "mode"                  TEXT NOT NULL,
+  "status"                TEXT NOT NULL,
+  "persona_name"          TEXT NOT NULL,
+  "persona_avatar_url"    TEXT,
+  "capabilities"          TEXT NOT NULL,
+  "session_granularity"   TEXT NOT NULL,
+  "created_at"            INTEGER NOT NULL,
+  "unpublished_at"        INTEGER,
+  "environment_id"        TEXT
+);
+INSERT INTO "linear_publications__new" (
+  "id", "tenant_id", "user_id", "agent_id", "installation_id", "mode", "status",
+  "persona_name", "persona_avatar_url", "capabilities", "session_granularity",
+  "created_at", "unpublished_at", "environment_id"
+)
+SELECT
+  x."id", u."tenantId", x."user_id", x."agent_id", x."installation_id", x."mode", x."status",
+  x."persona_name", x."persona_avatar_url", x."capabilities", x."session_granularity",
+  x."created_at", x."unpublished_at", x."environment_id"
+FROM "linear_publications" x
+LEFT JOIN "user" u ON u."id" = x."user_id";
+DROP TABLE "linear_publications";
+ALTER TABLE "linear_publications__new" RENAME TO "linear_publications";
+CREATE INDEX IF NOT EXISTS "idx_linear_publications_installation"
+  ON "linear_publications" ("installation_id");
+CREATE INDEX IF NOT EXISTS "idx_linear_publications_user_agent"
+  ON "linear_publications" ("user_id", "agent_id");
+CREATE INDEX IF NOT EXISTS "idx_linear_publications_tenant"
+  ON "linear_publications" ("tenant_id", "created_at" DESC);
+
+-- ─── linear_apps: tenant via linear_publications.tenant_id ───────────────
+-- Must run AFTER linear_publications swap so the join sees the new tenant_id.
+CREATE TABLE "linear_apps__new" (
+  "id"                    TEXT PRIMARY KEY NOT NULL,
+  "tenant_id"             TEXT NOT NULL,
+  "publication_id"        TEXT UNIQUE,
+  "client_id"             TEXT NOT NULL,
+  "client_secret_cipher"  TEXT NOT NULL,
+  "webhook_secret_cipher" TEXT NOT NULL,
+  "created_at"            INTEGER NOT NULL
+);
+INSERT INTO "linear_apps__new" (
+  "id", "tenant_id", "publication_id", "client_id", "client_secret_cipher",
+  "webhook_secret_cipher", "created_at"
+)
+SELECT
+  x."id", p."tenant_id", x."publication_id", x."client_id", x."client_secret_cipher",
+  x."webhook_secret_cipher", x."created_at"
+FROM "linear_apps" x
+LEFT JOIN "linear_publications" p ON p."id" = x."publication_id";
+DROP TABLE "linear_apps";
+ALTER TABLE "linear_apps__new" RENAME TO "linear_apps";
+CREATE INDEX IF NOT EXISTS "idx_linear_apps_tenant" ON "linear_apps" ("tenant_id");
+
+-- ─── github_apps: same shape as linear_apps ──────────────────────────────
+CREATE TABLE "github_apps__new" (
+  "id"                    TEXT PRIMARY KEY NOT NULL,
+  "tenant_id"             TEXT NOT NULL,
+  "publication_id"        TEXT UNIQUE,
+  "app_id"                TEXT NOT NULL,
+  "app_slug"              TEXT NOT NULL,
+  "bot_login"             TEXT NOT NULL,
+  "client_id"             TEXT,
+  "client_secret_cipher"  TEXT,
+  "webhook_secret_cipher" TEXT NOT NULL,
+  "private_key_cipher"    TEXT NOT NULL,
+  "created_at"            INTEGER NOT NULL
+);
+INSERT INTO "github_apps__new" (
+  "id", "tenant_id", "publication_id", "app_id", "app_slug", "bot_login",
+  "client_id", "client_secret_cipher", "webhook_secret_cipher",
+  "private_key_cipher", "created_at"
+)
+SELECT
+  x."id", p."tenant_id", x."publication_id", x."app_id", x."app_slug", x."bot_login",
+  x."client_id", x."client_secret_cipher", x."webhook_secret_cipher",
+  x."private_key_cipher", x."created_at"
+FROM "github_apps" x
+LEFT JOIN "linear_publications" p ON p."id" = x."publication_id";
+DROP TABLE "github_apps";
+ALTER TABLE "github_apps__new" RENAME TO "github_apps";
+CREATE INDEX IF NOT EXISTS "idx_github_apps_app_id" ON "github_apps" ("app_id");
+CREATE INDEX IF NOT EXISTS "idx_github_apps_tenant" ON "github_apps" ("tenant_id");
+
+-- ─── linear_webhook_events: tenant via linear_installations ──────────────
+CREATE TABLE "linear_webhook_events__new" (
+  "delivery_id"     TEXT PRIMARY KEY NOT NULL,
+  "tenant_id"       TEXT NOT NULL,
+  "installation_id" TEXT NOT NULL,
+  "publication_id"  TEXT,
+  "event_type"      TEXT NOT NULL,
+  "received_at"     INTEGER NOT NULL,
+  "session_id"      TEXT,
+  "error"           TEXT
+);
+INSERT INTO "linear_webhook_events__new" (
+  "delivery_id", "tenant_id", "installation_id", "publication_id",
+  "event_type", "received_at", "session_id", "error"
+)
+SELECT
+  x."delivery_id", i."tenant_id", x."installation_id", x."publication_id",
+  x."event_type", x."received_at", x."session_id", x."error"
+FROM "linear_webhook_events" x
+LEFT JOIN "linear_installations" i ON i."id" = x."installation_id";
+DROP TABLE "linear_webhook_events";
+ALTER TABLE "linear_webhook_events__new" RENAME TO "linear_webhook_events";
+CREATE INDEX IF NOT EXISTS "idx_linear_webhook_events_received"
+  ON "linear_webhook_events" ("received_at" DESC);
+CREATE INDEX IF NOT EXISTS "idx_linear_webhook_events_tenant"
+  ON "linear_webhook_events" ("tenant_id", "received_at" DESC);
+
+-- ─── linear_setup_links: tenant via user.tenantId (created_by → user) ────
+CREATE TABLE "linear_setup_links__new" (
+  "token"          TEXT PRIMARY KEY NOT NULL,
+  "tenant_id"      TEXT NOT NULL,
+  "publication_id" TEXT NOT NULL,
+  "created_by"     TEXT NOT NULL,
+  "expires_at"     INTEGER NOT NULL,
+  "used_at"        INTEGER,
+  "used_by_email"  TEXT
+);
+INSERT INTO "linear_setup_links__new" (
+  "token", "tenant_id", "publication_id", "created_by", "expires_at",
+  "used_at", "used_by_email"
+)
+SELECT
+  x."token", u."tenantId", x."publication_id", x."created_by", x."expires_at",
+  x."used_at", x."used_by_email"
+FROM "linear_setup_links" x
+LEFT JOIN "user" u ON u."id" = x."created_by";
+DROP TABLE "linear_setup_links";
+ALTER TABLE "linear_setup_links__new" RENAME TO "linear_setup_links";
+CREATE INDEX IF NOT EXISTS "idx_linear_setup_links_expires"
+  ON "linear_setup_links" ("expires_at");
+CREATE INDEX IF NOT EXISTS "idx_linear_setup_links_tenant"
+  ON "linear_setup_links" ("tenant_id", "expires_at");
+
+-- ─── linear_issue_sessions: tenant via linear_publications ───────────────
+CREATE TABLE "linear_issue_sessions__new" (
+  "tenant_id"      TEXT NOT NULL,
+  "publication_id" TEXT NOT NULL,
+  "issue_id"       TEXT NOT NULL,
+  "session_id"     TEXT NOT NULL,
+  "status"         TEXT NOT NULL,
+  "created_at"     INTEGER NOT NULL,
+  PRIMARY KEY ("publication_id", "issue_id")
+);
+INSERT INTO "linear_issue_sessions__new" (
+  "tenant_id", "publication_id", "issue_id", "session_id", "status", "created_at"
+)
+SELECT
+  p."tenant_id", x."publication_id", x."issue_id", x."session_id", x."status", x."created_at"
+FROM "linear_issue_sessions" x
+LEFT JOIN "linear_publications" p ON p."id" = x."publication_id";
+DROP TABLE "linear_issue_sessions";
+ALTER TABLE "linear_issue_sessions__new" RENAME TO "linear_issue_sessions";
+CREATE INDEX IF NOT EXISTS "idx_linear_issue_sessions_active"
+  ON "linear_issue_sessions" ("publication_id", "status")
+  WHERE "status" = 'active';
+CREATE INDEX IF NOT EXISTS "idx_linear_issue_sessions_tenant"
+  ON "linear_issue_sessions" ("tenant_id", "status");
+
+-- ─── linear_authored_comments: tenant via sessions.tenant_id ─────────────
+CREATE TABLE "linear_authored_comments__new" (
+  "comment_id"     TEXT PRIMARY KEY,
+  "tenant_id"      TEXT NOT NULL,
+  "oma_session_id" TEXT NOT NULL,
+  "issue_id"       TEXT NOT NULL,
+  "created_at"     INTEGER NOT NULL
+);
+INSERT INTO "linear_authored_comments__new" (
+  "comment_id", "tenant_id", "oma_session_id", "issue_id", "created_at"
+)
+SELECT
+  x."comment_id", s."tenant_id", x."oma_session_id", x."issue_id", x."created_at"
+FROM "linear_authored_comments" x
+LEFT JOIN "sessions" s ON s."id" = x."oma_session_id";
+DROP TABLE "linear_authored_comments";
+ALTER TABLE "linear_authored_comments__new" RENAME TO "linear_authored_comments";
+CREATE INDEX IF NOT EXISTS "idx_linear_authored_comments_session"
+  ON "linear_authored_comments" ("oma_session_id");
+CREATE INDEX IF NOT EXISTS "idx_linear_authored_comments_tenant"
+  ON "linear_authored_comments" ("tenant_id", "created_at" DESC);

--- a/apps/main/migrations/0003_tenant_shard.sql
+++ b/apps/main/migrations/0003_tenant_shard.sql
@@ -1,0 +1,46 @@
+-- Phase 2-revised of the per-tenant-D1 work: meta table router.
+--
+-- Two control-plane tables that drive how MetaTableTenantDbProvider
+-- (packages/tenant-db) routes tenant_id → D1 binding:
+--
+--   tenant_shard — assignment record. tenant_id → binding_name. The first
+--                  write per tenant wins (INSERT OR IGNORE in adapter), so
+--                  re-running sign-up never re-routes a live tenant. Missing
+--                  row = tenant falls back to env.AUTH_DB (the default
+--                  shard), which is the N=1 deployment behaviour.
+--
+--   shard_pool   — operational state per binding. status drives "which shard
+--                  do new tenants land on" via ORDER BY tenant_count ASC.
+--                  size_bytes / observed_at are populated by an out-of-band
+--                  capacity monitor (scripts/shard-pool-monitor.ts, future).
+--                  status='full' or 'archived' removes a shard from rotation.
+--
+-- N=1 seed: a single shard_pool row for AUTH_DB so the assign flow has
+-- something to pick. tenant_shard stays empty until N>1 — every tenant
+-- fallback resolves to AUTH_DB, no behaviour change.
+
+CREATE TABLE IF NOT EXISTS "tenant_shard" (
+  "tenant_id"    TEXT PRIMARY KEY NOT NULL,
+  "binding_name" TEXT NOT NULL,
+  "created_at"   INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS "idx_tenant_shard_binding"
+  ON "tenant_shard" ("binding_name");
+
+CREATE TABLE IF NOT EXISTS "shard_pool" (
+  "binding_name"  TEXT PRIMARY KEY NOT NULL,
+  "status"        TEXT NOT NULL DEFAULT 'open',  -- 'open' | 'draining' | 'full' | 'archived'
+  "tenant_count"  INTEGER NOT NULL DEFAULT 0,
+  "size_bytes"    INTEGER,                       -- last observed; NULL = unknown
+  "observed_at"   INTEGER,                       -- ms epoch of last observation
+  "notes"         TEXT
+);
+
+CREATE INDEX IF NOT EXISTS "idx_shard_pool_status"
+  ON "shard_pool" ("status", "tenant_count");
+
+-- Seed N=1 default shard. Idempotent — re-running this migration in any
+-- environment that already has the row no-ops via INSERT OR IGNORE.
+INSERT OR IGNORE INTO "shard_pool" ("binding_name", "status", "notes")
+VALUES ('AUTH_DB', 'open', 'default shard (N=1 baseline)');

--- a/apps/main/package.json
+++ b/apps/main/package.json
@@ -23,6 +23,8 @@
     "@open-managed-agents/session-secrets-store": "workspace:*",
     "@open-managed-agents/services": "workspace:*",
     "@open-managed-agents/shared": "workspace:*",
+    "@open-managed-agents/tenant-db": "workspace:*",
+    "@open-managed-agents/tenant-dbs-store": "workspace:*",
     "hono": "^4.7.0"
   }
 }

--- a/apps/main/src/eval-runner.ts
+++ b/apps/main/src/eval-runner.ts
@@ -14,7 +14,7 @@
 import type { Env, AgentConfig, EnvironmentConfig, StoredEvent } from "@open-managed-agents/shared";
 import { buildTrajectory } from "@open-managed-agents/shared";
 import type { SessionRecord, FullStatus } from "@open-managed-agents/shared";
-import { buildCfServices, type Services } from "@open-managed-agents/services";
+import { buildCfServices, getCfServicesForTenant, type Services } from "@open-managed-agents/services";
 import type { EvalRunRow, EvalRunStatus } from "@open-managed-agents/evals-store";
 import { toEnvironmentConfig } from "@open-managed-agents/environments-store";
 import { kvKey } from "./kv-helpers";
@@ -23,7 +23,8 @@ import type { EvalRunRecord, EvalTaskResult, EvalTaskSpec } from "./routes/evals
 // ---------- Sandbox helpers (mirrors routes/sessions.ts) ----------
 
 async function getSandboxBinding(env: Env, environmentId: string, tenantId: string): Promise<Fetcher | null> {
-  const envRow = await getServices(env).environments.get({ tenantId, environmentId });
+  const services = await getServices(env, tenantId);
+  const envRow = await services.environments.get({ tenantId, environmentId });
   if (!envRow) return null;
   const envConfig = toEnvironmentConfig(envRow);
   if (envConfig.status !== "ready" && envConfig.status !== undefined) return null;
@@ -65,12 +66,16 @@ function fwd(binding: Fetcher, path: string, method: string = "GET", body?: Body
   }));
 }
 
-// ---------- Services accessor (cached per worker isolate) ----------
+// ---------- Services accessor (cached per tenant per worker isolate) ----------
 
-let cachedServices: Services | null = null;
-function getServices(env: Env): Services {
-  if (!cachedServices) cachedServices = buildCfServices(env);
-  return cachedServices;
+const servicesCache = new Map<string, Services>();
+async function getServices(env: Env, tenantId: string): Promise<Services> {
+  let cached = servicesCache.get(tenantId);
+  if (!cached) {
+    cached = await getCfServicesForTenant(env, tenantId);
+    servicesCache.set(tenantId, cached);
+  }
+  return cached;
 }
 
 // ---------- Run / task lifecycle ----------
@@ -113,13 +118,14 @@ function extractResults(run: EvalRunRecord): unknown {
 }
 
 async function loadRun(env: Env, tenantId: string, runId: string): Promise<EvalRunRecord | null> {
-  const row = await getServices(env).evals.get({ tenantId, runId });
+  const services = await getServices(env, tenantId);
+  const row = await services.evals.get({ tenantId, runId });
   if (!row) return null;
   return rowToRecord(row);
 }
 
 async function saveRun(env: Env, run: EvalRunRecord): Promise<void> {
-  const services = getServices(env);
+  const services = await getServices(env, run.tenant_id);
   if (run.status === "completed" || run.status === "failed") {
     await services.evals.markCompleted({
       tenantId: run.tenant_id,
@@ -141,7 +147,7 @@ async function saveRun(env: Env, run: EvalRunRecord): Promise<void> {
 
 async function createTaskSession(env: Env, run: EvalRunRecord, task: EvalTaskResult): Promise<string> {
   const t = run.tenant_id;
-  const services = getServices(env);
+  const services = await getServices(env, t);
   const agentRow = await services.agents.get({ tenantId: t, agentId: run.agent_id });
   if (!agentRow) throw new Error(`agent ${run.agent_id} not found`);
   const { tenant_id: _atid, ...agentSnapshot } = agentRow;
@@ -153,7 +159,7 @@ async function createTaskSession(env: Env, run: EvalRunRecord, task: EvalTaskRes
 
   // Allocate the session row first (id comes from the store), then init the
   // sandbox with that id. Single D1 INSERT replaces the legacy KV.put.
-  const { session } = await getServices(env).sessions.create({
+  const { session } = await services.sessions.create({
     tenantId: t,
     agentId: run.agent_id,
     environmentId: run.environment_id,
@@ -200,7 +206,8 @@ async function getSessionStatus(env: Env, run: EvalRunRecord, sessionId: string)
 
 async function buildAndStoreTrajectory(env: Env, run: EvalRunRecord, sessionId: string): Promise<string> {
   const t = run.tenant_id;
-  const sessionRow = await getServices(env).sessions.get({ tenantId: t, sessionId });
+  const services = await getServices(env, t);
+  const sessionRow = await services.sessions.get({ tenantId: t, sessionId });
   if (!sessionRow) throw new Error(`session ${sessionId} not found`);
   const session = {
     id: sessionRow.id,
@@ -387,7 +394,11 @@ async function advanceRun(env: Env, run: EvalRunRecord): Promise<void> {
 // ---------- Public entry point (called by scheduled handler) ----------
 
 export async function tickEvalRuns(env: Env): Promise<{ advanced: number; total: number }> {
-  const services = getServices(env);
+  // Cross-tenant scan: list every active eval run across all tenants. Phase 1
+  // default returns the shared AUTH_DB so this still works against the
+  // legacy single DB. Phase 4 will need a control-plane index over tenants
+  // since per-tenant DBs make cross-tenant SELECTs impossible from one binding.
+  const services = buildCfServices(env, env.AUTH_DB);
   const activeRows = await services.evals.listActive();
   let advanced = 0;
   for (const row of activeRows) {

--- a/apps/main/src/index.ts
+++ b/apps/main/src/index.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import type { Env } from "@open-managed-agents/shared";
-import { servicesMiddleware } from "@open-managed-agents/services";
+import { servicesMiddleware, tenantDbMiddleware } from "@open-managed-agents/services";
 import { authMiddleware } from "./auth";
 import { rateLimitMiddleware } from "./rate-limit";
 import agentsRoutes from "./routes/agents";
@@ -51,6 +51,10 @@ app.get("/auth-info", (c) => {
 // API routes (require authentication)
 app.use("/v1/*", authMiddleware);
 app.use("/v1/*", rateLimitMiddleware);
+// Resolve the per-tenant D1 database for this request. Phase 1: returns the
+// shared AUTH_DB for every tenant (zero behaviour change). Phase 4: routes
+// to per-tenant bindings published by the CICD sync script.
+app.use("/v1/*", tenantDbMiddleware);
 // Build the platform-agnostic service container once per request and stash it
 // on c.var.services. Wiring (CF / Postgres / SQLite) lives in
 // packages/services — routes only see the abstract Services interface.

--- a/apps/main/src/routes/integrations.ts
+++ b/apps/main/src/routes/integrations.ts
@@ -45,7 +45,7 @@ function reposOr503(c: { env: Env; json: (b: unknown, s?: number) => Response })
   if (typeof k !== "string" || !k) {
     return { repos: null, err: c.json({ error: "MCP_SIGNING_KEY not configured" }, 503) as Response };
   }
-  return { repos: buildCfRepos({ AUTH_DB: c.env.AUTH_DB, MCP_SIGNING_KEY: k }), err: null };
+  return { repos: buildCfRepos({ db: c.env.AUTH_DB, controlPlaneDb: c.env.AUTH_DB, MCP_SIGNING_KEY: k }), err: null };
 }
 
 // ─── GET /v1/integrations/linear/installations ───────────────────────────

--- a/apps/main/src/routes/sessions.ts
+++ b/apps/main/src/routes/sessions.ts
@@ -5,7 +5,7 @@ import type { SessionMeta, UserMessageEvent, AgentConfig, EnvironmentConfig, Sto
 import { generateFileId, buildTrajectory, fileR2Key } from "@open-managed-agents/shared";
 import type { SessionRecord, FullStatus } from "@open-managed-agents/shared";
 import type { Services } from "@open-managed-agents/services";
-import { buildCfServices } from "@open-managed-agents/services";
+import { getCfServicesForTenant } from "@open-managed-agents/services";
 import { toFileRecord } from "@open-managed-agents/files-store";
 import { toEnvironmentConfig } from "@open-managed-agents/environments-store";
 import {
@@ -50,7 +50,8 @@ async function getSandboxBinding(
   environmentId: string,
   tenantId: string,
 ): Promise<{ binding: Fetcher | null; error?: string; status?: 404 | 500 | 503 }> {
-  const envRow = await buildCfServices(env).environments.get({ tenantId, environmentId });
+  const services = await getCfServicesForTenant(env, tenantId);
+  const envRow = await services.environments.get({ tenantId, environmentId });
   if (!envRow) return { binding: null, error: "Environment not found", status: 404 };
 
   const envConfig = toEnvironmentConfig(envRow);

--- a/packages/agents-store/src/adapters/index.ts
+++ b/packages/agents-store/src/adapters/index.ts
@@ -9,11 +9,11 @@ import type { Logger } from "../ports";
 import { AgentService } from "../service";
 
 export function createCfAgentService(
-  env: { AUTH_DB: D1Database },
+  deps: { db: D1Database },
   opts?: { logger?: Logger },
 ): AgentService {
   return new AgentService({
-    repo: new D1AgentRepo(env.AUTH_DB),
+    repo: new D1AgentRepo(deps.db),
     logger: opts?.logger,
   });
 }

--- a/packages/credentials-store/src/adapters/index.ts
+++ b/packages/credentials-store/src/adapters/index.ts
@@ -9,11 +9,11 @@ import type { Logger } from "../ports";
 import { CredentialService } from "../service";
 
 export function createCfCredentialService(
-  env: { AUTH_DB: D1Database },
+  deps: { db: D1Database },
   opts?: { logger?: Logger },
 ): CredentialService {
   return new CredentialService({
-    repo: new D1CredentialRepo(env.AUTH_DB),
+    repo: new D1CredentialRepo(deps.db),
     logger: opts?.logger,
   });
 }

--- a/packages/environments-store/src/adapters/index.ts
+++ b/packages/environments-store/src/adapters/index.ts
@@ -7,11 +7,11 @@ import type { Logger } from "../ports";
 import { EnvironmentService } from "../service";
 
 export function createCfEnvironmentService(
-  env: { AUTH_DB: D1Database },
+  deps: { db: D1Database },
   opts?: { logger?: Logger },
 ): EnvironmentService {
   return new EnvironmentService({
-    repo: new D1EnvironmentRepo(env.AUTH_DB),
+    repo: new D1EnvironmentRepo(deps.db),
     logger: opts?.logger,
   });
 }

--- a/packages/evals-store/src/adapters/index.ts
+++ b/packages/evals-store/src/adapters/index.ts
@@ -9,11 +9,11 @@ import type { Logger } from "../ports";
 import { EvalRunService } from "../service";
 
 export function createCfEvalRunService(
-  env: { AUTH_DB: D1Database },
+  deps: { db: D1Database },
   opts?: { logger?: Logger },
 ): EvalRunService {
   return new EvalRunService({
-    repo: new D1EvalRunRepo(env.AUTH_DB),
+    repo: new D1EvalRunRepo(deps.db),
     logger: opts?.logger,
   });
 }

--- a/packages/files-store/src/adapters/index.ts
+++ b/packages/files-store/src/adapters/index.ts
@@ -9,11 +9,11 @@ import type { Logger } from "../ports";
 import { FileService } from "../service";
 
 export function createCfFileService(
-  env: { AUTH_DB: D1Database },
+  deps: { db: D1Database },
   opts?: { logger?: Logger },
 ): FileService {
   return new FileService({
-    repo: new D1FileRepo(env.AUTH_DB),
+    repo: new D1FileRepo(deps.db),
     logger: opts?.logger,
   });
 }

--- a/packages/github/src/provider.ts
+++ b/packages/github/src/provider.ts
@@ -208,9 +208,12 @@ export class GitHubProvider implements IntegrationProvider {
     }
 
     // Upsert keyed on appOmaId so a re-submit (page refresh) doesn't create
-    // a second row with a different id.
+    // a second row with a different id. tenant_id is required at write time
+    // so the row can be mechanically routed to a per-tenant DB later.
+    const tenantId = await this.container.tenants.resolveByUserId(form.userId);
     const app = await this.container.githubApps.insert({
       id: form.appOmaId,
+      tenantId,
       publicationId: null,
       appId,
       appSlug: appInfo.slug,
@@ -302,7 +305,9 @@ export class GitHubProvider implements IntegrationProvider {
 
     const installDetail = await this.api.getInstallation(appJwt, installationId);
 
+    const tenantId = await this.container.tenants.resolveByUserId(state.userId);
     const installation = await this.container.installations.insert({
+      tenantId,
       userId: state.userId,
       providerId: PROVIDER_ID,
       // For GitHub the installation id is the stable workspace handle (orgs
@@ -350,6 +355,7 @@ export class GitHubProvider implements IntegrationProvider {
     await this.container.installations.setVaultId(installation.id, vaultId);
 
     const publication = await this.container.publications.insert({
+      tenantId,
       userId: state.userId,
       agentId: state.agentId,
       installationId: installation.id,
@@ -502,8 +508,10 @@ export class GitHubProvider implements IntegrationProvider {
 
     // Persist as a github_apps row keyed on the OMA-internal appOmaId we
     // pre-allocated at form-token time. Same upsert path as manual submit.
+    const tenantId = await this.container.tenants.resolveByUserId(state.userId);
     const app = await this.container.githubApps.insert({
       id: state.appOmaId,
+      tenantId,
       publicationId: null,
       appId: String(result.id),
       appSlug: result.slug,
@@ -624,6 +632,7 @@ export class GitHubProvider implements IntegrationProvider {
     // Idempotency: refuse to dispatch the same delivery twice.
     const fresh = await this.container.webhookEvents.recordIfNew(
       req.deliveryId,
+      app.tenantId, // Phase 0: nullable until backfill of pre-existing rows
       app.publicationId, // stash publicationId here for traceability
       req.headers["x-github-event"] ?? "unknown",
       this.container.clock.nowMs(),
@@ -756,6 +765,7 @@ export class GitHubProvider implements IntegrationProvider {
         initialEvent: sessionEvent,
       });
       await this.container.issueSessions.insert({
+        tenantId: publication.tenantId, // inherits from the publication
         publicationId: publication.id,
         issueId: issueKey,
         sessionId: created.sessionId,

--- a/packages/integrations-adapters-cf/src/cf-container.ts
+++ b/packages/integrations-adapters-cf/src/cf-container.ts
@@ -29,13 +29,19 @@ import { D1InstallationRepo } from "./d1/installation-repo";
 import { D1IssueSessionRepo } from "./d1/issue-session-repo";
 import { D1PublicationRepo } from "./d1/publication-repo";
 import { D1SetupLinkRepo } from "./d1/setup-link-repo";
+import { D1TenantResolver } from "./d1/tenant-resolver";
 import { D1WebhookEventStore } from "./d1/webhook-event-store";
 import { ServiceBindingSessionCreator } from "./service-binding-session-creator";
 import { ServiceBindingVaultManager } from "./service-binding-vault-manager";
 
 /** Env subset needed by buildCfRepos. */
 export interface CfReposEnv {
-  AUTH_DB: D1Database;
+  /** Per-tenant D1 database, resolved by the caller via TenantDbProvider.
+   *  In Phase 1 this is always env.AUTH_DB. */
+  db: D1Database;
+  /** Control-plane DB for cross-tenant lookups (TenantResolver). Always
+   *  env.AUTH_DB regardless of per-tenant routing. */
+  controlPlaneDb: D1Database;
   MCP_SIGNING_KEY: string;
 }
 
@@ -62,14 +68,18 @@ export function buildCfRepos(env: CfReposEnv) {
   const hmac = new WebCryptoHmacVerifier();
   const jwt = new WebCryptoJwtSigner(env.MCP_SIGNING_KEY);
   const http = new WorkerHttpClient();
-  const installations = new D1InstallationRepo(env.AUTH_DB, cryptoImpl, ids);
-  const publications = new D1PublicationRepo(env.AUTH_DB, ids);
-  const apps = new D1AppRepo(env.AUTH_DB, cryptoImpl, ids);
-  const githubApps = new D1GitHubAppRepo(env.AUTH_DB, cryptoImpl, ids);
-  const webhookEvents = new D1WebhookEventStore(env.AUTH_DB);
-  const issueSessions = new D1IssueSessionRepo(env.AUTH_DB);
-  const authoredComments = new D1AuthoredCommentRepo(env.AUTH_DB);
-  const setupLinks = new D1SetupLinkRepo(env.AUTH_DB, ids);
+  // TenantResolver always queries control-plane (better-auth `user` table) —
+  // it must work without per-tenant routing being decided yet (e.g. install
+  // callbacks know userId before they know tenantId).
+  const tenants = new D1TenantResolver(env.controlPlaneDb);
+  const installations = new D1InstallationRepo(env.db, cryptoImpl, ids);
+  const publications = new D1PublicationRepo(env.db, ids);
+  const apps = new D1AppRepo(env.db, cryptoImpl, ids);
+  const githubApps = new D1GitHubAppRepo(env.db, cryptoImpl, ids);
+  const webhookEvents = new D1WebhookEventStore(env.db);
+  const issueSessions = new D1IssueSessionRepo(env.db);
+  const authoredComments = new D1AuthoredCommentRepo(env.db);
+  const setupLinks = new D1SetupLinkRepo(env.db, ids);
 
   return {
     clock,
@@ -78,6 +88,7 @@ export function buildCfRepos(env: CfReposEnv) {
     hmac,
     jwt,
     http,
+    tenants,
     installations,
     publications,
     apps,

--- a/packages/integrations-adapters-cf/src/d1/app-repo.ts
+++ b/packages/integrations-adapters-cf/src/d1/app-repo.ts
@@ -8,6 +8,7 @@ import type {
 
 interface Row {
   id: string;
+  tenant_id: string;
   publication_id: string | null;
   client_id: string;
   client_secret_cipher: string;
@@ -65,22 +66,24 @@ export class D1AppRepo implements AppRepo {
     // for the same App in the publish wizard), refresh the credentials in
     // place rather than failing on PRIMARY KEY conflict. created_at and
     // publication_id are preserved (publication_id is set later via
-    // setPublicationId, after OAuth completes).
+    // setPublicationId, after OAuth completes). tenant_id is also preserved
+    // on conflict — re-submits should not silently re-tenant a row.
     await this.db
       .prepare(
         `INSERT INTO linear_apps (
-           id, publication_id, client_id, client_secret_cipher,
+           id, tenant_id, publication_id, client_id, client_secret_cipher,
            webhook_secret_cipher, created_at
-         ) VALUES (?, ?, ?, ?, ?, ?)
+         ) VALUES (?, ?, ?, ?, ?, ?, ?)
          ON CONFLICT(id) DO UPDATE SET
            client_id = excluded.client_id,
            client_secret_cipher = excluded.client_secret_cipher,
            webhook_secret_cipher = excluded.webhook_secret_cipher`,
       )
-      .bind(id, row.publicationId, row.clientId, clientSecretCipher, webhookSecretCipher, now)
+      .bind(id, row.tenantId, row.publicationId, row.clientId, clientSecretCipher, webhookSecretCipher, now)
       .run();
     return {
       id,
+      tenantId: row.tenantId,
       publicationId: row.publicationId,
       clientId: row.clientId,
       clientSecretCipher,
@@ -103,6 +106,7 @@ export class D1AppRepo implements AppRepo {
   private toDomain(row: Row): AppCredentials {
     return {
       id: row.id,
+      tenantId: row.tenant_id,
       publicationId: row.publication_id,
       clientId: row.client_id,
       clientSecretCipher: row.client_secret_cipher,

--- a/packages/integrations-adapters-cf/src/d1/authored-comment-repo.ts
+++ b/packages/integrations-adapters-cf/src/d1/authored-comment-repo.ts
@@ -2,6 +2,7 @@ import type { AuthoredComment, AuthoredCommentRepo } from "@open-managed-agents/
 
 interface Row {
   comment_id: string;
+  tenant_id: string;
   oma_session_id: string;
   issue_id: string;
   created_at: number;
@@ -22,16 +23,17 @@ export class D1AuthoredCommentRepo implements AuthoredCommentRepo {
     await this.db
       .prepare(
         `INSERT OR REPLACE INTO linear_authored_comments
-           (comment_id, oma_session_id, issue_id, created_at)
-         VALUES (?, ?, ?, ?)`,
+           (comment_id, tenant_id, oma_session_id, issue_id, created_at)
+         VALUES (?, ?, ?, ?, ?)`,
       )
-      .bind(row.commentId, row.omaSessionId, row.issueId, row.createdAt)
+      .bind(row.commentId, row.tenantId, row.omaSessionId, row.issueId, row.createdAt)
       .run();
   }
 
   private toDomain(row: Row): AuthoredComment {
     return {
       commentId: row.comment_id,
+      tenantId: row.tenant_id,
       omaSessionId: row.oma_session_id,
       issueId: row.issue_id,
       createdAt: row.created_at,

--- a/packages/integrations-adapters-cf/src/d1/github-app-repo.ts
+++ b/packages/integrations-adapters-cf/src/d1/github-app-repo.ts
@@ -8,6 +8,7 @@ import type {
 
 interface Row {
   id: string;
+  tenant_id: string;
   publication_id: string | null;
   app_id: string;
   app_slug: string;
@@ -86,15 +87,15 @@ export class D1GitHubAppRepo implements GitHubAppRepo {
     const privateKeyCipher = await this.crypto.encrypt(row.privateKey);
     // Upsert: a re-submit of the publish form (e.g. user pasted wrong key,
     // tries again with the same formToken) refreshes credentials in place
-    // rather than failing on PRIMARY KEY conflict. publication_id and
-    // created_at are preserved.
+    // rather than failing on PRIMARY KEY conflict. publication_id, tenant_id
+    // and created_at are preserved.
     await this.db
       .prepare(
         `INSERT INTO github_apps (
-           id, publication_id, app_id, app_slug, bot_login,
+           id, tenant_id, publication_id, app_id, app_slug, bot_login,
            client_id, client_secret_cipher, webhook_secret_cipher,
            private_key_cipher, created_at
-         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
          ON CONFLICT(id) DO UPDATE SET
            app_id = excluded.app_id,
            app_slug = excluded.app_slug,
@@ -106,6 +107,7 @@ export class D1GitHubAppRepo implements GitHubAppRepo {
       )
       .bind(
         id,
+        row.tenantId,
         row.publicationId,
         row.appId,
         row.appSlug,
@@ -119,6 +121,7 @@ export class D1GitHubAppRepo implements GitHubAppRepo {
       .run();
     return {
       id,
+      tenantId: row.tenantId,
       publicationId: row.publicationId,
       appId: row.appId,
       appSlug: row.appSlug,
@@ -145,6 +148,7 @@ export class D1GitHubAppRepo implements GitHubAppRepo {
   private toDomain(row: Row): GitHubAppCredentials {
     return {
       id: row.id,
+      tenantId: row.tenant_id,
       publicationId: row.publication_id,
       appId: row.app_id,
       appSlug: row.app_slug,

--- a/packages/integrations-adapters-cf/src/d1/installation-repo.ts
+++ b/packages/integrations-adapters-cf/src/d1/installation-repo.ts
@@ -11,6 +11,7 @@ import type {
 
 interface Row {
   id: string;
+  tenant_id: string;
   user_id: string;
   provider_id: string;
   workspace_id: string;
@@ -135,13 +136,14 @@ export class D1InstallationRepo implements InstallationRepo {
     await this.db
       .prepare(
         `INSERT INTO linear_installations (
-           id, user_id, provider_id, workspace_id, workspace_name,
+           id, tenant_id, user_id, provider_id, workspace_id, workspace_name,
            install_kind, app_id, access_token_cipher, refresh_token_cipher,
            scopes, bot_user_id, created_at, revoked_at
-         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)`,
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)`,
       )
       .bind(
         id,
+        row.tenantId,
         row.userId,
         row.providerId,
         row.workspaceId,
@@ -157,6 +159,7 @@ export class D1InstallationRepo implements InstallationRepo {
       .run();
     return {
       id,
+      tenantId: row.tenantId,
       userId: row.userId,
       providerId: row.providerId,
       workspaceId: row.workspaceId,
@@ -188,6 +191,7 @@ export class D1InstallationRepo implements InstallationRepo {
   private toDomain(row: Row): Installation {
     return {
       id: row.id,
+      tenantId: row.tenant_id,
       userId: row.user_id,
       providerId: row.provider_id as ProviderId,
       workspaceId: row.workspace_id,

--- a/packages/integrations-adapters-cf/src/d1/issue-session-repo.ts
+++ b/packages/integrations-adapters-cf/src/d1/issue-session-repo.ts
@@ -5,6 +5,7 @@ import type {
 } from "@open-managed-agents/integrations-core";
 
 interface Row {
+  tenant_id: string;
   publication_id: string;
   issue_id: string;
   session_id: string;
@@ -32,17 +33,19 @@ export class D1IssueSessionRepo implements IssueSessionRepo {
     // a prior delegation still occupies (publication_id, issue_id), which
     // is the natural state between the previous session ending and this
     // webhook arriving. excluded.* is SQLite syntax for the new VALUES.
+    // tenant_id is preserved on conflict — re-delegations within the same
+    // publication can never change tenant.
     await this.db
       .prepare(
         `INSERT INTO linear_issue_sessions
-           (publication_id, issue_id, session_id, status, created_at)
-         VALUES (?, ?, ?, ?, ?)
+           (tenant_id, publication_id, issue_id, session_id, status, created_at)
+         VALUES (?, ?, ?, ?, ?, ?)
          ON CONFLICT(publication_id, issue_id) DO UPDATE SET
            session_id = excluded.session_id,
            status     = excluded.status,
            created_at = excluded.created_at`,
       )
-      .bind(row.publicationId, row.issueId, row.sessionId, row.status, row.createdAt)
+      .bind(row.tenantId, row.publicationId, row.issueId, row.sessionId, row.status, row.createdAt)
       .run();
   }
 
@@ -73,6 +76,7 @@ export class D1IssueSessionRepo implements IssueSessionRepo {
 
   private toDomain(row: Row): IssueSession {
     return {
+      tenantId: row.tenant_id,
       publicationId: row.publication_id,
       issueId: row.issue_id,
       sessionId: row.session_id,

--- a/packages/integrations-adapters-cf/src/d1/publication-repo.ts
+++ b/packages/integrations-adapters-cf/src/d1/publication-repo.ts
@@ -13,6 +13,7 @@ import type {
 
 interface Row {
   id: string;
+  tenant_id: string;
   user_id: string;
   agent_id: string;
   installation_id: string;
@@ -72,13 +73,14 @@ export class D1PublicationRepo implements PublicationRepo {
     await this.db
       .prepare(
         `INSERT INTO linear_publications (
-           id, user_id, agent_id, installation_id, environment_id, mode, status,
+           id, tenant_id, user_id, agent_id, installation_id, environment_id, mode, status,
            persona_name, persona_avatar_url, capabilities,
            session_granularity, created_at, unpublished_at
-         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)`,
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)`,
       )
       .bind(
         id,
+        row.tenantId,
         row.userId,
         row.agentId,
         row.installationId,
@@ -95,6 +97,7 @@ export class D1PublicationRepo implements PublicationRepo {
       .run();
     return {
       id,
+      tenantId: row.tenantId,
       userId: row.userId,
       agentId: row.agentId,
       installationId: row.installationId,
@@ -147,6 +150,7 @@ export class D1PublicationRepo implements PublicationRepo {
     const caps = JSON.parse(row.capabilities) as CapabilityKey[];
     return {
       id: row.id,
+      tenantId: row.tenant_id,
       userId: row.user_id,
       agentId: row.agent_id,
       installationId: row.installation_id,

--- a/packages/integrations-adapters-cf/src/d1/setup-link-repo.ts
+++ b/packages/integrations-adapters-cf/src/d1/setup-link-repo.ts
@@ -7,6 +7,7 @@ import type {
 
 interface Row {
   token: string;
+  tenant_id: string;
   publication_id: string;
   created_by: string;
   expires_at: number;
@@ -34,13 +35,14 @@ export class D1SetupLinkRepo implements SetupLinkRepo {
     await this.db
       .prepare(
         `INSERT INTO linear_setup_links
-           (token, publication_id, created_by, expires_at, used_at, used_by_email)
-         VALUES (?, ?, ?, ?, NULL, NULL)`,
+           (token, tenant_id, publication_id, created_by, expires_at, used_at, used_by_email)
+         VALUES (?, ?, ?, ?, ?, NULL, NULL)`,
       )
-      .bind(token, row.publicationId, row.createdBy, row.expiresAt)
+      .bind(token, row.tenantId, row.publicationId, row.createdBy, row.expiresAt)
       .run();
     return {
       token,
+      tenantId: row.tenantId,
       publicationId: row.publicationId,
       createdBy: row.createdBy,
       expiresAt: row.expiresAt,
@@ -69,6 +71,7 @@ export class D1SetupLinkRepo implements SetupLinkRepo {
   private toDomain(row: Row): SetupLink {
     return {
       token: row.token,
+      tenantId: row.tenant_id,
       publicationId: row.publication_id,
       createdBy: row.created_by,
       expiresAt: row.expires_at,

--- a/packages/integrations-adapters-cf/src/d1/tenant-resolver.ts
+++ b/packages/integrations-adapters-cf/src/d1/tenant-resolver.ts
@@ -1,0 +1,31 @@
+import type { TenantResolver } from "@open-managed-agents/integrations-core";
+
+/**
+ * D1 implementation of TenantResolver. Reads `user.tenantId` from the
+ * better-auth control-plane table to resolve the OMA tenant for a given user.
+ *
+ * Throws when the user has no tenant — that's an integrity violation
+ * (auth-config.ts ensureTenant guarantees every user gets one on sign-up,
+ * and the cookie middleware in apps/main/src/auth.ts self-heals legacy
+ * users on first request). Silently inserting a row with an empty tenantId
+ * would defeat the point of the column.
+ */
+export class D1TenantResolver implements TenantResolver {
+  constructor(private readonly db: D1Database) {}
+
+  async resolveByUserId(userId: string): Promise<string> {
+    const row = await this.db
+      .prepare(`SELECT "tenantId" FROM "user" WHERE id = ?`)
+      .bind(userId)
+      .first<{ tenantId: string | null }>();
+    if (!row) {
+      throw new Error(`TenantResolver: no user found for userId=${userId}`);
+    }
+    if (!row.tenantId) {
+      throw new Error(
+        `TenantResolver: user ${userId} has no tenantId — fix the row before retrying`,
+      );
+    }
+    return row.tenantId;
+  }
+}

--- a/packages/integrations-adapters-cf/src/d1/webhook-event-store.ts
+++ b/packages/integrations-adapters-cf/src/d1/webhook-event-store.ts
@@ -10,6 +10,7 @@ export class D1WebhookEventStore implements WebhookEventStore {
    */
   async recordIfNew(
     deliveryId: string,
+    tenantId: string,
     installationId: string,
     eventType: string,
     receivedAt: number,
@@ -17,10 +18,10 @@ export class D1WebhookEventStore implements WebhookEventStore {
     const result = await this.db
       .prepare(
         `INSERT OR IGNORE INTO linear_webhook_events
-           (delivery_id, installation_id, event_type, received_at)
-         VALUES (?, ?, ?, ?)`,
+           (delivery_id, tenant_id, installation_id, event_type, received_at)
+         VALUES (?, ?, ?, ?, ?)`,
       )
-      .bind(deliveryId, installationId, eventType, receivedAt)
+      .bind(deliveryId, tenantId, installationId, eventType, receivedAt)
       .run();
     // D1 returns meta.changes for INSERT OR IGNORE; 0 means duplicate.
     return (result.meta?.changes ?? 0) > 0;

--- a/packages/integrations-adapters-cf/src/index.ts
+++ b/packages/integrations-adapters-cf/src/index.ts
@@ -21,6 +21,7 @@ export { D1WebhookEventStore } from "./d1/webhook-event-store";
 export { D1IssueSessionRepo } from "./d1/issue-session-repo";
 export { D1AuthoredCommentRepo } from "./d1/authored-comment-repo";
 export { D1SetupLinkRepo } from "./d1/setup-link-repo";
+export { D1TenantResolver } from "./d1/tenant-resolver";
 export { ServiceBindingSessionCreator } from "./service-binding-session-creator";
 export type { ServiceBindingSessionCreatorOptions } from "./service-binding-session-creator";
 export { ServiceBindingVaultManager } from "./service-binding-vault-manager";

--- a/packages/integrations-core/src/domain.ts
+++ b/packages/integrations-core/src/domain.ts
@@ -92,6 +92,9 @@ export type SessionGranularity = "per_issue" | "per_event";
 
 export interface Installation {
   id: string;
+  /** OMA tenant that owns this installation. NOT NULL in storage; backfilled
+   *  from user.tenantId for legacy rows in migration 0002. */
+  tenantId: string;
   userId: UserId;
   providerId: ProviderId;
   workspaceId: WorkspaceId;
@@ -114,6 +117,8 @@ export interface Installation {
 
 export interface Publication {
   id: string;
+  /** OMA tenant that owns this publication. NOT NULL in storage. */
+  tenantId: string;
   userId: UserId;
   agentId: AgentId;
   installationId: string;
@@ -133,6 +138,8 @@ export interface Publication {
 
 export interface AppCredentials {
   id: string;
+  /** OMA tenant that owns these App credentials. NOT NULL in storage. */
+  tenantId: string;
   /** Set only after the related publication has been materialized. */
   publicationId: string | null;
   /** OAuth client id from the provider's developer portal. */
@@ -161,6 +168,8 @@ export interface AppCredentials {
  */
 export interface GitHubAppCredentials {
   id: string;
+  /** OMA tenant that owns these App credentials. NOT NULL in storage. */
+  tenantId: string;
   publicationId: string | null;
   appId: string;
   appSlug: string;
@@ -173,6 +182,8 @@ export interface GitHubAppCredentials {
 }
 
 export interface IssueSession {
+  /** OMA tenant that owns this issue-session row. NOT NULL in storage. */
+  tenantId: string;
   publicationId: string;
   /** Provider-native issue id. */
   issueId: string;
@@ -183,6 +194,8 @@ export interface IssueSession {
 
 export interface SetupLink {
   token: string;
+  /** OMA tenant that owns this setup link. NOT NULL in storage. */
+  tenantId: string;
   publicationId: string;
   createdBy: UserId;
   expiresAt: number;

--- a/packages/integrations-core/src/persistence.ts
+++ b/packages/integrations-core/src/persistence.ts
@@ -28,6 +28,8 @@ import type {
 } from "./domain";
 
 export interface NewInstallation {
+  /** OMA tenant that owns this installation. NOT NULL in storage. */
+  tenantId: string;
   userId: UserId;
   providerId: ProviderId;
   workspaceId: WorkspaceId;
@@ -75,6 +77,8 @@ export interface InstallationRepo {
 }
 
 export interface NewPublication {
+  /** OMA tenant that owns this publication. See NewInstallation.tenantId. */
+  tenantId: string;
   userId: UserId;
   agentId: AgentId;
   installationId: string;
@@ -107,6 +111,8 @@ export interface NewAppCredentials {
    * credentials in place). When omitted, the repo generates a fresh id.
    */
   id?: string;
+  /** OMA tenant that owns these credentials. See NewInstallation.tenantId. */
+  tenantId: string;
   /** Null when registered ahead of the related publication (A1 install). */
   publicationId: string | null;
   clientId: string;
@@ -132,6 +138,8 @@ export interface AppRepo {
 export interface NewGitHubAppCredentials {
   /** Optional explicit id; insert behaves as upsert when provided. */
   id?: string;
+  /** OMA tenant that owns these credentials. See NewInstallation.tenantId. */
+  tenantId: string;
   publicationId: string | null;
   /** Numeric GitHub App id (string-typed so we don't truncate large ints). */
   appId: string;
@@ -165,9 +173,13 @@ export interface WebhookEventStore {
    * Atomically inserts the delivery id; returns true if it's new (caller should
    * proceed to dispatch), false if it's a duplicate (caller should return 200
    * immediately).
+   *
+   * `tenantId` is resolved by the caller from the related installation/App
+   * row. NOT NULL — the column is NOT NULL after migration 0002.
    */
   recordIfNew(
     deliveryId: string,
+    tenantId: string,
     installationId: string,
     eventType: string,
     receivedAt: number,
@@ -200,6 +212,9 @@ export interface IssueSessionRepo {
  */
 export interface AuthoredComment {
   commentId: string;
+  /** OMA tenant that owns the bot session this comment was authored from.
+   *  NOT NULL in storage; backfilled from sessions.tenant_id. */
+  tenantId: string;
   omaSessionId: string;
   issueId: string;
   createdAt: number;
@@ -211,6 +226,8 @@ export interface AuthoredCommentRepo {
 }
 
 export interface NewSetupLink {
+  /** OMA tenant that owns this setup link. See NewInstallation.tenantId. */
+  tenantId: string;
   publicationId: string;
   createdBy: UserId;
   expiresAt: number;

--- a/packages/integrations-core/src/ports.ts
+++ b/packages/integrations-core/src/ports.ts
@@ -31,6 +31,25 @@ export interface IdGenerator {
 }
 
 /**
+ * Resolves the OMA tenant id for a given OMA user. The integrations
+ * gateway needs this whenever it inserts a new installation/publication/App
+ * row so the row can carry tenant_id (Phase 0 of the per-tenant-D1 work).
+ *
+ * Implemented in adapters via a SELECT against the `user` table (which lives
+ * in the better-auth control-plane DB). Provider code calls this at install
+ * completion time, when only `state.userId` is known from the OAuth state JWT.
+ */
+export interface TenantResolver {
+  /**
+   * Returns the user's tenantId. Throws when the user has no tenant — that's
+   * an integrity violation (every user should have a tenant after sign-up,
+   * see auth-config.ts ensureTenant), and silently inserting a row with
+   * tenantId="" would defeat the point of this column.
+   */
+  resolveByUserId(userId: UserId): Promise<string>;
+}
+
+/**
  * Symmetric encryption for tokens at rest. Output is opaque to callers — only
  * the same Crypto instance can decrypt what it produced.
  */
@@ -234,6 +253,9 @@ export interface Container {
   hmac: HmacVerifier;
   jwt: JwtSigner;
   http: HttpClient;
+  /** Maps OMA userId → tenantId. Used by providers to populate tenant_id on
+   *  newly inserted installations/publications/Apps (Phase 0 of per-tenant-D1). */
+  tenants: TenantResolver;
   sessions: SessionCreator;
   vaults: VaultManager;
   installations: InstallationRepo;

--- a/packages/integrations-core/src/test-fakes.ts
+++ b/packages/integrations-core/src/test-fakes.ts
@@ -48,6 +48,7 @@ import type {
   SessionId,
   SetupLink,
   SetupLinkRepo,
+  TenantResolver,
   VaultManager,
   WebhookEventStore,
   WorkspaceId,
@@ -273,6 +274,7 @@ export class InMemoryInstallationRepo implements InstallationRepo {
     const id = `inst_${this.counter}`;
     const inst: Installation = {
       id,
+      tenantId: row.tenantId,
       userId: row.userId,
       providerId: row.providerId,
       workspaceId: row.workspaceId,
@@ -408,6 +410,8 @@ export class InMemoryAppRepo implements AppRepo {
     const existing = this.rows.get(id);
     const app: AppCredentials = {
       id,
+      // tenantId is preserved on upsert too — re-submits should not silently re-tenant.
+      tenantId: existing ? existing.tenantId : row.tenantId,
       // Preserve publicationId on upsert (only nulled by setPublicationId)
       publicationId: existing ? existing.publicationId : row.publicationId,
       clientId: row.clientId,
@@ -484,6 +488,7 @@ export class InMemoryGitHubAppRepo implements GitHubAppRepo {
     const existing = this.rows.get(id);
     const app: GitHubAppCredentials = {
       id,
+      tenantId: existing ? existing.tenantId : row.tenantId,
       publicationId: existing ? existing.publicationId : row.publicationId,
       appId: row.appId,
       appSlug: row.appSlug,
@@ -516,6 +521,7 @@ export class InMemoryGitHubAppRepo implements GitHubAppRepo {
 
 interface WebhookEventRow {
   deliveryId: string;
+  tenantId: string;
   installationId: string;
   eventType: string;
   receivedAt: number;
@@ -529,6 +535,7 @@ export class InMemoryWebhookEventStore implements WebhookEventStore {
 
   async recordIfNew(
     deliveryId: string,
+    tenantId: string,
     installationId: string,
     eventType: string,
     receivedAt: number,
@@ -536,6 +543,7 @@ export class InMemoryWebhookEventStore implements WebhookEventStore {
     if (this.rows.has(deliveryId)) return false;
     this.rows.set(deliveryId, {
       deliveryId,
+      tenantId,
       installationId,
       eventType,
       receivedAt,
@@ -617,6 +625,7 @@ export class InMemorySetupLinkRepo implements SetupLinkRepo {
     const token = `setup_${Math.random().toString(36).slice(2)}`;
     const link: SetupLink = {
       token,
+      tenantId: row.tenantId,
       publicationId: row.publicationId,
       createdBy: row.createdBy,
       expiresAt: row.expiresAt,
@@ -646,6 +655,29 @@ export class InMemorySetupLinkRepo implements SetupLinkRepo {
 
 // ─── Convenience: build a complete in-memory container ────────────────
 
+/**
+ * In-memory TenantResolver. Default behavior: when a userId hasn't been
+ * explicitly registered via `set(...)`, returns a derived `tn_for_<userId>`
+ * tenant id rather than throwing. This keeps existing tests that don't care
+ * about tenant routing working without modification — only tests that
+ * specifically exercise tenant scoping need to call `set(...)`.
+ *
+ * The strict-throw behavior is left to the D1 adapter (D1TenantResolver),
+ * which raises on missing rows because in production a missing tenant for a
+ * known user is an integrity violation.
+ */
+export class InMemoryTenantResolver implements TenantResolver {
+  private readonly mapping = new Map<string, string>();
+
+  set(userId: string, tenantId: string): void {
+    this.mapping.set(userId, tenantId);
+  }
+
+  async resolveByUserId(userId: string): Promise<string> {
+    return this.mapping.get(userId) ?? `tn_for_${userId}`;
+  }
+}
+
 export interface FakeContainer {
   clock: FakeClock;
   ids: FakeIdGenerator;
@@ -653,6 +685,7 @@ export interface FakeContainer {
   hmac: FakeHmacVerifier;
   jwt: FakeJwtSigner;
   http: FakeHttpClient;
+  tenants: InMemoryTenantResolver;
   sessions: FakeSessionCreator;
   vaults: FakeVaultManager;
   installations: InMemoryInstallationRepo;
@@ -674,6 +707,7 @@ export function buildFakeContainer(): FakeContainer {
     hmac: new FakeHmacVerifier(),
     jwt: new FakeJwtSigner(clock),
     http: new FakeHttpClient(),
+    tenants: new InMemoryTenantResolver(),
     sessions: new FakeSessionCreator(),
     vaults: new FakeVaultManager(),
     installations: new InMemoryInstallationRepo(clock),

--- a/packages/linear/src/provider.ts
+++ b/packages/linear/src/provider.ts
@@ -167,8 +167,10 @@ export class LinearProvider implements IntegrationProvider {
 
     // Upsert keyed on appId so a re-submit (page refresh, network retry)
     // doesn't create a second row with a different id.
+    const tenantId = await this.container.tenants.resolveByUserId(form.userId);
     const app = await this.container.apps.insert({
       id: form.appId,
+      tenantId,
       publicationId: null,
       clientId,
       clientSecret,
@@ -267,7 +269,9 @@ export class LinearProvider implements IntegrationProvider {
     const { viewer, organization } = await this.graphql.fetchViewerAndOrg(token.access_token);
 
     // A1 installs are always fresh — one App per agent per workspace, no reuse.
+    const tenantId = await this.container.tenants.resolveByUserId(state.userId);
     const installation = await this.container.installations.insert({
+      tenantId,
       userId: state.userId,
       providerId: PROVIDER_ID,
       workspaceId: organization.id,
@@ -292,6 +296,7 @@ export class LinearProvider implements IntegrationProvider {
 
     // Create publication and link App back to it.
     const publication = await this.container.publications.insert({
+      tenantId,
       userId: state.userId,
       agentId: state.agentId,
       installationId: installation.id,
@@ -398,6 +403,7 @@ export class LinearProvider implements IntegrationProvider {
     // aggressively on 5xx, so this gate matters.
     const fresh = await this.container.webhookEvents.recordIfNew(
       req.deliveryId,
+      installation.tenantId, // Phase 0: nullable until backfill of pre-existing rows
       installation.id,
       "unknown",
       this.container.clock.nowMs(),
@@ -560,6 +566,7 @@ export class LinearProvider implements IntegrationProvider {
         githubRepoUrl: PROD_GITHUB_REPO_URL,
       });
       await this.container.issueSessions.insert({
+        tenantId: publication.tenantId,
         publicationId: publication.id,
         issueId: event.issueId,
         sessionId: created.sessionId,

--- a/packages/memory-store/src/adapters/index.ts
+++ b/packages/memory-store/src/adapters/index.ts
@@ -26,17 +26,17 @@ import type { Logger } from "../ports";
  * NULL forever; nothing to reconcile against). Production deployments MUST
  * bind both for semantic search to function.
  */
-export function createCfMemoryStoreService(env: {
-  AUTH_DB: D1Database;
-  AI?: Ai;
-  VECTORIZE?: VectorizeIndex;
+export function createCfMemoryStoreService(deps: {
+  db: D1Database;
+  ai?: Ai;
+  vectorize?: VectorizeIndex;
 }, opts?: { logger?: Logger }): MemoryStoreService {
   return new MemoryStoreService({
-    storeRepo: new D1MemoryStoreRepo(env.AUTH_DB),
-    memoryRepo: new D1MemoryRepo(env.AUTH_DB),
-    versionRepo: new D1MemoryVersionRepo(env.AUTH_DB),
-    embedding: env.AI ? new WorkersAiEmbeddingProvider(env.AI) : new NoopEmbeddingProvider(),
-    vectorIndex: env.VECTORIZE ? new CfVectorIndex(env.VECTORIZE) : new NoopVectorIndex(),
+    storeRepo: new D1MemoryStoreRepo(deps.db),
+    memoryRepo: new D1MemoryRepo(deps.db),
+    versionRepo: new D1MemoryVersionRepo(deps.db),
+    embedding: deps.ai ? new WorkersAiEmbeddingProvider(deps.ai) : new NoopEmbeddingProvider(),
+    vectorIndex: deps.vectorize ? new CfVectorIndex(deps.vectorize) : new NoopVectorIndex(),
     logger: opts?.logger,
   });
 }

--- a/packages/model-cards-store/src/adapters/index.ts
+++ b/packages/model-cards-store/src/adapters/index.ts
@@ -9,11 +9,11 @@ import type { Crypto, Logger } from "../ports";
 import { ModelCardService } from "../service";
 
 export function createCfModelCardService(
-  env: { AUTH_DB: D1Database },
+  deps: { db: D1Database },
   opts?: { logger?: Logger; crypto?: Crypto },
 ): ModelCardService {
   return new ModelCardService({
-    repo: new D1ModelCardRepo(env.AUTH_DB),
+    repo: new D1ModelCardRepo(deps.db),
     logger: opts?.logger,
     crypto: opts?.crypto,
   });

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -19,6 +19,8 @@
     "@open-managed-agents/environments-store": "workspace:*",
     "@open-managed-agents/outbound-snapshots-store": "workspace:*",
     "@open-managed-agents/session-secrets-store": "workspace:*",
+    "@open-managed-agents/tenant-db": "workspace:*",
+    "@open-managed-agents/tenant-dbs-store": "workspace:*",
     "hono": "^4.7.0"
   }
 }

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -8,13 +8,22 @@
 //   - HTTP routes pick services off `c.var.services` (Hono request scope).
 //   - DO / outbound worker / cron / anything outside Hono builds its own
 //     instance via the same factory. Same `Services` type, no duplication.
-//   - Tests use `buildTestServices()` and inject mocks where needed.
+//   - Tests use a TenantDbProvider fake plus the same factory.
 //
 // Adding a new store:
 //   1. Add `<storeName>: <ServiceType>` to the `Services` interface
 //   2. Add construction call to each `buildXxxServices` (CF + future Node + tests)
 //   3. Consumers reference `c.var.services.<storeName>` (HTTP) or
 //      `services.<storeName>` (everywhere else). No import changes anywhere.
+//
+// Per-tenant DB routing (Phase 1+):
+//   - `buildCfServices(env, db)` takes a resolved D1Database — every adapter
+//     constructed inside reads/writes against that one DB.
+//   - The DB is resolved per-request by the new `tenantDbMiddleware`, which
+//     calls `TenantDbProvider.resolve(tenantId)` after authMiddleware sets
+//     `c.var.tenant_id`. Phase 1 default returns the shared `env.AUTH_DB`
+//     for every tenant — zero behaviour change. Phase 4 swaps in the
+//     static-binding resolver.
 //
 // The CFless escape hatch:
 //   - Today only `buildCfServices` exists.
@@ -69,6 +78,22 @@ import {
   SessionSecretService,
   createCfSessionSecretService,
 } from "@open-managed-agents/session-secrets-store";
+import {
+  CfSharedAuthDbProvider,
+  MetaTableTenantDbProvider,
+  type TenantDbProvider,
+} from "@open-managed-agents/tenant-db";
+import {
+  TenantShardDirectoryService,
+  ShardPoolService,
+  createCfTenantShardDirectoryService,
+  createCfShardPoolService,
+} from "@open-managed-agents/tenant-dbs-store";
+import { parseStoreBackends, pickBackend } from "./store-backends";
+
+export { parseStoreBackends, pickBackend } from "./store-backends";
+export type { StoreBackendName, BackendFactories } from "./store-backends";
+export { getPgPool } from "./pg-pool";
 
 /**
  * The platform-agnostic service surface. Every service the application uses
@@ -87,6 +112,13 @@ export interface Services {
   environments: EnvironmentService;
   outboundSnapshots: OutboundSnapshotService;
   sessionSecrets: SessionSecretService;
+  /** Control-plane: tenant_id → binding_name assignment. Hot-path read on
+   *  every authenticated request via MetaTableTenantDbProvider. Always
+   *  queries control-plane DB. */
+  tenantShardDirectory: TenantShardDirectoryService;
+  /** Control-plane: per-shard status / capacity / tenant count. Used for
+   *  shard selection at sign-up + capacity monitoring. */
+  shardPool: ShardPoolService;
 }
 
 /**
@@ -101,6 +133,8 @@ export interface AppContext {
   Bindings: Env;
   Variables: {
     services: Services;
+    /** Resolved per-tenant DB. Set by `tenantDbMiddleware` before routes run. */
+    tenantDb: D1Database;
   };
 }
 
@@ -113,6 +147,7 @@ export interface AppContextWithTenant {
   Bindings: Env;
   Variables: {
     services: Services;
+    tenantDb: D1Database;
     tenant_id: string;
     user_id?: string;
   };
@@ -124,22 +159,125 @@ export interface AppContextWithTenant {
 
 /**
  * Production / staging on Cloudflare Workers. Wires every service against
- * Cloudflare bindings (D1 today, possibly other CF primitives later).
+ * the resolved per-tenant D1 database. The TenantDbProvider middleware
+ * resolves the right DB for the current request before this factory runs.
+ *
+ * Per-store backend dispatch: each D1-backed store goes through `pickBackend`
+ * so its concrete adapter can be swapped to pg / memory / future backends
+ * via the `STORE_BACKENDS` env JSON without touching service or route code.
+ * Tenant routing is the storage provider's concern, NOT the service layer —
+ * the cf factory uses the per-tenant D1 binding, a pg factory could use
+ * row-level tenant_id filters or schema-per-tenant, etc.
+ *
+ * KV-backed services (outbound snapshots, session secrets) and control-plane
+ * services (tenant directory, installation index) are not dispatched today
+ * because they have a single sensible backend.
+ *
+ * To wire a new backend (e.g. pg) for a store:
+ *   1. Implement Pg<X>Repo + createPg<X>Service in packages/<store>-store
+ *   2. Uncomment / add the `pg: () => createPg<X>Service(...)` line in the
+ *      relevant pickBackend call below
+ *   3. Set STORE_BACKENDS={"<key>":"pg"} in the worker's env
  */
-export function buildCfServices(env: Env): Services {
+export function buildServices(env: Env, db: D1Database): Services {
+  const overrides = parseStoreBackends(env);
   return {
-    credentials: createCfCredentialService(env),
-    memory: createCfMemoryStoreService(env),
-    vaults: createCfVaultService(env),
-    sessions: createCfSessionService(env),
-    files: createCfFileService(env),
-    evals: createCfEvalRunService(env),
-    modelCards: createCfModelCardService(env),
-    agents: createCfAgentService(env),
-    environments: createCfEnvironmentService(env),
+    credentials: pickBackend(overrides, "credentials", {
+      cf: () => createCfCredentialService({ db }),
+      // pg: () => createPgCredentialService({ pg: getPgPool(env) }),
+    }),
+    memory: pickBackend(overrides, "memory", {
+      cf: () => createCfMemoryStoreService({ db, ai: env.AI, vectorize: env.VECTORIZE }),
+      // pg: () => createPgMemoryStoreService({ pg: getPgPool(env), ai: env.AI, vectorize: env.VECTORIZE }),
+    }),
+    vaults: pickBackend(overrides, "vaults", {
+      cf: () => createCfVaultService({ db }),
+      // pg: () => createPgVaultService({ pg: getPgPool(env) }),
+    }),
+    sessions: pickBackend(overrides, "sessions", {
+      cf: () => createCfSessionService({ db }),
+      // pg: () => createPgSessionService({ pg: getPgPool(env) }),
+    }),
+    files: pickBackend(overrides, "files", {
+      cf: () => createCfFileService({ db }),
+      // pg: () => createPgFileService({ pg: getPgPool(env) }),
+    }),
+    evals: pickBackend(overrides, "evals", {
+      cf: () => createCfEvalRunService({ db }),
+      // pg: () => createPgEvalRunService({ pg: getPgPool(env) }),
+    }),
+    modelCards: pickBackend(overrides, "modelCards", {
+      cf: () => createCfModelCardService({ db }),
+      // pg: () => createPgModelCardService({ pg: getPgPool(env) }),
+    }),
+    agents: pickBackend(overrides, "agents", {
+      cf: () => createCfAgentService({ db }),
+      // pg: () => createPgAgentService({ pg: getPgPool(env) }),
+    }),
+    environments: pickBackend(overrides, "environments", {
+      cf: () => createCfEnvironmentService({ db }),
+      // pg: () => createPgEnvironmentService({ pg: getPgPool(env) }),
+    }),
     outboundSnapshots: createCfOutboundSnapshotService(env),
     sessionSecrets: createCfSessionSecretService(env),
+    // Control-plane services: always query env.AUTH_DB, never the per-tenant db.
+    tenantShardDirectory: createCfTenantShardDirectoryService({ controlPlaneDb: env.AUTH_DB }),
+    shardPool: createCfShardPoolService({ controlPlaneDb: env.AUTH_DB }),
   };
+}
+
+/**
+ * Backwards-compat alias — old call sites still use `buildCfServices`. New
+ * code should prefer `buildServices` since the function is no longer
+ * Cloudflare-specific (a `pg` adapter, when wired, gets selected by env).
+ */
+export const buildCfServices = buildServices;
+
+/**
+ * Build the TenantDbProvider used by the middleware.
+ *
+ * Default (PER_TENANT_DB_ENABLED unset or "true"): the meta-table router
+ * that reads `tenant_shard` from the control-plane DB, with a permanent
+ * per-isolate cache and AUTH_DB fallback for tenants without a shard
+ * assignment. In N=1 deployments (no entries in tenant_shard) every tenant
+ * resolves to AUTH_DB → behaviour identical to the pre-sharding shared-DB
+ * world.
+ *
+ * Killswitch (PER_TENANT_DB_ENABLED="false"): bypasses the meta lookup
+ * entirely and returns AUTH_DB for every tenant. Use this to instantly roll
+ * back if the meta table itself develops a problem.
+ *
+ * Tests should construct their own StaticTenantDbProvider via
+ * @open-managed-agents/tenant-db/test-fakes and bypass this factory.
+ */
+export function buildCfTenantDbProvider(env: Env): TenantDbProvider {
+  const flag = (env as unknown as { PER_TENANT_DB_ENABLED?: string }).PER_TENANT_DB_ENABLED;
+  const disabled = flag === "false" || flag === "0";
+  if (disabled) {
+    return new CfSharedAuthDbProvider(env.AUTH_DB);
+  }
+  return new MetaTableTenantDbProvider(
+    env as unknown as Record<string, unknown>,
+    env.AUTH_DB,
+    env.AUTH_DB,
+  );
+}
+
+/**
+ * Async helper for non-Hono entry points (Durable Objects, cron, eval-runner,
+ * outbound worker). Resolves the per-tenant DB then builds the full Services
+ * container against it.
+ *
+ * Hono routes use `tenantDbMiddleware` + `servicesMiddleware` instead, so
+ * they don't need to call this directly.
+ */
+export async function getCfServicesForTenant(
+  env: Env,
+  tenantId: string,
+): Promise<Services> {
+  const provider = buildCfTenantDbProvider(env);
+  const db = await provider.resolve(tenantId);
+  return buildCfServices(env, db);
 }
 
 // Future:
@@ -160,15 +298,43 @@ export function buildCfServices(env: Env): Services {
 // ============================================================
 
 /**
+ * Resolve the per-tenant D1 binding for the current request and stash it on
+ * `c.var.tenantDb`. Mount AFTER the auth middleware (which sets
+ * `c.var.tenant_id`) and BEFORE `servicesMiddleware`.
+ *
+ *   app.use("*", authMiddleware);
+ *   app.use("*", tenantDbMiddleware);
+ *   app.use("*", servicesMiddleware);
+ *
+ * Routes that don't need the services container (e.g. /health, /auth/*)
+ * still get the resolved DB on `c.var.tenantDb` — cheap, async-light.
+ */
+export const tenantDbMiddleware: MiddlewareHandler<{
+  Bindings: Env;
+  Variables: { tenant_id?: string; tenantDb: D1Database };
+}> = async (c, next) => {
+  const provider = buildCfTenantDbProvider(c.env);
+  // Routes upstream of authMiddleware (e.g. /health, /auth/*) won't have
+  // tenant_id set; resolve("" ) returns the shared AUTH_DB under the Phase 1
+  // default, which is the right answer for those paths.
+  const tenantId = c.get("tenant_id") ?? "";
+  const tenantDb = await provider.resolve(tenantId);
+  c.set("tenantDb", tenantDb);
+  await next();
+};
+
+/**
  * Mount once at the top of the app. After this middleware runs every route
  * can read `c.var.services` to access the canonical service surface.
  *
  *   app.use("*", servicesMiddleware);
+ *
+ * Requires `c.var.tenantDb` to be set by `tenantDbMiddleware` first.
  */
 export const servicesMiddleware: MiddlewareHandler<AppContext> = async (
   c,
   next,
 ) => {
-  c.set("services", buildCfServices(c.env));
+  c.set("services", buildCfServices(c.env, c.var.tenantDb));
   await next();
 };

--- a/packages/services/src/pg-pool.ts
+++ b/packages/services/src/pg-pool.ts
@@ -1,0 +1,60 @@
+// Lazy Postgres pool helper. Initializes once per worker isolate (or Node
+// process) when the first pg-backed store is requested, then reuses the
+// connection pool for all subsequent calls.
+//
+// Today this is a Cloudflare-Workers-friendly stub — it constructs the pool
+// from the DATABASE_URL env var if the `postgres` driver is importable.
+// Concrete pg adapter packages (when added) call getPgPool(env) to receive
+// the pool and pass it into their PgXxxRepo constructors.
+//
+// Design notes:
+//   - Module-level cache. Invalidated by setting the env DATABASE_URL value
+//     differently between invocations would NOT clear it — restart the
+//     worker (redeploy) if you need to switch DSN.
+//   - Errors surface from the actual driver call when first used. We don't
+//     dial-test the connection on initialization; that's the pool's job.
+//   - On Cloudflare Workers, set up Hyperdrive and point DATABASE_URL at the
+//     hyperdrive connection string for production. Direct-to-Postgres works
+//     in local dev / Node deployments.
+//
+// The driver dependency is intentionally NOT pinned in this package's
+// package.json — the package compiles and runs without pg installed. Only
+// when a pg adapter is wired and an env actually requests pg does the
+// import resolve. To enable in your deployment: `pnpm add postgres -w`.
+
+import type { Env } from "@open-managed-agents/shared";
+
+// `unknown` so this module compiles without `postgres` installed. The cast
+// happens at the call site that actually uses the pool.
+let cached: unknown | null = null;
+let cachedDsn: string | null = null;
+
+/**
+ * Resolve a pg pool / sql client from env. Lazy: only imports the driver
+ * the first time a pg-backed store is actually constructed.
+ *
+ * Returns `unknown` deliberately — the concrete adapter package knows what
+ * driver shape it expects (postgres.js vs node-postgres) and casts.
+ */
+export async function getPgPool(env: Env): Promise<unknown> {
+  const dsn = (env as unknown as { DATABASE_URL?: string }).DATABASE_URL;
+  if (!dsn) {
+    throw new Error(
+      "getPgPool: DATABASE_URL is required when STORE_BACKENDS routes any store to pg",
+    );
+  }
+  if (cached && cachedDsn === dsn) return cached;
+  // Dynamic import so the package doesn't hard-depend on `postgres` at
+  // build time. If you've routed traffic to pg without installing the
+  // driver this will throw a clear MODULE_NOT_FOUND at runtime.
+  const mod = (await import(/* @vite-ignore */ "postgres" as string).catch(
+    (err) => {
+      throw new Error(
+        `getPgPool: failed to load 'postgres' driver — pnpm add postgres -w (cause: ${String(err)})`,
+      );
+    },
+  )) as { default: (dsn: string) => unknown };
+  cached = mod.default(dsn);
+  cachedDsn = dsn;
+  return cached;
+}

--- a/packages/services/src/store-backends.ts
+++ b/packages/services/src/store-backends.ts
@@ -1,0 +1,80 @@
+// Per-store backend selection mechanism.
+//
+// Each store in the Services container is backed by an adapter that lives in
+// its own package (e.g. packages/agents-store/src/adapters/d1-agent-repo.ts
+// for the D1 implementation). The service itself only depends on the
+// abstract repo port — swapping backends means swapping the adapter, not
+// touching service or route code.
+//
+// This module is the dispatch layer: given a store key (e.g. "agents") and
+// a bag of backend factories (cf, pg, ...), pick the one named in env.
+//
+// Configuration: STORE_BACKENDS env var, JSON object mapping store key →
+// backend name. Missing entries default to "cf".
+//
+//   STORE_BACKENDS={"agents":"pg","sessions":"cf"}
+//
+// Adding a new pg adapter:
+//   1. Implement Pg<X>Repo in packages/<store>-store/src/adapters/pg-<x>-repo.ts
+//   2. Export createPg<X>Service from that store's adapters/index.ts
+//   3. In services/index.ts, register the pg factory in the pickBackend call
+//   4. Set STORE_BACKENDS in env / wrangler vars to route traffic
+//
+// Tenant routing is the storage provider's concern, NOT the service layer.
+// A pg adapter might use row-level tenant_id filtering; the per-tenant-D1
+// adapter uses binding-per-tenant resolution; a hypothetical Postgres
+// schema-per-tenant adapter would do schema search_path tricks. The Services
+// surface is uniform regardless.
+
+import type { Env } from "@open-managed-agents/shared";
+
+export type StoreBackendName = "cf" | "pg" | "memory";
+
+/**
+ * Read the STORE_BACKENDS env override. Tolerates missing or malformed
+ * values — both fall back to "every store uses cf default".
+ */
+export function parseStoreBackends(env: Env): Record<string, StoreBackendName> {
+  const raw = (env as unknown as { STORE_BACKENDS?: string }).STORE_BACKENDS;
+  if (!raw) return {};
+  try {
+    const parsed = JSON.parse(raw) as Record<string, StoreBackendName>;
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return {};
+    return parsed;
+  } catch {
+    console.warn("[store-backends] STORE_BACKENDS is not valid JSON, ignoring");
+    return {};
+  }
+}
+
+/**
+ * Backend factory bag. Each backend is a no-arg builder closure that knows
+ * how to construct the service for that backend (caller provides the
+ * captured deps — db handle, pg pool, etc.).
+ */
+export type BackendFactories<S> = {
+  cf: () => S;
+  pg?: () => S;
+  memory?: () => S;
+};
+
+/**
+ * Pick the backend factory named in env (or "cf" default) and run it. Throws
+ * a clear error if the named backend has no factory registered — that's the
+ * signal to wire up the new adapter in services/index.ts.
+ */
+export function pickBackend<S>(
+  overrides: Record<string, StoreBackendName>,
+  key: string,
+  factories: BackendFactories<S>,
+): S {
+  const backend: StoreBackendName = overrides[key] ?? "cf";
+  const factory = factories[backend];
+  if (!factory) {
+    throw new Error(
+      `STORE_BACKENDS["${key}"]="${backend}" — but no ${backend} adapter is wired in services/index.ts for "${key}". ` +
+        `Implement the adapter, register the factory in pickBackend(), then redeploy.`,
+    );
+  }
+  return factory();
+}

--- a/packages/sessions-store/src/adapters/index.ts
+++ b/packages/sessions-store/src/adapters/index.ts
@@ -9,11 +9,11 @@ import type { Logger } from "../ports";
 import { SessionService } from "../service";
 
 export function createCfSessionService(
-  env: { AUTH_DB: D1Database },
+  deps: { db: D1Database },
   opts?: { logger?: Logger },
 ): SessionService {
   return new SessionService({
-    repo: new D1SessionRepo(env.AUTH_DB),
+    repo: new D1SessionRepo(deps.db),
     logger: opts?.logger,
   });
 }

--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -38,4 +38,21 @@ export interface Env {
   INTEGRATIONS_PUBLIC_URL?: string;
   // Used by integrations subsystem to sign tokens at rest. Gateway's value.
   MCP_SIGNING_KEY?: string;
+  // Killswitch for per-tenant D1 routing. Unset / "true" / anything else =
+  // routing enabled (the default — uses tenant_shard meta table). Set to
+  // "false" or "0" to roll back to the shared-AUTH_DB provider without
+  // redeploying code. Implemented in
+  // packages/services/src/index.ts buildCfTenantDbProvider.
+  PER_TENANT_DB_ENABLED?: string;
+  // Per-store backend selection. JSON object mapping store key (e.g.
+  // "agents", "sessions") to backend name ("cf" | "pg" | "memory"). Missing
+  // entries default to "cf". Lets a deployment route a single store to a
+  // self-hosted Postgres without touching service or route code — the
+  // adapter layer is the only thing that changes.
+  // Example: STORE_BACKENDS={"agents":"pg","sessions":"cf"}
+  STORE_BACKENDS?: string;
+  // Postgres connection string used by any pg-backed store. On Cloudflare
+  // Workers, point this at a Hyperdrive connection string for production;
+  // direct DSN works in local dev / Node deployments.
+  DATABASE_URL?: string;
 }

--- a/packages/tenant-db/package.json
+++ b/packages/tenant-db/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@open-managed-agents/tenant-db",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./test-fakes": "./src/test-fakes.ts"
+  },
+  "dependencies": {}
+}

--- a/packages/tenant-db/src/cf-meta-router.ts
+++ b/packages/tenant-db/src/cf-meta-router.ts
@@ -1,0 +1,82 @@
+import type { TenantDbProvider } from "./ports";
+
+/**
+ * Production TenantDbProvider: reads `tenant_shard` from the control-plane
+ * DB to look up which D1 binding holds a tenant's data.
+ *
+ * Resolution rules:
+ *   1. Cache hit → return cached D1Database (no control-plane round-trip)
+ *   2. Cache miss → SELECT binding_name FROM tenant_shard WHERE tenant_id=?
+ *   3. Row found → env[binding_name] (cache it)
+ *   4. No row    → env.AUTH_DB (cache the fallback too)
+ *
+ * Cache strategy: per-isolate Map, never expires. Justification:
+ *   - tenant→binding mapping is monotonic in normal operation (we only ever
+ *     INSERT, never UPDATE, in the auto-assign path)
+ *   - admin migrate-tenant ops are rare + manual + require worker restart
+ *     (or `/admin/cache/flush` in a future enhancement) to take effect
+ *   - never-expiring cache keeps hot path zero-cost after first hit
+ *
+ * The fallback to env.AUTH_DB is what makes N=1 deployments seamless: when
+ * tenant_shard is empty, every tenant resolves to AUTH_DB, behaviour is
+ * identical to the pre-sharding shared-DB world.
+ */
+export class MetaTableTenantDbProvider implements TenantDbProvider {
+  private readonly cache = new Map<string, D1Database>();
+
+  constructor(
+    private readonly env: Record<string, unknown>,
+    private readonly controlPlaneDb: D1Database,
+    private readonly defaultBinding: D1Database = controlPlaneDb,
+  ) {}
+
+  async resolve(tenantId: string): Promise<D1Database> {
+    const cached = this.cache.get(tenantId);
+    if (cached) return cached;
+
+    let row: { binding_name: string } | null = null;
+    try {
+      row = await this.controlPlaneDb
+        .prepare(`SELECT binding_name FROM tenant_shard WHERE tenant_id = ?`)
+        .bind(tenantId)
+        .first<{ binding_name: string }>();
+    } catch (err) {
+      // Control-plane lookup itself failed (DB down, table missing). Fall
+      // back to the default binding rather than 500'ing the request. The
+      // cache then remembers the fallback — acceptable in N=1 deployments
+      // and degrades gracefully in N>1 (a few requests on the wrong shard
+      // until cache cycles via restart).
+      console.warn(
+        `[MetaTableTenantDbProvider] control-plane lookup failed for tenantId=${tenantId}: ${err}`,
+      );
+      this.cache.set(tenantId, this.defaultBinding);
+      return this.defaultBinding;
+    }
+
+    let resolved = this.defaultBinding;
+    if (row?.binding_name) {
+      const binding = this.env[row.binding_name] as D1Database | undefined;
+      if (!binding) {
+        // tenant_shard claims this tenant lives on a binding that doesn't
+        // exist in env. This is a real config bug — almost certainly forgot
+        // to add the binding to wrangler.jsonc after registering the shard.
+        // Throw so the operator notices, don't silently fall back.
+        throw new Error(
+          `MetaTableTenantDbProvider: tenant_shard row for tenantId=${tenantId} ` +
+            `references binding "${row.binding_name}" but env doesn't have it. ` +
+            `Add the binding to wrangler.jsonc and redeploy, or migrate the tenant.`,
+        );
+      }
+      resolved = binding;
+    }
+
+    this.cache.set(tenantId, resolved);
+    return resolved;
+  }
+
+  /** Test helper: clear the cache. Production code never calls this — cache
+   *  is invalidated by worker restart. */
+  __clearCache(): void {
+    this.cache.clear();
+  }
+}

--- a/packages/tenant-db/src/cf-shared-default.ts
+++ b/packages/tenant-db/src/cf-shared-default.ts
@@ -1,0 +1,17 @@
+import type { TenantDbProvider } from "./ports";
+
+/**
+ * Phase 1 default: ignore tenantId, always return the shared AUTH_DB binding.
+ * This makes Phase 1 a pure refactor — every tenant's data continues to
+ * land in the same physical D1 it does today.
+ *
+ * Replaced by CfStaticBindingTenantDbProvider once Phase 4 lands and the
+ * CICD binding-sync pipeline starts populating per-tenant bindings.
+ */
+export class CfSharedAuthDbProvider implements TenantDbProvider {
+  constructor(private readonly authDb: D1Database) {}
+
+  async resolve(_tenantId: string): Promise<D1Database> {
+    return this.authDb;
+  }
+}

--- a/packages/tenant-db/src/index.ts
+++ b/packages/tenant-db/src/index.ts
@@ -1,0 +1,22 @@
+// @open-managed-agents/tenant-db
+//
+// Abstraction for "given a tenant id, give me the D1 database that holds that
+// tenant's data".
+//
+// Phase 2-revised (current): the production implementation will be a
+// MetaTableTenantDbProvider that reads `tenant_shard` from the control-plane
+// DB to look up which binding holds a tenant's data. With permanent
+// per-isolate cache and AUTH_DB fallback for tenants without a shard row.
+// N=1 deployment: nothing in tenant_shard, all tenants fallback to AUTH_DB
+// and behaviour matches today's shared-DB OMA. Adding new shards = add
+// binding + insert shard_pool row + assign new tenants to it; existing
+// tenants stay (no rehash).
+//
+// CfSharedAuthDbProvider is the killswitch fallback that always returns
+// AUTH_DB regardless of tenant — used when PER_TENANT_DB_ENABLED=false or
+// during early-boot routes that don't have a control-plane lookup yet.
+
+export type { TenantDbProvider } from "./ports";
+export { CfSharedAuthDbProvider } from "./cf-shared-default";
+export { MetaTableTenantDbProvider } from "./cf-meta-router";
+

--- a/packages/tenant-db/src/ports.ts
+++ b/packages/tenant-db/src/ports.ts
@@ -1,0 +1,20 @@
+/**
+ * The single port the storage layer depends on for tenant→DB resolution.
+ *
+ * Implementations:
+ *   - CfSharedAuthDbProvider (cf-shared-default.ts): returns env.AUTH_DB for
+ *     every tenant. The Phase 1 default — zero behaviour change.
+ *   - CfStaticBindingTenantDbProvider (cf-static.ts): looks up
+ *     env[`TENANT_DB_<sanitized>`] for the tenant, falls back to env.AUTH_DB
+ *     when no per-tenant binding exists (legacy tenants). Used in Phase 4
+ *     after the CICD sync script populates wrangler.jsonc with one binding
+ *     per active tenant from the control-plane `tenant_dbs` directory.
+ *   - StaticTenantDbProvider (test-fakes.ts): pre-loaded map for tests.
+ *
+ * The async signature is intentional even though most implementations resolve
+ * synchronously — leaves room for HTTP-API-backed adapters or sharding-table
+ * lookups without changing the port shape.
+ */
+export interface TenantDbProvider {
+  resolve(tenantId: string): Promise<D1Database>;
+}

--- a/packages/tenant-db/src/test-fakes.ts
+++ b/packages/tenant-db/src/test-fakes.ts
@@ -1,0 +1,31 @@
+import type { TenantDbProvider } from "./ports";
+
+/**
+ * Test-only TenantDbProvider. Constructed with a default DB and an optional
+ * map of (tenantId → DB) overrides — call sites can either inject one
+ * shared in-memory D1 fake (most existing tests, where tenant routing
+ * doesn't matter) or distinct fakes per tenant (when verifying isolation).
+ *
+ * No throw on miss: returns the default. Tests that want to assert "no DB
+ * for unknown tenant" should construct without a default.
+ */
+export class StaticTenantDbProvider implements TenantDbProvider {
+  constructor(
+    private readonly defaultDb: D1Database | null,
+    private readonly perTenant: Map<string, D1Database> = new Map(),
+  ) {}
+
+  set(tenantId: string, db: D1Database): void {
+    this.perTenant.set(tenantId, db);
+  }
+
+  async resolve(tenantId: string): Promise<D1Database> {
+    const db = this.perTenant.get(tenantId) ?? this.defaultDb;
+    if (!db) {
+      throw new Error(
+        `StaticTenantDbProvider: no DB for tenantId=${tenantId} and no default set`,
+      );
+    }
+    return db;
+  }
+}

--- a/packages/tenant-dbs-store/package.json
+++ b/packages/tenant-dbs-store/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@open-managed-agents/tenant-dbs-store",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./test-fakes": "./src/test-fakes.ts"
+  },
+  "dependencies": {}
+}

--- a/packages/tenant-dbs-store/src/adapters/d1-shard-pool-repo.ts
+++ b/packages/tenant-dbs-store/src/adapters/d1-shard-pool-repo.ts
@@ -1,0 +1,106 @@
+import type {
+  NewShardPool,
+  ShardPoolRepo,
+  ShardPoolRow,
+  ShardStatus,
+} from "../ports";
+
+interface Row {
+  binding_name: string;
+  status: string;
+  tenant_count: number;
+  size_bytes: number | null;
+  observed_at: number | null;
+  notes: string | null;
+}
+
+export class D1ShardPoolRepo implements ShardPoolRepo {
+  constructor(private readonly db: D1Database) {}
+
+  async get(bindingName: string): Promise<ShardPoolRow | null> {
+    const row = await this.db
+      .prepare(`SELECT * FROM shard_pool WHERE binding_name = ?`)
+      .bind(bindingName)
+      .first<Row>();
+    return row ? toDomain(row) : null;
+  }
+
+  async insert(input: NewShardPool): Promise<ShardPoolRow> {
+    // Idempotent on PK collision — second registration of the same shard
+    // preserves any operational state already accumulated.
+    await this.db
+      .prepare(
+        `INSERT OR IGNORE INTO shard_pool
+           (binding_name, status, tenant_count, size_bytes, observed_at, notes)
+         VALUES (?, ?, 0, NULL, NULL, ?)`,
+      )
+      .bind(input.bindingName, input.status ?? "open", input.notes ?? null)
+      .run();
+    const row = await this.get(input.bindingName);
+    if (!row) throw new Error(`shard_pool row vanished after insert: ${input.bindingName}`);
+    return row;
+  }
+
+  async pickOpen(): Promise<ShardPoolRow | null> {
+    // Lowest tenant_count first; tie-break by smallest observed size; nulls
+    // last (treat unknown size as "probably newest, use it").
+    const row = await this.db
+      .prepare(
+        `SELECT * FROM shard_pool
+         WHERE status = 'open'
+         ORDER BY tenant_count ASC,
+                  CASE WHEN size_bytes IS NULL THEN 1 ELSE 0 END,
+                  size_bytes ASC
+         LIMIT 1`,
+      )
+      .first<Row>();
+    return row ? toDomain(row) : null;
+  }
+
+  async setStatus(bindingName: string, status: ShardStatus): Promise<void> {
+    await this.db
+      .prepare(`UPDATE shard_pool SET status = ? WHERE binding_name = ?`)
+      .bind(status, bindingName)
+      .run();
+  }
+
+  async setObservedSize(
+    bindingName: string,
+    sizeBytes: number,
+    observedAt: number,
+  ): Promise<void> {
+    await this.db
+      .prepare(
+        `UPDATE shard_pool SET size_bytes = ?, observed_at = ? WHERE binding_name = ?`,
+      )
+      .bind(sizeBytes, observedAt, bindingName)
+      .run();
+  }
+
+  async incrementTenantCount(bindingName: string): Promise<void> {
+    await this.db
+      .prepare(
+        `UPDATE shard_pool SET tenant_count = tenant_count + 1 WHERE binding_name = ?`,
+      )
+      .bind(bindingName)
+      .run();
+  }
+
+  async listAll(): Promise<readonly ShardPoolRow[]> {
+    const { results } = await this.db
+      .prepare(`SELECT * FROM shard_pool ORDER BY binding_name`)
+      .all<Row>();
+    return (results ?? []).map(toDomain);
+  }
+}
+
+function toDomain(row: Row): ShardPoolRow {
+  return {
+    bindingName: row.binding_name,
+    status: row.status as ShardStatus,
+    tenantCount: row.tenant_count,
+    sizeBytes: row.size_bytes,
+    observedAt: row.observed_at,
+    notes: row.notes,
+  };
+}

--- a/packages/tenant-dbs-store/src/adapters/d1-tenant-shard-repo.ts
+++ b/packages/tenant-dbs-store/src/adapters/d1-tenant-shard-repo.ts
@@ -1,0 +1,63 @@
+import type {
+  NewTenantShard,
+  TenantShardDirectoryRepo,
+  TenantShardRow,
+} from "../ports";
+
+interface Row {
+  tenant_id: string;
+  binding_name: string;
+  created_at: number;
+}
+
+export class D1TenantShardDirectoryRepo implements TenantShardDirectoryRepo {
+  constructor(private readonly db: D1Database) {}
+
+  async get(tenantId: string): Promise<TenantShardRow | null> {
+    const row = await this.db
+      .prepare(`SELECT * FROM tenant_shard WHERE tenant_id = ?`)
+      .bind(tenantId)
+      .first<Row>();
+    return row ? toDomain(row) : null;
+  }
+
+  async insert(input: NewTenantShard): Promise<TenantShardRow> {
+    const now = Date.now();
+    // INSERT OR IGNORE: re-running sign-up for an existing tenant must NOT
+    // accidentally re-route to a different shard. The first assignment wins
+    // and stays for the lifetime of the tenant.
+    await this.db
+      .prepare(
+        `INSERT OR IGNORE INTO tenant_shard
+           (tenant_id, binding_name, created_at)
+         VALUES (?, ?, ?)`,
+      )
+      .bind(input.tenantId, input.bindingName, now)
+      .run();
+    const row = await this.get(input.tenantId);
+    if (!row) throw new Error(`tenant_shard row vanished after insert: ${input.tenantId}`);
+    return row;
+  }
+
+  async reassign(tenantId: string, bindingName: string): Promise<void> {
+    await this.db
+      .prepare(`UPDATE tenant_shard SET binding_name = ? WHERE tenant_id = ?`)
+      .bind(bindingName, tenantId)
+      .run();
+  }
+
+  async listAll(): Promise<readonly TenantShardRow[]> {
+    const { results } = await this.db
+      .prepare(`SELECT * FROM tenant_shard ORDER BY created_at`)
+      .all<Row>();
+    return (results ?? []).map(toDomain);
+  }
+}
+
+function toDomain(row: Row): TenantShardRow {
+  return {
+    tenantId: row.tenant_id,
+    bindingName: row.binding_name,
+    createdAt: row.created_at,
+  };
+}

--- a/packages/tenant-dbs-store/src/adapters/index.ts
+++ b/packages/tenant-dbs-store/src/adapters/index.ts
@@ -1,0 +1,25 @@
+// Cloudflare adapter wiring for the control-plane shard router store. All
+// reads and writes target the control-plane DB (env.AUTH_DB), never a
+// per-tenant DB.
+
+export { D1TenantShardDirectoryRepo } from "./d1-tenant-shard-repo";
+export { D1ShardPoolRepo } from "./d1-shard-pool-repo";
+
+import { D1TenantShardDirectoryRepo } from "./d1-tenant-shard-repo";
+import { D1ShardPoolRepo } from "./d1-shard-pool-repo";
+import {
+  TenantShardDirectoryService,
+  ShardPoolService,
+} from "../service";
+
+export function createCfTenantShardDirectoryService(deps: {
+  controlPlaneDb: D1Database;
+}): TenantShardDirectoryService {
+  return new TenantShardDirectoryService(new D1TenantShardDirectoryRepo(deps.controlPlaneDb));
+}
+
+export function createCfShardPoolService(deps: {
+  controlPlaneDb: D1Database;
+}): ShardPoolService {
+  return new ShardPoolService(new D1ShardPoolRepo(deps.controlPlaneDb));
+}

--- a/packages/tenant-dbs-store/src/index.ts
+++ b/packages/tenant-dbs-store/src/index.ts
@@ -1,0 +1,25 @@
+// @open-managed-agents/tenant-dbs-store
+//
+// Control-plane shard router tables. Two responsibilities:
+//
+//   tenant_shard  — tenant_id → binding_name. Permanent assignment record.
+//                   Read on every authenticated request via
+//                   MetaTableTenantDbProvider (with per-isolate cache).
+//                   Missing row = tenant falls back to the default shard
+//                   (env.AUTH_DB), which is the N=1 default behaviour.
+//
+//   shard_pool    — binding_name → status / capacity. Operational state for
+//                   choosing where new tenants land + capacity monitoring.
+//                   Updated by the capacity monitor cron and admin scripts.
+//
+// Both ALWAYS query the control-plane DB (env.AUTH_DB) regardless of how
+// per-tenant data is sharded — they're the routing map itself.
+
+export * from "./ports";
+export * from "./service";
+export {
+  D1TenantShardDirectoryRepo,
+  D1ShardPoolRepo,
+  createCfTenantShardDirectoryService,
+  createCfShardPoolService,
+} from "./adapters";

--- a/packages/tenant-dbs-store/src/ports.ts
+++ b/packages/tenant-dbs-store/src/ports.ts
@@ -1,0 +1,73 @@
+// Persistence ports for the control-plane shard router tables.
+//
+// Two tables, both ALWAYS in the control-plane DB regardless of tenant
+// sharding:
+//
+//   tenant_shard  — assignment record. tenant_id → binding_name. Missing row
+//                   means tenant falls back to the default shard (AUTH_DB).
+//                   Permanent: never updated unless we manually migrate a
+//                   tenant between shards (rare admin op).
+//
+//   shard_pool    — operational state. binding_name → status / capacity.
+//                   Drives "which shard should the next new tenant land on".
+//                   Updated by the capacity monitor + admin scripts.
+//
+// Used by MetaTableTenantDbProvider (in @open-managed-agents/tenant-db) for
+// the per-request `tenantId → D1Database` resolution. Cached per-isolate.
+
+export interface TenantShardRow {
+  tenantId: string;
+  bindingName: string;
+  createdAt: number;
+}
+
+export interface NewTenantShard {
+  tenantId: string;
+  bindingName: string;
+}
+
+export interface TenantShardDirectoryRepo {
+  /** O(1) lookup. Used on hot path (every request) — caller caches. */
+  get(tenantId: string): Promise<TenantShardRow | null>;
+  /** First-time tenant assignment. Idempotent on PK collision (existing row
+   *  preserved — never re-route a live tenant accidentally). */
+  insert(row: NewTenantShard): Promise<TenantShardRow>;
+  /** Manual migrate-tenant op only. Writes are visible only after worker
+   *  restart due to per-isolate cache. */
+  reassign(tenantId: string, bindingName: string): Promise<void>;
+  /** For admin views. Returns ALL assigned tenants. */
+  listAll(): Promise<readonly TenantShardRow[]>;
+}
+
+// ─── Shard pool ─────────────────────────────────────────────────────────
+
+export type ShardStatus = "open" | "draining" | "full" | "archived";
+
+export interface ShardPoolRow {
+  bindingName: string;
+  status: ShardStatus;
+  tenantCount: number;
+  sizeBytes: number | null;
+  observedAt: number | null;
+  notes: string | null;
+}
+
+export interface NewShardPool {
+  bindingName: string;
+  status?: ShardStatus;
+  notes?: string;
+}
+
+export interface ShardPoolRepo {
+  get(bindingName: string): Promise<ShardPoolRow | null>;
+  /** Register a new shard binding. Status defaults to 'open'. */
+  insert(row: NewShardPool): Promise<ShardPoolRow>;
+  /** Pick the shard new tenants should land on. Returns the open shard with
+   *  the lowest tenant_count (ties broken by smallest size_bytes). Returns
+   *  null when no shard is open — caller falls back to AUTH_DB. */
+  pickOpen(): Promise<ShardPoolRow | null>;
+  setStatus(bindingName: string, status: ShardStatus): Promise<void>;
+  setObservedSize(bindingName: string, sizeBytes: number, observedAt: number): Promise<void>;
+  incrementTenantCount(bindingName: string): Promise<void>;
+  listAll(): Promise<readonly ShardPoolRow[]>;
+}

--- a/packages/tenant-dbs-store/src/service.ts
+++ b/packages/tenant-dbs-store/src/service.ts
@@ -1,0 +1,74 @@
+import type {
+  NewShardPool,
+  NewTenantShard,
+  ShardPoolRepo,
+  ShardPoolRow,
+  ShardStatus,
+  TenantShardDirectoryRepo,
+  TenantShardRow,
+} from "./ports";
+
+/**
+ * Service wrapper around TenantShardDirectoryRepo. Hot path on every
+ * authenticated request via MetaTableTenantDbProvider — keep thin.
+ */
+export class TenantShardDirectoryService {
+  constructor(private readonly repo: TenantShardDirectoryRepo) {}
+
+  get(tenantId: string): Promise<TenantShardRow | null> {
+    return this.repo.get(tenantId);
+  }
+
+  /** Called once per tenant at sign-up (or first access for legacy tenants). */
+  assign(input: NewTenantShard): Promise<TenantShardRow> {
+    return this.repo.insert(input);
+  }
+
+  /** Admin-only — wipe + re-route. Cache-invalidating, requires worker restart. */
+  migrateTo(tenantId: string, bindingName: string): Promise<void> {
+    return this.repo.reassign(tenantId, bindingName);
+  }
+
+  listAll(): Promise<readonly TenantShardRow[]> {
+    return this.repo.listAll();
+  }
+}
+
+/**
+ * Service wrapper around ShardPoolRepo. Used by:
+ *   - sign-up flow to pick a shard for a new tenant (`pickOpen`)
+ *   - capacity monitor cron to update size + flip status (`setObservedSize`,
+ *     `setStatus`)
+ *   - admin scripts to register a new shard (`register`)
+ */
+export class ShardPoolService {
+  constructor(private readonly repo: ShardPoolRepo) {}
+
+  /** Register a new shard binding. Idempotent — second call no-ops. */
+  register(input: NewShardPool): Promise<ShardPoolRow> {
+    return this.repo.insert(input);
+  }
+
+  /** Returns null when no shard is open — caller should fall back to default. */
+  pickShardForNewTenant(): Promise<ShardPoolRow | null> {
+    return this.repo.pickOpen();
+  }
+
+  markStatus(bindingName: string, status: ShardStatus): Promise<void> {
+    return this.repo.setStatus(bindingName, status);
+  }
+
+  recordObservedSize(bindingName: string, sizeBytes: number): Promise<void> {
+    return this.repo.setObservedSize(bindingName, sizeBytes, Date.now());
+  }
+
+  incrementTenantCount(bindingName: string): Promise<void> {
+    return this.repo.incrementTenantCount(bindingName);
+  }
+
+  listAll(): Promise<readonly ShardPoolRow[]> {
+    return this.repo.listAll();
+  }
+}
+
+export type { ShardStatus };

--- a/packages/tenant-dbs-store/src/test-fakes.ts
+++ b/packages/tenant-dbs-store/src/test-fakes.ts
@@ -1,0 +1,104 @@
+import type {
+  NewShardPool,
+  NewTenantShard,
+  ShardPoolRepo,
+  ShardPoolRow,
+  ShardStatus,
+  TenantShardDirectoryRepo,
+  TenantShardRow,
+} from "./ports";
+
+export class InMemoryTenantShardDirectoryRepo implements TenantShardDirectoryRepo {
+  private rows = new Map<string, TenantShardRow>();
+  private clock: () => number;
+
+  constructor(clock: () => number = () => Date.now()) {
+    this.clock = clock;
+  }
+
+  async get(tenantId: string): Promise<TenantShardRow | null> {
+    return this.rows.get(tenantId) ?? null;
+  }
+
+  async insert(input: NewTenantShard): Promise<TenantShardRow> {
+    // INSERT OR IGNORE semantics: existing row preserved, never re-routed.
+    const existing = this.rows.get(input.tenantId);
+    if (existing) return existing;
+    const row: TenantShardRow = {
+      tenantId: input.tenantId,
+      bindingName: input.bindingName,
+      createdAt: this.clock(),
+    };
+    this.rows.set(input.tenantId, row);
+    return row;
+  }
+
+  async reassign(tenantId: string, bindingName: string): Promise<void> {
+    const row = this.rows.get(tenantId);
+    if (row) this.rows.set(tenantId, { ...row, bindingName });
+  }
+
+  async listAll(): Promise<readonly TenantShardRow[]> {
+    return [...this.rows.values()].sort((a, b) => a.createdAt - b.createdAt);
+  }
+}
+
+export class InMemoryShardPoolRepo implements ShardPoolRepo {
+  private rows = new Map<string, ShardPoolRow>();
+
+  async get(bindingName: string): Promise<ShardPoolRow | null> {
+    return this.rows.get(bindingName) ?? null;
+  }
+
+  async insert(input: NewShardPool): Promise<ShardPoolRow> {
+    const existing = this.rows.get(input.bindingName);
+    if (existing) return existing;
+    const row: ShardPoolRow = {
+      bindingName: input.bindingName,
+      status: input.status ?? "open",
+      tenantCount: 0,
+      sizeBytes: null,
+      observedAt: null,
+      notes: input.notes ?? null,
+    };
+    this.rows.set(input.bindingName, row);
+    return row;
+  }
+
+  async pickOpen(): Promise<ShardPoolRow | null> {
+    const open = [...this.rows.values()].filter((r) => r.status === "open");
+    if (open.length === 0) return null;
+    open.sort((a, b) => {
+      if (a.tenantCount !== b.tenantCount) return a.tenantCount - b.tenantCount;
+      const aSize = a.sizeBytes ?? -1;
+      const bSize = b.sizeBytes ?? -1;
+      return aSize - bSize;
+    });
+    return open[0];
+  }
+
+  async setStatus(bindingName: string, status: ShardStatus): Promise<void> {
+    const row = this.rows.get(bindingName);
+    if (row) this.rows.set(bindingName, { ...row, status });
+  }
+
+  async setObservedSize(
+    bindingName: string,
+    sizeBytes: number,
+    observedAt: number,
+  ): Promise<void> {
+    const row = this.rows.get(bindingName);
+    if (row) this.rows.set(bindingName, { ...row, sizeBytes, observedAt });
+  }
+
+  async incrementTenantCount(bindingName: string): Promise<void> {
+    const row = this.rows.get(bindingName);
+    if (row) this.rows.set(bindingName, { ...row, tenantCount: row.tenantCount + 1 });
+  }
+
+  async listAll(): Promise<readonly ShardPoolRow[]> {
+    return [...this.rows.values()].sort((a, b) =>
+      a.bindingName.localeCompare(b.bindingName),
+    );
+  }
+}

--- a/packages/vaults-store/src/adapters/index.ts
+++ b/packages/vaults-store/src/adapters/index.ts
@@ -7,11 +7,11 @@ import type { Logger } from "../ports";
 import { VaultService } from "../service";
 
 export function createCfVaultService(
-  env: { AUTH_DB: D1Database },
+  deps: { db: D1Database },
   opts?: { logger?: Logger },
 ): VaultService {
   return new VaultService({
-    repo: new D1VaultRepo(env.AUTH_DB),
+    repo: new D1VaultRepo(deps.db),
     logger: opts?.logger,
   });
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -202,6 +202,12 @@ importers:
       '@open-managed-agents/shared':
         specifier: workspace:*
         version: link:../../packages/shared
+      '@open-managed-agents/tenant-db':
+        specifier: workspace:*
+        version: link:../../packages/tenant-db
+      '@open-managed-agents/tenant-dbs-store':
+        specifier: workspace:*
+        version: link:../../packages/tenant-dbs-store
       hono:
         specifier: ^4.7.0
         version: 4.12.12
@@ -259,6 +265,12 @@ importers:
       '@open-managed-agents/shared':
         specifier: workspace:*
         version: link:../../packages/shared
+      '@open-managed-agents/tenant-db':
+        specifier: workspace:*
+        version: link:../../packages/tenant-db
+      '@open-managed-agents/tenant-dbs-store':
+        specifier: workspace:*
+        version: link:../../packages/tenant-dbs-store
       '@open-managed-agents/vaults-store':
         specifier: workspace:*
         version: link:../../packages/vaults-store
@@ -408,6 +420,12 @@ importers:
       '@open-managed-agents/shared':
         specifier: workspace:*
         version: link:../shared
+      '@open-managed-agents/tenant-db':
+        specifier: workspace:*
+        version: link:../tenant-db
+      '@open-managed-agents/tenant-dbs-store':
+        specifier: workspace:*
+        version: link:../tenant-dbs-store
       '@open-managed-agents/vaults-store':
         specifier: workspace:*
         version: link:../vaults-store
@@ -438,6 +456,10 @@ importers:
       nanoid:
         specifier: ^5.1.0
         version: 5.1.7
+
+  packages/tenant-db: {}
+
+  packages/tenant-dbs-store: {}
 
   packages/vaults-store:
     dependencies:

--- a/test/integration/evals-route.test.ts
+++ b/test/integration/evals-route.test.ts
@@ -295,7 +295,7 @@ describe("tickEvalRuns advances state", () => {
 
     // Active list (status-driven via services.evals.listActive) should
     // contain the new run.
-    const services = buildCfServices(env);
+    const services = buildCfServices(env, env.AUTH_DB);
     const activeBefore = await services.evals.listActive();
     expect(activeBefore.some((r: any) => r.id === run_id)).toBe(true);
 

--- a/test/test-worker.ts
+++ b/test/test-worker.ts
@@ -22,8 +22,16 @@ export { outbound, outboundByHost } from "../apps/agent/src/outbound";
 
 // @ts-expect-error vitest resolves SQL via ?raw
 import schema0001 from "../apps/main/migrations/0001_schema.sql?raw";
+// @ts-expect-error vitest resolves SQL via ?raw
+import schema0002 from "../apps/main/migrations/0002_integrations_tenant_id.sql?raw";
+// @ts-expect-error vitest resolves SQL via ?raw
+import schema0003 from "../apps/main/migrations/0003_tenant_shard.sql?raw";
 
-const MIGRATIONS_RAW: string[] = [schema0001 as string];
+const MIGRATIONS_RAW: string[] = [
+  schema0001 as string,
+  schema0002 as string,
+  schema0003 as string,
+];
 
 let migrationsApplied = false;
 async function ensureMigrations(env: { AUTH_DB?: D1Database }): Promise<void> {

--- a/test/unit/services-dispatch.test.ts
+++ b/test/unit/services-dispatch.test.ts
@@ -1,0 +1,81 @@
+// Smoke tests for the integration of buildServices + STORE_BACKENDS dispatch.
+//
+// We don't have a real pg adapter wired in services/index.ts (Phase 4 of the
+// per-tenant-D1 work intentionally only added the mechanism). What we CAN
+// verify here:
+//   - Default (no STORE_BACKENDS) returns a fully populated Services object
+//     using the cf factories.
+//   - Setting STORE_BACKENDS to route a store to "pg" trips the pickBackend
+//     not-wired error (since no pg factory is registered yet) — confirming
+//     the dispatch mechanism is actually consulting env.
+//   - Setting STORE_BACKENDS to bogus JSON falls back to all-cf without
+//     blowing up.
+//
+// When a real pg adapter is wired (uncommenting the pg: () => createPgX...
+// line in services/index.ts), this file should be extended with a dispatch
+// test that actually constructs the pg instance.
+
+import { describe, it, expect } from "vitest";
+import { buildCfServices } from "@open-managed-agents/services";
+import type { Env } from "@open-managed-agents/shared";
+
+const fakeDb = { __fake: "db" } as unknown as D1Database;
+
+function envWith(extras: Record<string, string | undefined> = {}): Env {
+  return {
+    AUTH_DB: fakeDb,
+    CONFIG_KV: {} as unknown,
+    ...extras,
+  } as unknown as Env;
+}
+
+describe("buildServices — default cf wiring", () => {
+  it("constructs every service when STORE_BACKENDS is unset", () => {
+    const env = envWith();
+    const services = buildCfServices(env, fakeDb);
+    expect(services.agents).toBeDefined();
+    expect(services.sessions).toBeDefined();
+    expect(services.credentials).toBeDefined();
+    expect(services.memory).toBeDefined();
+    expect(services.vaults).toBeDefined();
+    expect(services.files).toBeDefined();
+    expect(services.evals).toBeDefined();
+    expect(services.modelCards).toBeDefined();
+    expect(services.environments).toBeDefined();
+    expect(services.outboundSnapshots).toBeDefined();
+    expect(services.sessionSecrets).toBeDefined();
+    expect(services.tenantShardDirectory).toBeDefined();
+    expect(services.shardPool).toBeDefined();
+  });
+
+  it("ignores malformed STORE_BACKENDS — all stores still cf", () => {
+    const env = envWith({ STORE_BACKENDS: "not-json" });
+    const services = buildCfServices(env, fakeDb);
+    expect(services.agents).toBeDefined();
+  });
+});
+
+describe("buildServices — pg dispatch", () => {
+  it("throws clear error when routing to pg without an adapter wired", () => {
+    const env = envWith({ STORE_BACKENDS: '{"agents":"pg"}' });
+    expect(() => buildCfServices(env, fakeDb)).toThrow(/agents.+pg.+no pg adapter/);
+  });
+
+  it("error message names the specific store key — easy to act on", () => {
+    const env = envWith({ STORE_BACKENDS: '{"sessions":"pg"}' });
+    expect(() => buildCfServices(env, fakeDb)).toThrow(/sessions/);
+  });
+
+  it("only the routed store throws — others would have constructed cf", () => {
+    // agents → pg (throws), sessions → cf (would succeed). The throw fires
+    // first because pickBackend executes during the object literal build, but
+    // we can verify the message is about agents not sessions.
+    const env = envWith({ STORE_BACKENDS: '{"agents":"pg","sessions":"cf"}' });
+    expect(() => buildCfServices(env, fakeDb)).toThrow(/agents/);
+  });
+
+  it("memory backend dispatch — also throws when not wired", () => {
+    const env = envWith({ STORE_BACKENDS: '{"vaults":"memory"}' });
+    expect(() => buildCfServices(env, fakeDb)).toThrow(/vaults.+memory.+no memory adapter/);
+  });
+});

--- a/test/unit/store-backends.test.ts
+++ b/test/unit/store-backends.test.ts
@@ -1,0 +1,92 @@
+// Unit tests for the storage backend dispatch mechanism.
+//
+// Pure functions, no D1 / pg / mocks needed. Covers:
+//   - parseStoreBackends parsing (valid JSON, malformed, missing)
+//   - pickBackend default cf, override, missing pg adapter error message
+//   - error message includes the store key + backend name for debugging
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  parseStoreBackends,
+  pickBackend,
+  type StoreBackendName,
+} from "@open-managed-agents/services";
+import type { Env } from "@open-managed-agents/shared";
+
+function envWith(STORE_BACKENDS?: string): Env {
+  return { STORE_BACKENDS } as unknown as Env;
+}
+
+describe("parseStoreBackends", () => {
+  it("returns empty object when env var unset", () => {
+    expect(parseStoreBackends(envWith())).toEqual({});
+  });
+
+  it("parses valid JSON", () => {
+    const result = parseStoreBackends(envWith('{"agents":"pg","sessions":"cf"}'));
+    expect(result).toEqual({ agents: "pg", sessions: "cf" });
+  });
+
+  it("returns empty object on malformed JSON, with a warning", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    expect(parseStoreBackends(envWith("not-json"))).toEqual({});
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it("returns empty object on JSON null / array (not an object)", () => {
+    expect(parseStoreBackends(envWith("null"))).toEqual({});
+    expect(parseStoreBackends(envWith("[]"))).toEqual({}); // arrays are objects but typeof is object — we accept both, ports won't lookup their keys
+  });
+});
+
+describe("pickBackend", () => {
+  it("defaults to cf when no override", () => {
+    const cfFactory = vi.fn(() => "cf-instance");
+    const pgFactory = vi.fn(() => "pg-instance");
+    const result = pickBackend({}, "agents", { cf: cfFactory, pg: pgFactory });
+    expect(result).toBe("cf-instance");
+    expect(cfFactory).toHaveBeenCalledOnce();
+    expect(pgFactory).not.toHaveBeenCalled();
+  });
+
+  it("uses pg when overridden and pg factory registered", () => {
+    const cfFactory = vi.fn(() => "cf-instance");
+    const pgFactory = vi.fn(() => "pg-instance");
+    const result = pickBackend({ agents: "pg" }, "agents", {
+      cf: cfFactory,
+      pg: pgFactory,
+    });
+    expect(result).toBe("pg-instance");
+    expect(pgFactory).toHaveBeenCalledOnce();
+    expect(cfFactory).not.toHaveBeenCalled();
+  });
+
+  it("throws helpful error when pg requested but no pg factory wired", () => {
+    expect(() =>
+      pickBackend({ agents: "pg" }, "agents", {
+        cf: () => "cf-instance",
+      }),
+    ).toThrow(/STORE_BACKENDS\["agents"\]="pg".+no pg adapter/);
+  });
+
+  it("only the specified store is overridden — others stay cf", () => {
+    const overrides = { agents: "pg" as StoreBackendName };
+    const sessionsCf = vi.fn(() => "sessions-cf");
+    const sessionsPg = vi.fn(() => "sessions-pg");
+    const result = pickBackend(overrides, "sessions", {
+      cf: sessionsCf,
+      pg: sessionsPg,
+    });
+    expect(result).toBe("sessions-cf");
+    expect(sessionsPg).not.toHaveBeenCalled();
+  });
+
+  it("supports memory backend (3rd registered factory)", () => {
+    const result = pickBackend({ agents: "memory" }, "agents", {
+      cf: () => "cf",
+      memory: () => "memory-instance",
+    });
+    expect(result).toBe("memory-instance");
+  });
+});

--- a/test/unit/tenant-db-provider.test.ts
+++ b/test/unit/tenant-db-provider.test.ts
@@ -1,0 +1,19 @@
+// Unit tests for CfSharedAuthDbProvider — the killswitch fallback.
+//
+// MetaTableTenantDbProvider tests live in tenant-dbs-store-services.test.ts
+// alongside the directory service it depends on.
+
+import { describe, it, expect } from "vitest";
+import { CfSharedAuthDbProvider } from "@open-managed-agents/tenant-db";
+
+const fakeDb = (label: string) => ({ __label: label }) as unknown as D1Database;
+
+describe("CfSharedAuthDbProvider (killswitch fallback)", () => {
+  it("returns the shared AUTH_DB for any tenant id", async () => {
+    const auth = fakeDb("AUTH_DB");
+    const provider = new CfSharedAuthDbProvider(auth);
+    expect(await provider.resolve("tenant_a")).toBe(auth);
+    expect(await provider.resolve("tenant_b")).toBe(auth);
+    expect(await provider.resolve("")).toBe(auth);
+  });
+});

--- a/test/unit/tenant-dbs-store-services.test.ts
+++ b/test/unit/tenant-dbs-store-services.test.ts
@@ -1,0 +1,220 @@
+// Unit tests for the new shard-router services + MetaTableTenantDbProvider.
+//
+// Verifies:
+//   - TenantShardDirectoryService.assign is idempotent (first write wins,
+//     never re-routes a live tenant)
+//   - ShardPoolService.pickShardForNewTenant picks lowest tenant_count
+//   - MetaTableTenantDbProvider falls back to default binding when
+//     tenant_shard has no row (N=1 baseline)
+//   - MetaTableTenantDbProvider caches per-isolate (no second control-plane
+//     query for same tenantId)
+
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  TenantShardDirectoryService,
+  ShardPoolService,
+} from "@open-managed-agents/tenant-dbs-store";
+import {
+  InMemoryTenantShardDirectoryRepo,
+  InMemoryShardPoolRepo,
+} from "@open-managed-agents/tenant-dbs-store/test-fakes";
+
+describe("TenantShardDirectoryService", () => {
+  let service: TenantShardDirectoryService;
+
+  beforeEach(() => {
+    service = new TenantShardDirectoryService(new InMemoryTenantShardDirectoryRepo());
+  });
+
+  it("assign creates a new tenant_shard row", async () => {
+    const row = await service.assign({ tenantId: "tn_a", bindingName: "AUTH_DB" });
+    expect(row.tenantId).toBe("tn_a");
+    expect(row.bindingName).toBe("AUTH_DB");
+    expect(row.createdAt).toBeGreaterThan(0);
+  });
+
+  it("assign is idempotent — second call preserves the original binding", async () => {
+    await service.assign({ tenantId: "tn_a", bindingName: "AUTH_DB" });
+    // A misguided second call (e.g. retry) tries to assign a different shard.
+    const row = await service.assign({ tenantId: "tn_a", bindingName: "DB_001" });
+    // The original assignment stands — never silently re-route a live tenant.
+    expect(row.bindingName).toBe("AUTH_DB");
+  });
+
+  it("get returns null when tenant has no assignment", async () => {
+    expect(await service.get("tn_unknown")).toBeNull();
+  });
+
+  it("get returns the assignment after assign", async () => {
+    await service.assign({ tenantId: "tn_a", bindingName: "DB_007" });
+    expect((await service.get("tn_a"))?.bindingName).toBe("DB_007");
+  });
+
+  it("migrateTo updates the binding (admin op, requires worker restart in prod)", async () => {
+    await service.assign({ tenantId: "tn_a", bindingName: "AUTH_DB" });
+    await service.migrateTo("tn_a", "DB_001");
+    expect((await service.get("tn_a"))?.bindingName).toBe("DB_001");
+  });
+
+  it("listAll returns rows in createdAt order", async () => {
+    await service.assign({ tenantId: "tn_z", bindingName: "AUTH_DB" });
+    await service.assign({ tenantId: "tn_a", bindingName: "DB_001" });
+    const all = await service.listAll();
+    expect(all.map((r) => r.tenantId)).toEqual(["tn_z", "tn_a"]);
+  });
+});
+
+describe("ShardPoolService", () => {
+  let service: ShardPoolService;
+
+  beforeEach(() => {
+    service = new ShardPoolService(new InMemoryShardPoolRepo());
+  });
+
+  it("register inserts a new shard with status open by default", async () => {
+    const row = await service.register({ bindingName: "DB_001" });
+    expect(row.status).toBe("open");
+    expect(row.tenantCount).toBe(0);
+    expect(row.sizeBytes).toBeNull();
+  });
+
+  it("pickShardForNewTenant returns null when no shards registered", async () => {
+    expect(await service.pickShardForNewTenant()).toBeNull();
+  });
+
+  it("pickShardForNewTenant returns the only open shard", async () => {
+    await service.register({ bindingName: "AUTH_DB" });
+    const pick = await service.pickShardForNewTenant();
+    expect(pick?.bindingName).toBe("AUTH_DB");
+  });
+
+  it("pickShardForNewTenant prefers lowest tenant_count", async () => {
+    await service.register({ bindingName: "DB_a" });
+    await service.register({ bindingName: "DB_b" });
+    await service.incrementTenantCount("DB_a");
+    await service.incrementTenantCount("DB_a");
+    await service.incrementTenantCount("DB_b");
+    const pick = await service.pickShardForNewTenant();
+    expect(pick?.bindingName).toBe("DB_b"); // count=1 < DB_a count=2
+  });
+
+  it("draining/full/archived shards are excluded from pickOpen", async () => {
+    await service.register({ bindingName: "DB_a" });
+    await service.register({ bindingName: "DB_b" });
+    await service.markStatus("DB_a", "draining");
+    const pick = await service.pickShardForNewTenant();
+    expect(pick?.bindingName).toBe("DB_b");
+  });
+
+  it("recordObservedSize updates size + observedAt", async () => {
+    await service.register({ bindingName: "DB_a" });
+    await service.recordObservedSize("DB_a", 9_500_000_000);
+    const row = await service.listAll();
+    expect(row[0].sizeBytes).toBe(9_500_000_000);
+    expect(row[0].observedAt).toBeGreaterThan(0);
+  });
+});
+
+describe("MetaTableTenantDbProvider — caching + fallback", () => {
+  // Direct unit test for cache + fallback semantics. Driven via miniflare
+  // D1 in test-worker.ts isn't available here — we hand-roll a fake D1
+  // adapter that records prepare/bind/first calls.
+
+  function makeFakeDb(rows: Array<{ binding_name: string } | null>): D1Database {
+    let callCount = 0;
+    return {
+      prepare: () => ({
+        bind: () => ({
+          first: async () => {
+            const r = rows[callCount] ?? null;
+            callCount++;
+            return r;
+          },
+        }),
+      }),
+    } as unknown as D1Database;
+  }
+
+  it("falls back to defaultBinding when tenant_shard has no row", async () => {
+    const { MetaTableTenantDbProvider } = await import("@open-managed-agents/tenant-db");
+    const auth = { __label: "AUTH_DB" } as unknown as D1Database;
+    const provider = new MetaTableTenantDbProvider(
+      { AUTH_DB: auth },
+      makeFakeDb([null]), // control-plane returns no row
+      auth,
+    );
+    const result = await provider.resolve("tn_no_shard");
+    expect(result).toBe(auth);
+  });
+
+  it("returns the env-bound D1 when tenant_shard has a row", async () => {
+    const { MetaTableTenantDbProvider } = await import("@open-managed-agents/tenant-db");
+    const auth = { __label: "AUTH_DB" } as unknown as D1Database;
+    const db001 = { __label: "DB_001" } as unknown as D1Database;
+    const provider = new MetaTableTenantDbProvider(
+      { AUTH_DB: auth, DB_001: db001 },
+      makeFakeDb([{ binding_name: "DB_001" }]),
+      auth,
+    );
+    const result = await provider.resolve("tn_on_db001");
+    expect(result).toBe(db001);
+  });
+
+  it("caches per-tenant — second resolve does not re-query control plane", async () => {
+    const { MetaTableTenantDbProvider } = await import("@open-managed-agents/tenant-db");
+    const auth = { __label: "AUTH_DB" } as unknown as D1Database;
+    const db007 = { __label: "DB_007" } as unknown as D1Database;
+    let queryCount = 0;
+    const trackingDb = {
+      prepare: () => ({
+        bind: () => ({
+          first: async () => {
+            queryCount++;
+            return { binding_name: "DB_007" };
+          },
+        }),
+      }),
+    } as unknown as D1Database;
+    const provider = new MetaTableTenantDbProvider(
+      { AUTH_DB: auth, DB_007: db007 },
+      trackingDb,
+      auth,
+    );
+    await provider.resolve("tn_cached");
+    await provider.resolve("tn_cached");
+    await provider.resolve("tn_cached");
+    expect(queryCount).toBe(1);
+  });
+
+  it("control-plane lookup failure falls back to defaultBinding (graceful degradation)", async () => {
+    const { MetaTableTenantDbProvider } = await import("@open-managed-agents/tenant-db");
+    const auth = { __label: "AUTH_DB" } as unknown as D1Database;
+    const failingDb = {
+      prepare: () => ({
+        bind: () => ({
+          first: async () => {
+            throw new Error("D1 unreachable");
+          },
+        }),
+      }),
+    } as unknown as D1Database;
+    const provider = new MetaTableTenantDbProvider(
+      { AUTH_DB: auth },
+      failingDb,
+      auth,
+    );
+    const result = await provider.resolve("tn_failing");
+    expect(result).toBe(auth);
+  });
+
+  it("throws when tenant_shard row references a binding that doesn't exist in env", async () => {
+    const { MetaTableTenantDbProvider } = await import("@open-managed-agents/tenant-db");
+    const auth = { __label: "AUTH_DB" } as unknown as D1Database;
+    const provider = new MetaTableTenantDbProvider(
+      { AUTH_DB: auth }, // no DB_999 binding
+      makeFakeDb([{ binding_name: "DB_999" }]),
+      auth,
+    );
+    await expect(provider.resolve("tn_misconfigured")).rejects.toThrow(/DB_999.+env doesn't have it/);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -36,6 +36,10 @@ export default defineConfig({
       "@open-managed-agents/session-secrets-store/test-fakes": "./packages/session-secrets-store/src/test-fakes.ts",
       "@open-managed-agents/session-secrets-store": "./packages/session-secrets-store/src/index.ts",
       "@open-managed-agents/services": "./packages/services/src/index.ts",
+      "@open-managed-agents/tenant-db/test-fakes": "./packages/tenant-db/src/test-fakes.ts",
+      "@open-managed-agents/tenant-db": "./packages/tenant-db/src/index.ts",
+      "@open-managed-agents/tenant-dbs-store/test-fakes": "./packages/tenant-dbs-store/src/test-fakes.ts",
+      "@open-managed-agents/tenant-dbs-store": "./packages/tenant-dbs-store/src/index.ts",
     },
   },
   test: {


### PR DESCRIPTION
## Summary

- Adds `TenantDbProvider` abstraction + `MetaTableTenantDbProvider` (meta-table router with permanent per-isolate cache + AUTH_DB fallback) — N=1 behaviour unchanged, scales to N>1 by adding bindings + writing `tenant_shard` rows, no rehash ever.
- Fixes a real schema bug: 8 integrations tables (`linear_*`, `github_apps`) were tenant-owned via FK-shaped joins only. Now all 21 per-tenant tables have `tenant_id NOT NULL`.
- Adds `pickBackend` per-store backend dispatch (`STORE_BACKENDS` env JSON) so a single store can be swapped to a pg adapter without touching service / route code — for the CFless self-host path.

## Architecture decision

Started this work intending per-tenant D1 with static binding pool + CICD sync script. Multiple iterations (see commit body for full history): rejected dispatch namespace as over-isolated (worker-per-tenant breaks CFless), rejected HTTP REST API for 50–500ms latency overhead per query, rejected hash-mod-N sharding for rehash pain, rejected self-bind-on-demand because CF bindings are deploy-time metadata not runtime resources.

Landed on **meta-table router with explicit assignment**: `tenant_shard` (PK tenant_id → binding_name) + `shard_pool` (binding metadata + status + capacity). Adding shards is additive and never re-routes existing tenants.

## Test plan

- [x] pnpm typecheck clean
- [x] pnpm test — 1148 passed / 9 skipped / 0 failed
- [x] wrangler d1 migrations apply --local for 0001+0002+0003 — all ✅
- [x] Real SQLite NOT NULL enforcement verified
- [x] Orphan-row fail-loud verified
- [x] wrangler dev end-to-end (auth → tenantDb → services → repos)
- [x] STORE_BACKENDS pg dispatch error path verified
- [x] Staging DB migrations applied: shard_pool seed row confirmed
- [x] apps/main deployed to staging (Version 65306d59-979b-4fe3-b959-ff864130206a)
- [ ] Curl smoke against *.workers.dev blocked locally by DNS pollution
- [ ] apps/agent + apps/integrations staging deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)