### PR TITLE
feat(console+cli): Linear PAT install + autopilot dispatch UI

### DIFF
--- a/apps/console/src/integrations/api/client.ts
+++ b/apps/console/src/integrations/api/client.ts
@@ -18,6 +18,10 @@ import type {
   LinearInstallation,
   LinearPublication,
   LinearSubmitCredentialsInput,
+  LinearPersonalTokenInput,
+  LinearPersonalTokenResult,
+  LinearDispatchRule,
+  LinearDispatchRuleInput,
   PublishWizardInput,
   SessionSummary,
   SlackInstallation,
@@ -126,6 +130,56 @@ class LinearClient {
       method: "POST",
       body: JSON.stringify({ formToken }),
     });
+  }
+
+  /** Symphony-equivalent install: paste a Linear PAT, get a publication. */
+  async installPersonalToken(input: LinearPersonalTokenInput): Promise<LinearPersonalTokenResult> {
+    return request<LinearPersonalTokenResult>(
+      this.basePath,
+      "/v1/integrations/linear/personal-token",
+      { method: "POST", body: JSON.stringify(input) },
+    );
+  }
+
+  // ─── Linear: dispatch rules CRUD ────────────────────────────────────
+
+  async listDispatchRules(publicationId: string): Promise<LinearDispatchRule[]> {
+    const r = await request<{ rules: LinearDispatchRule[] }>(
+      this.basePath,
+      `/v1/integrations/linear/publications/${encodeURIComponent(publicationId)}/dispatch-rules`,
+    );
+    return r.rules;
+  }
+
+  async createDispatchRule(
+    publicationId: string,
+    input: LinearDispatchRuleInput,
+  ): Promise<LinearDispatchRule> {
+    return request<LinearDispatchRule>(
+      this.basePath,
+      `/v1/integrations/linear/publications/${encodeURIComponent(publicationId)}/dispatch-rules`,
+      { method: "POST", body: JSON.stringify(input) },
+    );
+  }
+
+  async updateDispatchRule(
+    publicationId: string,
+    ruleId: string,
+    patch: LinearDispatchRuleInput,
+  ): Promise<LinearDispatchRule> {
+    return request<LinearDispatchRule>(
+      this.basePath,
+      `/v1/integrations/linear/publications/${encodeURIComponent(publicationId)}/dispatch-rules/${encodeURIComponent(ruleId)}`,
+      { method: "PATCH", body: JSON.stringify(patch) },
+    );
+  }
+
+  async deleteDispatchRule(publicationId: string, ruleId: string): Promise<void> {
+    await request<unknown>(
+      this.basePath,
+      `/v1/integrations/linear/publications/${encodeURIComponent(publicationId)}/dispatch-rules/${encodeURIComponent(ruleId)}`,
+      { method: "DELETE" },
+    );
   }
 
   // ─── GitHub: list + manage ──────────────────────────────────────────
@@ -339,5 +393,20 @@ export class IntegrationsApi {
   }
   createHandoffLink(formToken: string): Promise<HandoffLink> {
     return this.linear.createHandoffLink(formToken);
+  }
+  installPersonalToken(input: LinearPersonalTokenInput): Promise<LinearPersonalTokenResult> {
+    return this.linear.installPersonalToken(input);
+  }
+  listDispatchRules(publicationId: string): Promise<LinearDispatchRule[]> {
+    return this.linear.listDispatchRules(publicationId);
+  }
+  createDispatchRule(publicationId: string, input: LinearDispatchRuleInput): Promise<LinearDispatchRule> {
+    return this.linear.createDispatchRule(publicationId, input);
+  }
+  updateDispatchRule(publicationId: string, ruleId: string, patch: LinearDispatchRuleInput): Promise<LinearDispatchRule> {
+    return this.linear.updateDispatchRule(publicationId, ruleId, patch);
+  }
+  deleteDispatchRule(publicationId: string, ruleId: string): Promise<void> {
+    return this.linear.deleteDispatchRule(publicationId, ruleId);
   }
 }

--- a/apps/console/src/integrations/api/types.ts
+++ b/apps/console/src/integrations/api/types.ts
@@ -115,6 +115,46 @@ export interface LinearSubmitCredentialsInput {
   webhookSecret: string;
 }
 
+/** Symphony-equivalent install — Personal API Key in one shot, no OAuth dance. */
+export interface LinearPersonalTokenInput {
+  agentId: string;
+  environmentId: string;
+  personaName: string;
+  personaAvatarUrl?: string | null;
+  /** Linear PAT, format `lin_api_…`. Validated via viewer query before vault write. */
+  patToken: string;
+}
+
+export interface LinearPersonalTokenResult {
+  publicationId: string;
+}
+
+/** Cron-driven autopilot rule. One rule belongs to one publication. */
+export interface LinearDispatchRule {
+  id: string;
+  publication_id: string;
+  name: string;
+  enabled: boolean;
+  filter_label: string | null;
+  filter_states: string[] | null;
+  filter_project_id: string | null;
+  max_concurrent: number;
+  poll_interval_seconds: number;
+  last_polled_at: number | null;
+  created_at: number;
+  updated_at: number;
+}
+
+export interface LinearDispatchRuleInput {
+  name?: string;
+  enabled?: boolean;
+  filter_label?: string | null;
+  filter_states?: string[] | null;
+  filter_project_id?: string | null;
+  max_concurrent?: number;
+  poll_interval_seconds?: number;
+}
+
 // ─── GitHub ────────────────────────────────────────────────────────────
 
 export interface GitHubInstallation {

--- a/apps/console/src/integrations/index.ts
+++ b/apps/console/src/integrations/index.ts
@@ -6,6 +6,7 @@
 export { IntegrationsLinearList } from "./pages/IntegrationsLinearList";
 export { IntegrationsLinearWorkspace } from "./pages/IntegrationsLinearWorkspace";
 export { IntegrationsLinearPublishWizard } from "./pages/IntegrationsLinearPublishWizard";
+export { IntegrationsLinearPatInstall } from "./pages/IntegrationsLinearPatInstall";
 export { IntegrationsGitHubList } from "./pages/IntegrationsGitHubList";
 export { IntegrationsGitHubWorkspace } from "./pages/IntegrationsGitHubWorkspace";
 export { IntegrationsGitHubBindWizard } from "./pages/IntegrationsGitHubBindWizard";
@@ -19,6 +20,10 @@ export type {
   LinearInstallation,
   LinearPublication,
   LinearSubmitCredentialsInput,
+  LinearPersonalTokenInput,
+  LinearPersonalTokenResult,
+  LinearDispatchRule,
+  LinearDispatchRuleInput,
   SlackInstallation,
   SlackPublication,
   SlackSubmitCredentialsInput,

--- a/apps/console/src/integrations/pages/IntegrationsLinearList.tsx
+++ b/apps/console/src/integrations/pages/IntegrationsLinearList.tsx
@@ -51,13 +51,22 @@ export function IntegrationsLinearList() {
               in comments, watch them push status.
             </p>
           </div>
-          <Link
-            to="/integrations/linear/publish"
-            className="shrink-0 inline-flex items-center gap-1.5 px-3.5 py-2 bg-brand text-brand-fg rounded-md text-[13px] font-medium hover:bg-brand-hover transition-colors whitespace-nowrap"
-          >
-            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><path d="M12 5v14M5 12h14" /></svg>
-            Publish agent
-          </Link>
+          <div className="shrink-0 flex items-center gap-2">
+            <Link
+              to="/integrations/linear/install-pat"
+              className="inline-flex items-center gap-1.5 px-3.5 py-2 border border-border rounded-md text-[13px] font-medium hover:border-brand transition-colors whitespace-nowrap"
+              title="Symphony-equivalent: paste a Linear PAT, no OAuth dance"
+            >
+              Install via PAT
+            </Link>
+            <Link
+              to="/integrations/linear/publish"
+              className="inline-flex items-center gap-1.5 px-3.5 py-2 bg-brand text-brand-fg rounded-md text-[13px] font-medium hover:bg-brand-hover transition-colors whitespace-nowrap"
+            >
+              <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><path d="M12 5v14M5 12h14" /></svg>
+              Publish agent
+            </Link>
+          </div>
         </header>
 
         {loading && <p className="text-sm text-fg-muted">Loading…</p>}

--- a/apps/console/src/integrations/pages/IntegrationsLinearPatInstall.tsx
+++ b/apps/console/src/integrations/pages/IntegrationsLinearPatInstall.tsx
@@ -1,0 +1,197 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router";
+import { IntegrationsApi } from "../api/client";
+
+const api = new IntegrationsApi();
+
+interface AgentOption {
+  id: string;
+  name: string;
+}
+
+interface EnvironmentOption {
+  id: string;
+  name: string;
+}
+
+interface Props {
+  loadAgents: () => Promise<AgentOption[]>;
+  loadEnvironments: () => Promise<EnvironmentOption[]>;
+}
+
+/**
+ * Install Linear via Personal API Key — Symphony-equivalent: paste PAT,
+ * pick agent + environment, done. No OAuth dance, no Linear OAuth app to
+ * register.
+ *
+ * Tradeoffs vs A1 OAuth-app install:
+ *   - bot identity is the PAT owner (their face on every comment)
+ *   - no AgentSession panel UX (Linear can't open a panel for a non-app user)
+ *   - cron-driven autopilot only — no realtime webhook trigger
+ * For a single-user setup or small private workspace this is the fast path.
+ */
+export function IntegrationsLinearPatInstall({ loadAgents, loadEnvironments }: Props) {
+  const navigate = useNavigate();
+  const [agents, setAgents] = useState<AgentOption[]>([]);
+  const [envs, setEnvs] = useState<EnvironmentOption[]>([]);
+  const [agentId, setAgentId] = useState("");
+  const [envId, setEnvId] = useState("");
+  const [personaName, setPersonaName] = useState("");
+  const [pat, setPat] = useState("");
+  const [working, setWorking] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    void (async () => {
+      try {
+        const [a, e] = await Promise.all([loadAgents(), loadEnvironments()]);
+        setAgents(a);
+        setEnvs(e);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err));
+      }
+    })();
+  }, [loadAgents, loadEnvironments]);
+
+  // Default persona to the agent's name if still empty.
+  useEffect(() => {
+    if (!personaName && agentId) {
+      const agent = agents.find((a) => a.id === agentId);
+      if (agent) setPersonaName(agent.name);
+    }
+  }, [agentId, agents, personaName]);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    if (!agentId || !envId || !personaName.trim() || !pat.trim()) {
+      setError("All fields required");
+      return;
+    }
+    setWorking(true);
+    try {
+      const res = await api.installPersonalToken({
+        agentId,
+        environmentId: envId,
+        personaName: personaName.trim(),
+        personaAvatarUrl: null,
+        patToken: pat.trim(),
+      });
+      // Navigate to the publication detail (workspace page) so user can
+      // immediately configure dispatch rules.
+      navigate(`/integrations/linear`);
+      void res.publicationId;
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setWorking(false);
+    }
+  }
+
+  return (
+    <div className="flex-1 overflow-y-auto">
+      <div className="max-w-[720px] mx-auto px-8 lg:px-10 py-10 lg:py-12">
+        <header className="mb-8">
+          <h1 className="font-display text-[28px] leading-tight font-semibold tracking-tight text-fg">
+            Install Linear via Personal API Key
+          </h1>
+          <p className="mt-1.5 text-[14px] text-fg-muted max-w-xl">
+            Paste a Linear PAT, pick the agent + environment to bind. Bot
+            actions in Linear will be attributed to the PAT owner. For full
+            agent identity (panel UX, dedicated bot user), use{" "}
+            <a className="text-accent underline" href="/integrations/linear/publish">
+              Publish agent
+            </a>{" "}
+            instead.
+          </p>
+        </header>
+
+        {error && (
+          <div className="mb-4 px-4 py-3 rounded-md border border-red-500/40 bg-red-500/10 text-[13px] text-red-300">
+            {error}
+          </div>
+        )}
+
+        <form onSubmit={handleSubmit} className="space-y-5">
+          <div>
+            <label className="block text-[13px] font-medium text-fg mb-1.5">Agent</label>
+            <select
+              className="w-full px-3 py-2 rounded-md border border-border bg-bg text-[14px]"
+              value={agentId}
+              onChange={(e) => setAgentId(e.target.value)}
+            >
+              <option value="">— pick an agent —</option>
+              {agents.map((a) => (
+                <option key={a.id} value={a.id}>
+                  {a.name} ({a.id})
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div>
+            <label className="block text-[13px] font-medium text-fg mb-1.5">Environment</label>
+            <select
+              className="w-full px-3 py-2 rounded-md border border-border bg-bg text-[14px]"
+              value={envId}
+              onChange={(e) => setEnvId(e.target.value)}
+            >
+              <option value="">— pick an environment —</option>
+              {envs.map((e) => (
+                <option key={e.id} value={e.id}>
+                  {e.name} ({e.id})
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div>
+            <label className="block text-[13px] font-medium text-fg mb-1.5">
+              Persona display name
+            </label>
+            <input
+              className="w-full px-3 py-2 rounded-md border border-border bg-bg text-[14px]"
+              placeholder="e.g. Coder"
+              value={personaName}
+              onChange={(e) => setPersonaName(e.target.value)}
+            />
+          </div>
+
+          <div>
+            <label className="block text-[13px] font-medium text-fg mb-1.5">
+              Linear Personal API Key
+            </label>
+            <input
+              type="password"
+              className="w-full px-3 py-2 rounded-md border border-border bg-bg text-[14px] font-mono"
+              placeholder="lin_api_…"
+              value={pat}
+              onChange={(e) => setPat(e.target.value)}
+              autoComplete="off"
+            />
+            <p className="mt-1 text-[12px] text-fg-muted">
+              Generate at Linear → Settings → Security &amp; access → Personal API keys.
+              Stored encrypted in your tenant vault; not shared with agents directly.
+            </p>
+          </div>
+
+          <div className="flex items-center gap-3 pt-2">
+            <button
+              type="submit"
+              disabled={working}
+              className="px-4 py-2 rounded-md bg-accent text-accent-fg text-[14px] font-medium disabled:opacity-50"
+            >
+              {working ? "Installing…" : "Install"}
+            </button>
+            <a
+              href="/integrations/linear"
+              className="px-4 py-2 text-[14px] text-fg-muted hover:text-fg"
+            >
+              Cancel
+            </a>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/apps/console/src/integrations/pages/IntegrationsLinearWorkspace.tsx
+++ b/apps/console/src/integrations/pages/IntegrationsLinearWorkspace.tsx
@@ -1,7 +1,11 @@
 import { useEffect, useState } from "react";
 import { Link, useParams } from "react-router";
 import { IntegrationsApi } from "../api/client";
-import type { LinearInstallation, LinearPublication } from "../api/types";
+import type {
+  LinearInstallation,
+  LinearPublication,
+  LinearDispatchRule,
+} from "../api/types";
 
 const api = new IntegrationsApi();
 
@@ -277,7 +281,184 @@ function PublicationCard({
           </div>
         </div>
       )}
+      {open && <DispatchRulesSection publicationId={pub.id} />}
     </div>
+  );
+}
+
+/**
+ * Cron-driven autopilot rules for a publication. Each rule defines a filter
+ * (label / state / project) — the cron sweep assigns matching unassigned
+ * issues to this bot. Symphony-style "issue lands in Todo → bot picks it up
+ * automatically", scoped per-publication.
+ */
+function DispatchRulesSection({ publicationId }: { publicationId: string }) {
+  const [rules, setRules] = useState<LinearDispatchRule[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [showCreate, setShowCreate] = useState(false);
+
+  async function load() {
+    setError(null);
+    try {
+      const r = await api.listDispatchRules(publicationId);
+      setRules(r);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  }
+  useEffect(() => { void load(); }, [publicationId]);
+
+  async function toggle(rule: LinearDispatchRule) {
+    try {
+      await api.updateDispatchRule(publicationId, rule.id, { enabled: !rule.enabled });
+      await load();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  }
+
+  async function remove(rule: LinearDispatchRule) {
+    if (!confirm(`Delete rule "${rule.name}"?`)) return;
+    try {
+      await api.deleteDispatchRule(publicationId, rule.id);
+      await load();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  }
+
+  return (
+    <div className="border-t border-border px-5 py-4 bg-bg-surface/30">
+      <div className="flex items-center justify-between mb-3">
+        <div>
+          <h4 className="text-[13px] font-medium text-fg">Autopilot rules</h4>
+          <p className="text-[12px] text-fg-muted">
+            Cron sweep assigns matching unassigned issues to this bot. At least one filter required (matching everything is a footgun).
+          </p>
+        </div>
+        <button
+          onClick={() => setShowCreate((s) => !s)}
+          className="px-3 py-1.5 text-[12px] rounded-md border border-border hover:border-brand transition-colors"
+        >
+          {showCreate ? "Cancel" : "+ Add rule"}
+        </button>
+      </div>
+
+      {error && <div className="mb-3 px-3 py-2 rounded-md bg-red-500/10 border border-red-500/40 text-[12px] text-red-300">{error}</div>}
+
+      {showCreate && (
+        <CreateRuleForm
+          publicationId={publicationId}
+          onCreated={() => { setShowCreate(false); void load(); }}
+        />
+      )}
+
+      {rules === null && <p className="text-[12px] text-fg-muted">Loading…</p>}
+      {rules?.length === 0 && (
+        <p className="text-[12px] text-fg-muted">No rules. Add one to enable autopilot.</p>
+      )}
+      {rules && rules.length > 0 && (
+        <div className="space-y-2">
+          {rules.map((r) => (
+            <div key={r.id} className="border border-border rounded-md px-3 py-2 bg-bg flex items-center justify-between text-[12px]">
+              <div className="min-w-0">
+                <div className="font-medium text-fg flex items-center gap-2">
+                  {r.name}
+                  {!r.enabled && <span className="text-fg-subtle">(disabled)</span>}
+                </div>
+                <div className="text-fg-muted font-mono text-[11px] mt-0.5">
+                  {r.filter_label && <>label=<code>{r.filter_label}</code> </>}
+                  {r.filter_states && r.filter_states.length > 0 && <>states=<code>{r.filter_states.join(",")}</code> </>}
+                  {r.filter_project_id && <>project=<code>{r.filter_project_id.slice(0, 8)}…</code> </>}
+                  · max={r.max_concurrent} · poll={r.poll_interval_seconds}s
+                  {r.last_polled_at && ` · last=${new Date(r.last_polled_at).toLocaleTimeString()}`}
+                </div>
+              </div>
+              <div className="flex items-center gap-2">
+                <button onClick={() => toggle(r)} className="px-2 py-1 text-[11px] hover:underline">
+                  {r.enabled ? "Disable" : "Enable"}
+                </button>
+                <button onClick={() => remove(r)} className="px-2 py-1 text-[11px] text-danger hover:underline">
+                  Delete
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function CreateRuleForm({
+  publicationId,
+  onCreated,
+}: {
+  publicationId: string;
+  onCreated: () => void;
+}) {
+  const [name, setName] = useState("Auto-pickup");
+  const [label, setLabel] = useState("bot-ready");
+  const [states, setStates] = useState("Todo");
+  const [maxC, setMaxC] = useState(5);
+  const [poll, setPoll] = useState(600);
+  const [working, setWorking] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    if (!label.trim() && !states.trim()) {
+      setError("Need at least a label or a state");
+      return;
+    }
+    setWorking(true);
+    try {
+      await api.createDispatchRule(publicationId, {
+        name: name.trim() || "Auto-pickup",
+        filter_label: label.trim() || null,
+        filter_states: states.trim() ? states.split(",").map((s) => s.trim()).filter(Boolean) : null,
+        filter_project_id: null,
+        max_concurrent: maxC,
+        poll_interval_seconds: poll,
+      });
+      onCreated();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setWorking(false);
+    }
+  }
+
+  return (
+    <form onSubmit={submit} className="mb-3 border border-border rounded-md p-3 bg-bg space-y-2 text-[12px]">
+      {error && <div className="px-2 py-1.5 rounded bg-red-500/10 border border-red-500/40 text-red-300">{error}</div>}
+      <div className="grid grid-cols-2 gap-2">
+        <label className="flex flex-col gap-1">
+          <span className="text-fg-muted">Name</span>
+          <input value={name} onChange={(e) => setName(e.target.value)} className="px-2 py-1 border border-border rounded bg-bg" />
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className="text-fg-muted">Filter label</span>
+          <input value={label} onChange={(e) => setLabel(e.target.value)} placeholder="bot-ready" className="px-2 py-1 border border-border rounded bg-bg font-mono" />
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className="text-fg-muted">States (comma)</span>
+          <input value={states} onChange={(e) => setStates(e.target.value)} placeholder="Todo" className="px-2 py-1 border border-border rounded bg-bg font-mono" />
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className="text-fg-muted">Max concurrent</span>
+          <input type="number" value={maxC} onChange={(e) => setMaxC(parseInt(e.target.value, 10) || 1)} min="1" max="100" className="px-2 py-1 border border-border rounded bg-bg" />
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className="text-fg-muted">Poll interval (s)</span>
+          <input type="number" value={poll} onChange={(e) => setPoll(parseInt(e.target.value, 10) || 60)} min="60" max="86400" className="px-2 py-1 border border-border rounded bg-bg" />
+        </label>
+      </div>
+      <button type="submit" disabled={working} className="px-3 py-1.5 bg-brand text-brand-fg rounded text-[12px] disabled:opacity-50">
+        {working ? "Creating…" : "Create rule"}
+      </button>
+    </form>
   );
 }
 

--- a/apps/console/src/main.tsx
+++ b/apps/console/src/main.tsx
@@ -22,6 +22,7 @@ import {
   IntegrationsLinearList,
   IntegrationsLinearWorkspace,
   IntegrationsLinearPublishPage,
+  IntegrationsLinearPatInstallPage,
 } from "./pages/IntegrationsLinear";
 import {
   IntegrationsGitHubList,
@@ -58,6 +59,10 @@ createRoot(document.getElementById("root")!).render(
             <Route
               path="integrations/linear/publish"
               element={<IntegrationsLinearPublishPage />}
+            />
+            <Route
+              path="integrations/linear/install-pat"
+              element={<IntegrationsLinearPatInstallPage />}
             />
             <Route
               path="integrations/linear/installations/:id"

--- a/apps/console/src/pages/IntegrationsLinear.tsx
+++ b/apps/console/src/pages/IntegrationsLinear.tsx
@@ -1,5 +1,6 @@
 import {
   IntegrationsLinearList,
+  IntegrationsLinearPatInstall,
   IntegrationsLinearPublishWizard,
   IntegrationsLinearWorkspace,
 } from "../integrations";
@@ -13,6 +14,27 @@ export function IntegrationsLinearPublishPage() {
   const { api } = useApi();
   return (
     <IntegrationsLinearPublishWizard
+      loadAgents={async () => {
+        const r = await api<{ data: Array<{ id: string; name: string }> }>(
+          "/v1/agents?limit=200",
+        );
+        return r.data;
+      }}
+      loadEnvironments={async () => {
+        const r = await api<{ data: Array<{ id: string; name: string }> }>(
+          "/v1/environments?limit=200",
+        );
+        return r.data;
+      }}
+    />
+  );
+}
+
+/** Fast-path install via Personal API Key — bypasses OAuth dance. */
+export function IntegrationsLinearPatInstallPage() {
+  const { api } = useApi();
+  return (
+    <IntegrationsLinearPatInstall
       loadAgents={async () => {
         const r = await api<{ data: Array<{ id: string; name: string }> }>(
           "/v1/agents?limit=200",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1147,6 +1147,142 @@ const commands: Cmd[] = [
       console.log(`Unpublished: ${args[0]}`);
     },
   },
+  {
+    group: "Linear", match: ["linear", "install-pat"], needsArg: false,
+    usage: "oma linear install-pat --pat <token> --agent <id> --env <id> [--persona <name>]",
+    desc: "Install Linear via Personal API Key (Symphony-equivalent — no OAuth dance)",
+    http: "POST   /v1/integrations/linear/personal-token {agentId, environmentId, personaName, patToken}",
+    async run(config, args) {
+      const pat = flag(args, "--pat") ?? process.env.LINEAR_API_KEY ?? "";
+      const agentId = flag(args, "--agent") ?? "";
+      const envId = flag(args, "--env") ?? "";
+      const persona = flag(args, "--persona") || "Linear bot (PAT)";
+      if (!pat || !agentId || !envId) {
+        console.error("Usage: oma linear install-pat --pat <token> --agent <id> --env <id> [--persona <name>]");
+        console.error("  --pat may also be supplied via LINEAR_API_KEY env var.");
+        process.exit(1);
+      }
+      const result = await apiFetch<{ publicationId: string }>(
+        config,
+        "/v1/integrations/linear/personal-token",
+        {
+          method: "POST",
+          body: JSON.stringify({
+            agentId,
+            environmentId: envId,
+            personaName: persona,
+            personaAvatarUrl: null,
+            patToken: pat,
+          }),
+        },
+      );
+      if (config.json) { console.log(JSON.stringify(result, null, 2)); return; }
+      console.log(`Installed via PAT. Publication: ${result.publicationId}`);
+      console.log(`Next: configure autopilot rules with`);
+      console.log(`  oma linear rules create ${result.publicationId} --label bot-ready`);
+    },
+  },
+  {
+    group: "Linear", match: ["linear", "rules", "list"], needsArg: true,
+    usage: "oma linear rules list <publication-id>", desc: "List dispatch rules for a publication",
+    http: "GET    /v1/integrations/linear/publications/:id/dispatch-rules",
+    async run(config, args) {
+      const { rules } = await apiFetch<{ rules: Array<any> }>(
+        config,
+        `/v1/integrations/linear/publications/${args[0]}/dispatch-rules`,
+      );
+      if (config.json) { console.log(JSON.stringify(rules, null, 2)); return; }
+      if (!rules.length) { console.log("No rules. Create with: oma linear rules create <pub-id> --label <name>"); return; }
+      table([
+        ["RULE ID", "NAME", "EN", "LABEL", "STATES", "MAX", "POLL", "LAST"],
+        ...rules.map((r: any) => [
+          r.id, r.name, r.enabled ? "y" : "n",
+          r.filter_label ?? "-",
+          (r.filter_states ?? []).join(",") || "-",
+          String(r.max_concurrent),
+          `${r.poll_interval_seconds}s`,
+          r.last_polled_at ? new Date(r.last_polled_at).toLocaleTimeString() : "never",
+        ]),
+      ]);
+    },
+  },
+  {
+    group: "Linear", match: ["linear", "rules", "create"], needsArg: true,
+    usage: "oma linear rules create <publication-id> [--name <s>] [--label <s>] [--states <Todo,...>] [--project <id>] [--max <n>] [--poll <s>]",
+    desc: "Create a dispatch rule. At least one of --label, --states, --project required.",
+    http: "POST   /v1/integrations/linear/publications/:id/dispatch-rules",
+    async run(config, args) {
+      const pubId = args[0];
+      const name = flag(args, "--name") || "Auto-pickup";
+      const label = flag(args, "--label") || null;
+      const statesRaw = flag(args, "--states") || "";
+      const states = statesRaw ? statesRaw.split(",").map(s => s.trim()).filter(Boolean) : null;
+      const project = flag(args, "--project") || null;
+      const maxC = parseInt(flag(args, "--max") || "5", 10);
+      const poll = parseInt(flag(args, "--poll") || "600", 10);
+      if (!label && !states && !project) {
+        console.error("At least one of --label, --states, --project is required (matching everything is a footgun).");
+        process.exit(1);
+      }
+      const r = await apiFetch<any>(
+        config,
+        `/v1/integrations/linear/publications/${pubId}/dispatch-rules`,
+        {
+          method: "POST",
+          body: JSON.stringify({
+            name, filter_label: label, filter_states: states,
+            filter_project_id: project, max_concurrent: maxC, poll_interval_seconds: poll,
+          }),
+        },
+      );
+      if (config.json) { console.log(JSON.stringify(r, null, 2)); return; }
+      console.log(`Created rule ${r.id} (${r.name}). Cron picks up issues matching this rule next tick (~1 min).`);
+    },
+  },
+  {
+    group: "Linear", match: ["linear", "rules", "patch"], needsArg: true,
+    usage: "oma linear rules patch <publication-id> <rule-id> [--enabled true|false] [--label <s>] [--states <Todo,...>] [--max <n>] [--poll <s>]",
+    desc: "Update a dispatch rule. Pass only fields to change.",
+    http: "PATCH  /v1/integrations/linear/publications/:id/dispatch-rules/:ruleId",
+    async run(config, args) {
+      const pubId = args[0];
+      const ruleId = args[1];
+      if (!pubId || !ruleId) { console.error("Usage: oma linear rules patch <publication-id> <rule-id> [...flags]"); process.exit(1); }
+      const patch: any = {};
+      const name = flag(args, "--name"); if (name !== undefined) patch.name = name;
+      const enabled = flag(args, "--enabled"); if (enabled !== undefined) patch.enabled = enabled === "true";
+      const label = flag(args, "--label"); if (label !== undefined) patch.filter_label = label || null;
+      const statesRaw = flag(args, "--states");
+      if (statesRaw !== undefined) patch.filter_states = statesRaw ? statesRaw.split(",").map(s => s.trim()).filter(Boolean) : null;
+      const project = flag(args, "--project"); if (project !== undefined) patch.filter_project_id = project || null;
+      const maxC = flag(args, "--max"); if (maxC !== undefined) patch.max_concurrent = parseInt(maxC, 10);
+      const poll = flag(args, "--poll"); if (poll !== undefined) patch.poll_interval_seconds = parseInt(poll, 10);
+      const r = await apiFetch<any>(
+        config,
+        `/v1/integrations/linear/publications/${pubId}/dispatch-rules/${ruleId}`,
+        { method: "PATCH", body: JSON.stringify(patch) },
+      );
+      if (config.json) { console.log(JSON.stringify(r, null, 2)); return; }
+      console.log(`Updated rule ${r.id}.`);
+    },
+  },
+  {
+    group: "Linear", match: ["linear", "rules", "delete"], needsArg: true,
+    usage: "oma linear rules delete <publication-id> <rule-id>",
+    desc: "Delete a dispatch rule",
+    http: "DELETE /v1/integrations/linear/publications/:id/dispatch-rules/:ruleId",
+    async run(config, args) {
+      const pubId = args[0];
+      const ruleId = args[1];
+      if (!pubId || !ruleId) { console.error("Usage: oma linear rules delete <publication-id> <rule-id>"); process.exit(1); }
+      await apiFetch(
+        config,
+        `/v1/integrations/linear/publications/${pubId}/dispatch-rules/${ruleId}`,
+        { method: "DELETE" },
+      );
+      console.log(`Deleted rule ${ruleId}.`);
+    },
+  },
 
   // GitHub integration — mirrors `oma linear *` shape exactly.
   {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1925,9 +1925,7 @@ async function main() {
   // the user typed a real subcommand but forgot the required positional.
   let needsArgMatch: Cmd | null = null;
   for (const c of commands) {
-    const verbMatch = c.match.length === 1
-      ? args[0] === c.match[0]
-      : args[0] === c.match[0] && args[1] === c.match[1];
+    const verbMatch = c.match.every((tok, i) => args[i] === tok);
     if (!verbMatch) continue;
     if (c.needsArg && !args[c.match.length]) {
       needsArgMatch = c;


### PR DESCRIPTION
## Summary

Follow-up to #21 — wires the Console UI and `oma` CLI to the new backend endpoints.

- **Console**: new `/integrations/linear/install-pat` page (Symphony-equivalent one-shot install via Linear Personal API Key — no OAuth dance), plus an "Autopilot rules" section on the workspace page (list/create/toggle/delete cron-driven dispatch rules per publication).
- **CLI**: `oma linear install-pat` and `oma linear rules list|create|patch|delete` for headless workflows.
- **CLI fix** (`0967ebb`): the dispatcher only matched the first 2 verb tokens, so `oma linear rules <create|patch|delete>` all silently ran `list`. Now uses `match.every()`.

## Test plan
- [x] Console PAT install form submits to `/v1/integrations/linear/personal-token`; backend 400 surfaces inline
- [x] Console `+ Add rule` form posts → new rule appears in list (verified via API)
- [x] Console `Disable` toggles `enabled: false`
- [x] Console `Delete` removes the rule
- [x] CLI `linear rules list` — renders table
- [x] CLI `linear rules create` — POST hits the right route (after fix)
- [x] CLI `linear rules patch --enabled false` — disables
- [x] CLI `linear rules delete` — removes
- [x] Console SPA built clean and deployed to staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)