### PR TITLE
ci(deploy): apply D1 migrations before deploying workers

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,6 +30,27 @@ jobs:
       - name: Build console
         run: pnpm --filter managed-agents-console build
 
+      # Apply D1 migrations BEFORE deploying any worker. New code that
+      # references columns / tables added in this PR will start serving
+      # traffic the moment the deploy step finishes, so the schema must
+      # already be in place. Fail-fast: if the migration apply fails, the
+      # deploy steps don't run — better than half-applied schema with
+      # mismatched worker code.
+      #
+      # `wrangler d1 migrations apply` is idempotent: it tracks applied
+      # names in `d1_migrations` and skips anything already done. So this
+      # step is safe to run on every push, including no-op pushes.
+      - name: Apply D1 migrations
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          cd apps/main
+          # `--remote` targets the prod D1 (binding AUTH_DB). The CI runner
+          # is non-interactive, so wrangler picks the default "yes" for the
+          # "DB may be unavailable during migration" prompt.
+          npx wrangler d1 migrations apply AUTH_DB --remote
+
       # --- Deploy both workers with retry ---
       - name: Deploy agent worker
         env:


### PR DESCRIPTION
## Summary

Add `wrangler d1 migrations apply AUTH_DB --remote` step in the Deploy workflow, before the worker deploy steps.

## Why

Previously the workflow only ran `wrangler deploy`, never migration apply. Any schema-changing PR shipped half-deployed: new worker code live, but the columns/tables it references not yet on prod D1.

PR #13 (tenant→shard router) tripped this — added 8 NOT NULL columns + 2 new tables. New worker code went live before migration ran. Saved only because the affected integrations tables had 0 rows; an install callback in that 4-minute window would have 500'd.

## Behaviour

- **Fail-fast**: migration apply runs before deploy. If it errors, deploy steps don't run — better to keep old worker + old schema than mismatch them.
- **Idempotent**: wrangler tracks applied migrations in `d1_migrations` table, no-op pushes do no work.
- **Prod only for now**: staging deploy isn't in this workflow (manual). Future work: extract reusable step + add staging job.

## Test plan

- [x] Diff is 1 file, 21 lines added (the new step)
- [x] Step ordering correct: Apply migrations → Deploy agent → Deploy main → Verify
- [ ] Next merge to main triggers the new step (the merge of this PR itself will be the canary; no migrations to apply yet so it's a clean no-op proving idempotence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)