### PR TITLE
Local ACP runtime + per-agent local-skill blocklist

### DIFF
--- a/.github/workflows/deploy-lane.yml
+++ b/.github/workflows/deploy-lane.yml
@@ -16,6 +16,11 @@ on:
         required: true
         type: boolean
         default: false
+      workers:
+        description: 'Subset of workers to redeploy (comma-separated): main,agent,integrations. Default = all (full lane bring-up).'
+        required: false
+        type: string
+        default: 'all'
 
 # Allow concurrent deploys of different lanes; serialize within a single lane.
 concurrency:
@@ -95,7 +100,14 @@ jobs:
       #   3. main (binds integrations + agent, both exist)
       #   4. integrations re-deploy (now with MAIN binding to lane main)
       # jq is preinstalled on ubuntu-latest.
+      #
+      # `workers` input opts into single-worker redeploy when the lane is
+      # already up and you only changed one app's code. Skips the whole
+      # circular-binding dance — wrangler updates the script in place and the
+      # bindings are already live from the prior full deploy. Pass e.g.
+      # `workers=agent` to redeploy only the agent worker (~30s vs ~5min).
       - name: Deploy integrations worker (stub, no service bindings yet)
+        if: contains(inputs.workers, 'all') || contains(inputs.workers, 'integrations')
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
@@ -106,6 +118,7 @@ jobs:
           npx wrangler deploy --config "wrangler.lane-${{ inputs.lane_name }}.stub.jsonc"
 
       - name: Deploy agent worker
+        if: contains(inputs.workers, 'all') || contains(inputs.workers, 'agent')
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
@@ -114,6 +127,7 @@ jobs:
           npx wrangler deploy --config wrangler.lane-${{ inputs.lane_name }}.jsonc
 
       - name: Deploy main worker
+        if: contains(inputs.workers, 'all') || contains(inputs.workers, 'main')
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
@@ -122,6 +136,7 @@ jobs:
           npx wrangler deploy --config wrangler.lane-${{ inputs.lane_name }}.jsonc
 
       - name: Re-deploy integrations worker (full config, MAIN binding live)
+        if: contains(inputs.workers, 'all') || contains(inputs.workers, 'integrations')
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
@@ -133,6 +148,7 @@ jobs:
       # silently — operators can `wrangler secret put` per worker post-hoc for
       # anything not in repo secrets.
       - name: Set worker secrets
+        if: contains(inputs.workers, 'all')
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/deploy-lane.yml
+++ b/.github/workflows/deploy-lane.yml
@@ -188,6 +188,11 @@ jobs:
           set_secret ANTHROPIC_BASE_URL           "$AGENT" "${{ secrets.ANTHROPIC_BASE_URL }}"
           set_secret INTERNAL_TOKEN               "$AGENT" "${{ secrets.INTERNAL_TOKEN }}"
           set_secret TAVILY_API_KEY               "$AGENT" "${{ secrets.TAVILY_API_KEY }}"
+          # AcpProxyHarness in the agent worker calls main's /v1/internal/*
+          # endpoints (runtime-attach-harness, runtime-session-bundle), which
+          # gate on this header secret. Without it, local-runtime sessions
+          # error with "INTEGRATIONS_INTERNAL_SECRET unset".
+          set_secret INTEGRATIONS_INTERNAL_SECRET "$AGENT" "${{ secrets.INTEGRATIONS_INTERNAL_SECRET }}"
 
           echo "Setting secrets on $INT:"
           set_secret API_KEY                      "$INT" "${{ secrets.API_KEY }}"

--- a/apps/agent/src/harness/acp-proxy-loop.ts
+++ b/apps/agent/src/harness/acp-proxy-loop.ts
@@ -1,0 +1,245 @@
+/**
+ * AcpProxyHarness — HarnessInterface implementation that delegates the agent
+ * loop to a Claude Code (or other ACP-compatible) child running on a user's
+ * registered local runtime.
+ *
+ * Per-turn flow:
+ *   1. Open a WebSocket through the MAIN service binding to the RuntimeRoom
+ *      DO (`/v1/internal/runtime-attach-harness?sid=...&runtime_id=...`).
+ *      DO holds it open and shuttles session.* messages to/from the daemon.
+ *   2. Send `session.start` (idempotent on the daemon — first time spawns the
+ *      ACP child, subsequent times short-circuits to session.ready).
+ *   3. Send `session.prompt { text, turn_id }` with the latest user message.
+ *   4. Drain `session.event` notifications via AcpTranslator → SessionEvent
+ *      broadcast through the runtime.
+ *   5. Resolve when `session.complete` arrives, error on `session.error` or
+ *      WS close. Honor `runtime.abortSignal` by sending `session.cancel`.
+ *
+ * Optional ports / no-op surface (Meta-harness fit):
+ *   - `onSessionInit`: no-op. System prompt + skills land on the user's
+ *     filesystem as AGENTS.md / `.claude/skills/...` via the daemon's bundle
+ *     fetch — they don't enter the events stream.
+ *   - `shouldCompact` / `compact` / `deriveModelContext`: ACP agents own their
+ *     own context; OMA doesn't drive a generateText call here. All return
+ *     false / no-op.
+ */
+
+import type { HarnessInterface, HarnessContext, HarnessRuntime } from "./interface";
+import type { SessionEvent, UserMessageEvent } from "@open-managed-agents/shared";
+import { AcpTranslator } from "./acp-translate";
+import { generateEventId, log, logError, logWarn } from "@open-managed-agents/shared";
+
+interface AttachedWs {
+  send(data: string): void;
+  close(code?: number, reason?: string): void;
+  addEventListener(
+    event: "message" | "close" | "error",
+    listener: (event: MessageEvent | CloseEvent | Event) => void,
+  ): void;
+}
+
+export class AcpProxyHarness implements HarnessInterface {
+  // No platform reminders for ACP path — the spawn-cwd AGENTS.md handles it.
+  async onSessionInit(): Promise<void> {
+    /* no-op */
+  }
+
+  shouldCompact(): boolean {
+    return false; // ACP agent manages its own context window
+  }
+
+  async compact(): Promise<void> {
+    /* no-op */
+  }
+
+  deriveModelContext(): never[] {
+    return []; // never called — we don't run generateText
+  }
+
+  async run(ctx: HarnessContext): Promise<void> {
+    const runtime = ctx.runtime;
+    const binding = ctx.agent.runtime_binding;
+    if (!binding) {
+      this.#emitError(runtime, "AcpProxyHarness requires agent.runtime_binding to be set");
+      return;
+    }
+
+    const env = ctx.env as unknown as { MAIN?: Fetcher; INTEGRATIONS_INTERNAL_SECRET?: string };
+    if (!env.MAIN) {
+      this.#emitError(runtime, "MAIN service binding missing on agent worker");
+      return;
+    }
+    if (!env.INTEGRATIONS_INTERNAL_SECRET) {
+      this.#emitError(runtime, "INTEGRATIONS_INTERNAL_SECRET unset — cannot call main internal endpoints");
+      return;
+    }
+
+    const sid = ctx.session_id ?? "";
+    if (!sid) {
+      this.#emitError(runtime, "AcpProxyHarness needs ctx.session_id but it was not set");
+      return;
+    }
+
+    const userText = extractUserText(ctx.userMessage);
+    if (!userText) {
+      this.#emitError(runtime, "Could not extract text from user message — empty turn");
+      return;
+    }
+
+    const ws = await this.#openHarnessWs(env.MAIN, env.INTEGRATIONS_INTERNAL_SECRET, sid, binding.runtime_id);
+    if (!ws) {
+      this.#emitError(runtime, "Failed to attach to RuntimeRoom — runtime_id may be invalid or daemon offline");
+      return;
+    }
+
+    const turnId = generateEventId();
+    const translator = new AcpTranslator(runtime);
+    const abortHandler = () => {
+      try { ws.send(JSON.stringify({ type: "session.cancel", turn_id: turnId })); } catch { /* ws may be dead */ }
+    };
+    runtime.abortSignal?.addEventListener("abort", abortHandler);
+
+    try {
+      // Wait for the DO's "attached" handshake (synthetic, daemon may also
+      // have replayed session.ready). After that the daemon is ready to
+      // receive session.start / session.prompt.
+      await waitForFrame(ws, (m) => m.type === "attached", 5_000);
+
+      // Idempotent session.start — daemon spawns ACP child on first call,
+      // short-circuits to session.ready on subsequent calls for the same sid.
+      ws.send(JSON.stringify({
+        type: "session.start",
+        agent_id: binding.acp_agent_id,
+      }));
+      await waitForFrame(ws, (m) => m.type === "session.ready" || m.type === "session.error", 60_000)
+        .then((m) => {
+          if (m.type === "session.error") throw new Error(`session.start failed: ${m.message ?? "unknown"}`);
+        });
+
+      ws.send(JSON.stringify({
+        type: "session.prompt",
+        turn_id: turnId,
+        text: userText,
+      }));
+
+      // Drain until session.complete or session.error or close.
+      await new Promise<void>((resolve, reject) => {
+        const onMessage = (ev: MessageEvent | CloseEvent | Event) => {
+          const data = (ev as MessageEvent).data;
+          if (typeof data !== "string") return;
+          let parsed: { type?: string; turn_id?: string; message?: string; event?: unknown };
+          try { parsed = JSON.parse(data); } catch { return; }
+
+          if (parsed.type === "session.event" && parsed.turn_id === turnId) {
+            void translator.consume(parsed as never);
+          } else if (parsed.type === "session.complete" && parsed.turn_id === turnId) {
+            resolve();
+          } else if (parsed.type === "session.error") {
+            reject(new Error(parsed.message ?? "session.error from runtime"));
+          }
+        };
+        const onClose = () => reject(new Error("WS to RuntimeRoom closed before turn complete"));
+        const onError = () => reject(new Error("WS error to RuntimeRoom"));
+        ws.addEventListener("message", onMessage);
+        ws.addEventListener("close", onClose);
+        ws.addEventListener("error", onError);
+      });
+
+      await translator.flush("completed");
+    } catch (err) {
+      const aborted = runtime.abortSignal?.aborted ?? false;
+      await translator.flush(aborted ? "aborted" : "completed");
+      const msg = err instanceof Error ? err.message : String(err);
+      if (aborted) {
+        log({ op: "acp_proxy.aborted", session_id: sid }, "user-aborted");
+      } else {
+        logError({ op: "acp_proxy.turn_failed", session_id: sid, err: msg }, "turn failed");
+        this.#emitError(runtime, msg);
+      }
+    } finally {
+      runtime.abortSignal?.removeEventListener("abort", abortHandler);
+      try { ws.close(1000, "turn done"); } catch { /* already closed */ }
+    }
+  }
+
+  #emitError(runtime: HarnessRuntime, message: string): void {
+    runtime.broadcast({ type: "session.error", error: message } as SessionEvent);
+  }
+
+  async #openHarnessWs(
+    main: Fetcher,
+    internalSecret: string,
+    sid: string,
+    runtimeId: string,
+  ): Promise<AttachedWs | null> {
+    const url = new URL("https://main.internal/v1/internal/runtime-attach-harness");
+    url.searchParams.set("sid", sid);
+    url.searchParams.set("runtime_id", runtimeId);
+    try {
+      const res = await main.fetch(
+        new Request(url.toString(), {
+          headers: {
+            Upgrade: "websocket",
+            "x-internal-secret": internalSecret,
+          },
+        }),
+      );
+      if (res.status !== 101 || !res.webSocket) {
+        logWarn(
+          { op: "acp_proxy.attach_failed", status: res.status, sid, runtime_id: runtimeId },
+          "harness WS attach didn't upgrade",
+        );
+        return null;
+      }
+      res.webSocket.accept();
+      return res.webSocket as unknown as AttachedWs;
+    } catch (e) {
+      logError({ op: "acp_proxy.attach_throw", err: String(e), sid }, "harness WS attach threw");
+      return null;
+    }
+  }
+}
+
+function extractUserText(msg: UserMessageEvent): string {
+  const content = msg.content;
+  if (!Array.isArray(content)) return "";
+  return (content as Array<{ type?: string; text?: string }>)
+    .filter((c) => c.type === "text" && typeof c.text === "string")
+    .map((c) => c.text!)
+    .join("\n")
+    .trim();
+}
+
+interface ParsedFrame {
+  type?: string;
+  message?: string;
+  [k: string]: unknown;
+}
+
+/** Wait for a single WS frame matching the predicate, with timeout. */
+function waitForFrame(
+  ws: AttachedWs,
+  pred: (msg: ParsedFrame) => boolean,
+  timeoutMs: number,
+): Promise<ParsedFrame> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error(`timeout waiting for matching frame (${timeoutMs}ms)`));
+    }, timeoutMs);
+    const onMessage = (ev: MessageEvent | CloseEvent | Event) => {
+      const data = (ev as MessageEvent).data;
+      if (typeof data !== "string") return;
+      let parsed: ParsedFrame;
+      try { parsed = JSON.parse(data); } catch { return; }
+      if (!pred(parsed)) return;
+      clearTimeout(timer);
+      resolve(parsed);
+    };
+    const onClose = () => {
+      clearTimeout(timer);
+      reject(new Error("WS closed while waiting for frame"));
+    };
+    ws.addEventListener("message", onMessage);
+    ws.addEventListener("close", onClose);
+  });
+}

--- a/apps/agent/src/harness/acp-translate.ts
+++ b/apps/agent/src/harness/acp-translate.ts
@@ -1,0 +1,204 @@
+/**
+ * Translate ACP `sessionUpdate` notifications into OMA `SessionEvent`s.
+ *
+ * ACP streams agent_message_chunk / agent_thought_chunk per token, with no
+ * explicit "message done" marker — the message is implicitly closed when a
+ * different sessionUpdate type arrives, or the turn completes (`session.complete`
+ * from the daemon side). This translator owns that boundary detection: it
+ * accumulates chunks per (kind, session) and flushes on transition.
+ *
+ * Output contract — for each closed message:
+ *   - `agent.message_chunk` for every delta during streaming (broadcast-only,
+ *     not persisted to events log)
+ *   - `agent.message_stream_start` once at first chunk
+ *   - `agent.message` once with the final concatenated text (this IS persisted)
+ *   - `agent.message_stream_end` once when the message closes
+ * For thinking, same shape with `agent.thinking_*` events.
+ *
+ * Tool calls (sessionUpdate "tool_call" / "tool_call_update") become OMA
+ * `agent.tool_use` + `agent.tool_result`. The ACP child runs the tool itself
+ * (claude-code-acp ships its own bash/edit/read), so OMA never executes —
+ * we only mirror the trace for replay/audit.
+ */
+
+import { generateEventId } from "@open-managed-agents/shared";
+import type { HarnessRuntime } from "./interface";
+
+interface AcpSessionUpdate {
+  sessionUpdate: string;
+  // ContentChunk shape
+  content?: { type?: string; text?: string };
+  // ToolCall / ToolCallUpdate shape
+  toolCallId?: string;
+  title?: string;
+  rawInput?: unknown;
+  rawOutput?: unknown;
+  status?: string;
+  kind?: string;
+}
+
+/** Wire shape of an ACP `session/update` notification. The agent SDK
+ *  yields these to the Client.sessionUpdate callback as
+ *  `{ sessionId, update: { sessionUpdate, ... } }` — the actual update
+ *  payload is nested one level under `update`. */
+interface AcpNotification {
+  sessionId?: string;
+  update?: AcpSessionUpdate;
+}
+
+interface AcpEvent {
+  type?: string;
+  // session.event wrapper
+  event?: AcpNotification;
+  // session.error / session.complete carry these
+  message?: string;
+}
+
+/**
+ * Per-turn streaming-translator. One instance per call to `harness.run`.
+ * Holds the accumulating message id + buffer for the in-flight ACP message
+ * or thinking block. Call `consume(event)` on every daemon-relayed message,
+ * `flush()` at turn end to emit any trailing messages still open.
+ */
+export class AcpTranslator {
+  #runtime: HarnessRuntime;
+  #activeMessage: { id: string; text: string } | null = null;
+  #activeThinking: { id: string; text: string } | null = null;
+
+  constructor(runtime: HarnessRuntime) {
+    this.#runtime = runtime;
+  }
+
+  /** Process one message from the daemon-relayed stream. */
+  async consume(msg: AcpEvent): Promise<void> {
+    if (msg.type !== "session.event" || !msg.event) return;
+    const upd = msg.event.update;
+    if (!upd) return;
+    switch (upd.sessionUpdate) {
+      case "agent_message_chunk":
+        await this.#onTextChunk(upd.content?.text ?? "");
+        break;
+      case "agent_thought_chunk":
+        await this.#onThinkingChunk(upd.content?.text ?? "");
+        break;
+      case "tool_call":
+        // New tool call — close any in-flight message/thinking first since
+        // ACP doesn't have an explicit "message complete" marker.
+        await this.#closeMessage();
+        await this.#closeThinking();
+        await this.#emitToolUse(upd);
+        break;
+      case "tool_call_update":
+        // Tool finished or progress update. We only emit a tool_result on
+        // status=completed (or first non-pending update with rawOutput).
+        if (upd.status && upd.status !== "in_progress" && upd.status !== "pending") {
+          await this.#emitToolResult(upd);
+        }
+        break;
+      case "user_message_chunk":
+        // Echo of the user's own message — ignore. We already wrote the
+        // user.message event when SessionDO accepted the prompt.
+        break;
+      case "plan":
+      case "available_commands_update":
+      case "current_mode_update":
+      case "config_option_update":
+      case "session_info_update":
+      case "usage_update":
+        // Useful telemetry but no canonical OMA event yet. Drop silently
+        // for v1; revisit when Console grows surfaces for them.
+        break;
+      default:
+        // Unknown sessionUpdate — keep the conversation alive.
+        break;
+    }
+  }
+
+  /** Close any open message/thinking at turn boundary. */
+  async flush(reason: "completed" | "aborted" = "completed"): Promise<void> {
+    if (reason === "aborted") {
+      if (this.#activeMessage) {
+        await this.#runtime.broadcastStreamEnd(this.#activeMessage.id, "aborted");
+        this.#activeMessage = null;
+      }
+      if (this.#activeThinking) {
+        await this.#runtime.broadcastThinkingEnd(this.#activeThinking.id, "aborted");
+        this.#activeThinking = null;
+      }
+      return;
+    }
+    await this.#closeMessage();
+    await this.#closeThinking();
+  }
+
+  async #onTextChunk(delta: string): Promise<void> {
+    if (this.#activeThinking) await this.#closeThinking();
+    if (!this.#activeMessage) {
+      const id = generateEventId();
+      this.#activeMessage = { id, text: "" };
+      await this.#runtime.broadcastStreamStart(id);
+    }
+    this.#activeMessage.text += delta;
+    await this.#runtime.broadcastChunk(this.#activeMessage.id, delta);
+  }
+
+  async #onThinkingChunk(delta: string): Promise<void> {
+    if (this.#activeMessage) await this.#closeMessage();
+    if (!this.#activeThinking) {
+      const id = generateEventId();
+      this.#activeThinking = { id, text: "" };
+      await this.#runtime.broadcastThinkingStart(id);
+    }
+    this.#activeThinking.text += delta;
+    await this.#runtime.broadcastThinkingChunk(this.#activeThinking.id, delta);
+  }
+
+  async #closeMessage(): Promise<void> {
+    const m = this.#activeMessage;
+    if (!m) return;
+    this.#activeMessage = null;
+    await this.#runtime.broadcastStreamEnd(m.id, "completed");
+    this.#runtime.broadcast({
+      type: "agent.message",
+      message_id: m.id,
+      content: [{ type: "text", text: m.text.replace(/\s+$/, "") }],
+    });
+  }
+
+  async #closeThinking(): Promise<void> {
+    const t = this.#activeThinking;
+    if (!t) return;
+    this.#activeThinking = null;
+    await this.#runtime.broadcastThinkingEnd(t.id, "completed");
+    this.#runtime.broadcast({
+      type: "agent.thinking",
+      text: t.text.replace(/\s+$/, ""),
+    });
+  }
+
+  async #emitToolUse(upd: AcpSessionUpdate): Promise<void> {
+    const id = upd.toolCallId ?? generateEventId();
+    const name = upd.title ?? upd.kind ?? "tool";
+    const input = (upd.rawInput as Record<string, unknown>) ?? {};
+    this.#runtime.broadcast({
+      type: "agent.tool_use",
+      id,
+      name,
+      input,
+    });
+  }
+
+  async #emitToolResult(upd: AcpSessionUpdate): Promise<void> {
+    if (!upd.toolCallId) return;
+    const out = upd.rawOutput;
+    const text =
+      typeof out === "string" ? out
+      : out == null ? `(status: ${upd.status ?? "unknown"})`
+      : JSON.stringify(out);
+    this.#runtime.broadcast({
+      type: "agent.tool_result",
+      tool_use_id: upd.toolCallId,
+      content: text,
+    });
+  }
+}

--- a/apps/agent/src/harness/interface.ts
+++ b/apps/agent/src/harness/interface.ts
@@ -132,6 +132,12 @@ export interface HarnessRuntime {
 export interface HarnessContext {
   agent: AgentConfig;
   userMessage: UserMessageEvent;
+  /**
+   * The OMA session id this turn belongs to. Optional during the transition
+   * for legacy harnesses; AcpProxyHarness needs it to address the
+   * RuntimeRoom DO. SessionDO populates this on every harness.run call.
+   */
+  session_id?: string;
 
   /** Platform-prepared tools: built from agent config, ready to pass to generateText. */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -180,6 +186,12 @@ export interface HarnessContext {
     environmentConfig?: { networking?: { type: string; allowed_hosts?: string[] } };
     /** Register a background task for completion notification (CC-style task_notification). */
     watchBackgroundTask?: (taskId: string, pid: string, outputFile: string, proc: ProcessHandle | null) => void;
+    /** Service binding back to apps/main. Used by AcpProxyHarness to attach
+     *  to the RuntimeRoom DO via /v1/internal/runtime-attach-harness. */
+    MAIN?: Fetcher;
+    /** Shared header secret to call /v1/internal/* on main. Set on the agent
+     *  worker; same value as main's INTEGRATIONS_INTERNAL_SECRET. */
+    INTEGRATIONS_INTERNAL_SECRET?: string;
   };
   runtime: HarnessRuntime;
 }

--- a/apps/agent/src/index.ts
+++ b/apps/agent/src/index.ts
@@ -12,7 +12,9 @@ import type { Env } from "@open-managed-agents/shared";
 // --- Register harnesses ---
 import { registerHarness } from "./harness/registry";
 import { DefaultHarness } from "./harness/default-loop";
+import { AcpProxyHarness } from "./harness/acp-proxy-loop";
 registerHarness("default", () => new DefaultHarness());
+registerHarness("acp-proxy", () => new AcpProxyHarness());
 
 // --- Export DO classes (required by wrangler) ---
 export { SessionDO } from "./runtime/session-do";

--- a/apps/agent/src/runtime/session-do.ts
+++ b/apps/agent/src/runtime/session-do.ts
@@ -2311,6 +2311,7 @@ export class SessionDO extends Agent<Env, SessionState> {
     const ctx: HarnessContext = {
       agent,
       userMessage,
+      session_id: this.state.session_id,
       tools: allTools,
       model,
       systemPrompt,
@@ -2324,6 +2325,11 @@ export class SessionDO extends Agent<Env, SessionState> {
         CONFIG_KV: this.env.CONFIG_KV,
         memoryStoreIds,
         environmentConfig,
+        // Wired through so AcpProxyHarness can attach to the RuntimeRoom DO
+        // via the apps/main worker. Optional on the env type — non-acp
+        // harnesses simply don't read these.
+        MAIN: this.env.MAIN,
+        INTEGRATIONS_INTERNAL_SECRET: this.env.INTEGRATIONS_INTERNAL_SECRET,
         delegateToAgent: async (agentId: string, message: string) => {
           return this.runSubAgent(agentId, message, history, sandbox);
         },

--- a/apps/agent/wrangler.dev.jsonc
+++ b/apps/agent/wrangler.dev.jsonc
@@ -31,6 +31,12 @@
     { "binding": "FILES_BUCKET", "bucket_name": "managed-agents-files" }
   ],
 
+  // MAIN service binding so AcpProxyHarness can call into the main worker's
+  // /v1/internal/runtime-attach-harness endpoint to reach RuntimeRoom DO.
+  "services": [
+    { "binding": "MAIN", "service": "managed-agents" }
+  ],
+
   "browser": { "binding": "BROWSER" },
 
   "migrations": [

--- a/apps/agent/wrangler.jsonc
+++ b/apps/agent/wrangler.jsonc
@@ -37,8 +37,11 @@
   // ~1hr TTL) on 401. The agent worker never sees provider secrets directly
   // — it just asks the gateway "please refresh credential X" and the gateway
   // does the App-JWT signing using its locally-held private key.
+  // MAIN binding lets AcpProxyHarness call /v1/internal/runtime-attach-harness
+  // to reach the RuntimeRoom DO (where the user's `oma bridge daemon` is wired).
   "services": [
-    { "binding": "INTEGRATIONS", "service": "managed-agents-integrations" }
+    { "binding": "INTEGRATIONS", "service": "managed-agents-integrations" },
+    { "binding": "MAIN", "service": "managed-agents" }
   ],
 
   // Workers AI for generating embeddings
@@ -105,7 +108,8 @@
         { "binding": "AUTH_DB", "database_name": "openma-auth-staging", "database_id": "aff5dbb7-36f9-46b7-b82f-4513e5603ac6" }
       ],
       "services": [
-        { "binding": "INTEGRATIONS", "service": "managed-agents-integrations-staging" }
+        { "binding": "INTEGRATIONS", "service": "managed-agents-integrations-staging" },
+        { "binding": "MAIN", "service": "managed-agents-staging" }
       ],
       "ai": { "binding": "AI" },
       "vectorize": [

--- a/apps/agent/wrangler.template.jsonc
+++ b/apps/agent/wrangler.template.jsonc
@@ -37,8 +37,11 @@
   // Outbound proxy on-401 token refresh path delegates to the integrations
   // gateway (App-JWT signing for GitHub installation tokens etc.). Without
   // this binding, refreshes silently no-op.
+  // MAIN binding lets AcpProxyHarness call /v1/internal/runtime-attach-harness
+  // to reach the RuntimeRoom DO (where the user's `oma bridge daemon` is wired).
   "services": [
-    { "binding": "INTEGRATIONS", "service": "managed-agents-integrations" }
+    { "binding": "INTEGRATIONS", "service": "managed-agents-integrations" },
+    { "binding": "MAIN", "service": "managed-agents" }
   ],
 
   // Workers AI for embedding generation (memory tools).

--- a/apps/console/src/components/Layout.tsx
+++ b/apps/console/src/components/Layout.tsx
@@ -8,6 +8,7 @@ import { TenantSwitcher } from "./TenantSwitcher";
 import {
   AgentIcon,
   ApiKeysIcon,
+  RuntimesIcon,
   ChevronDownIcon,
   DashboardIcon,
   EnvIcon,
@@ -62,6 +63,7 @@ const navGroups: NavGroup[] = [
       { to: "/memory", label: "Memory Stores", icon: MemoryIcon },
       { to: "/model-cards", label: "Model Cards", icon: ModelCardsIcon },
       { to: "/api-keys", label: "API Keys", icon: ApiKeysIcon },
+      { to: "/runtimes", label: "Local Runtimes", icon: RuntimesIcon },
     ],
   },
   {

--- a/apps/console/src/components/icons.tsx
+++ b/apps/console/src/components/icons.tsx
@@ -81,6 +81,12 @@ export function ApiKeysIcon({ className }: IconProps) {
   return <StrokeIcon className={className} d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z" />;
 }
 
+/** Local Runtimes — the user's machine running `oma bridge daemon`. Laptop /
+ *  desktop-mac silhouette. */
+export function RuntimesIcon({ className }: IconProps) {
+  return <StrokeIcon className={className} d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />;
+}
+
 // ─── Brand marks (simple-icons paths, full 0..24 coverage, fill-rendered) ─
 
 export function LinearIcon({ className }: IconProps) {

--- a/apps/console/src/main.tsx
+++ b/apps/console/src/main.tsx
@@ -18,6 +18,8 @@ import { MemoryStoresList } from "./pages/MemoryStoresList";
 import { ModelCardsList } from "./pages/ModelCardsList";
 import { ApiKeysList } from "./pages/ApiKeysList";
 import { CliLogin } from "./pages/CliLogin";
+import { RuntimesList } from "./pages/RuntimesList";
+import { ConnectRuntime } from "./pages/ConnectRuntime";
 import {
   IntegrationsLinearList,
   IntegrationsLinearWorkspace,
@@ -43,6 +45,7 @@ createRoot(document.getElementById("root")!).render(
         <Routes>
           <Route path="login" element={<Login />} />
           <Route path="cli/login" element={<CliLogin />} />
+          <Route path="connect-runtime" element={<ConnectRuntime />} />
           <Route element={<Layout />}>
             <Route index element={<Dashboard />} />
             <Route path="agents" element={<AgentsList />} />
@@ -55,6 +58,7 @@ createRoot(document.getElementById("root")!).render(
             <Route path="memory" element={<MemoryStoresList />} />
             <Route path="model-cards" element={<ModelCardsList />} />
             <Route path="api-keys" element={<ApiKeysList />} />
+            <Route path="runtimes" element={<RuntimesList />} />
             <Route path="integrations/linear" element={<IntegrationsLinearList />} />
             <Route
               path="integrations/linear/publish"

--- a/apps/console/src/pages/AgentDetail.tsx
+++ b/apps/console/src/pages/AgentDetail.tsx
@@ -8,6 +8,7 @@ interface Agent {
   system?: string; harness?: string; version: number; description?: string;
   tools?: unknown[]; callable_agents?: unknown[]; mcp_servers?: unknown[];
   skills?: unknown[]; created_at: string; updated_at?: string; archived_at?: string;
+  runtime_binding?: { runtime_id: string; acp_agent_id: string };
 }
 
 /** Shared publication shape across Linear / GitHub / Slack — they all
@@ -83,6 +84,16 @@ export function AgentDetail() {
         <span className="text-fg-muted">ID</span><span className="font-mono text-xs">{agent.id}</span>
         <span className="text-fg-muted">Model</span><span>{modelStr(agent.model)}</span>
         <span className="text-fg-muted">Harness</span><span>{agent.harness || "default"}</span>
+        {agent.runtime_binding && (
+          <>
+            <span className="text-fg-muted">Local Runtime</span>
+            <span className="text-xs">
+              <span className="font-mono">{agent.runtime_binding.runtime_id.slice(0, 8)}…</span>
+              <span className="text-fg-subtle"> · ACP agent: </span>
+              <span className="font-mono">{agent.runtime_binding.acp_agent_id}</span>
+            </span>
+          </>
+        )}
         <span className="text-fg-muted">Version</span><span>v{agent.version}</span>
         <span className="text-fg-muted">Tools</span>
         <span>{(agent.tools || []).map((t: any) => t.type === "custom" ? `Custom: ${t.name}` : t.type).join(", ") || "None"}</span>

--- a/apps/console/src/pages/AgentsList.tsx
+++ b/apps/console/src/pages/AgentsList.tsx
@@ -35,6 +35,9 @@ const INITIAL_FORM = {
   // default cloud agent.
   runtimeId: "",
   acpAgentId: "claude-code-acp",
+  /** Local skill ids to HIDE from this agent's ACP child. Empty = all
+   *  detected local skills are visible (the daemon's default). */
+  localSkillBlocklist: [] as string[],
 };
 
 export function AgentsList() {
@@ -44,7 +47,16 @@ export function AgentsList() {
   const [allAgents, setAllAgents] = useState<Agent[]>([]);
   const [customSkills, setCustomSkills] = useState<Array<{ id: string; name: string; description: string }>>([]);
   const [modelCards, setModelCards] = useState<ModelCard[]>([]);
-  const [runtimes, setRuntimes] = useState<Array<{ id: string; hostname: string; status: string; agents: Array<{ id: string }> }>>([]);
+  const [runtimes, setRuntimes] = useState<Array<{
+    id: string;
+    hostname: string;
+    status: string;
+    agents: Array<{ id: string }>;
+    /** Skills daemon detected locally on the user's machine, keyed by
+     *  acp agent id. Source for the blocklist multi-select that appears
+     *  when the user picks an acp agent. */
+    local_skills?: Record<string, Array<{ id: string; name?: string; description?: string; source?: string; source_label?: string }>>;
+  }>>([]);
   const [loading, setLoading] = useState(true);
   const [createError, setCreateError] = useState("");
   const [showArchived, setShowArchived] = useState(false);
@@ -103,6 +115,9 @@ export function AgentsList() {
         payload.runtime_binding = {
           runtime_id: form.runtimeId,
           acp_agent_id: form.acpAgentId,
+          ...(form.localSkillBlocklist.length > 0
+            ? { local_skill_blocklist: form.localSkillBlocklist }
+            : {}),
         };
       }
 
@@ -204,7 +219,7 @@ export function AgentsList() {
       // code → form: try to parse back (best-effort, may lose data)
       try {
         const parsed = createMode === "yaml" ? yaml.load(codeValue) as Record<string, unknown> : JSON.parse(codeValue);
-        const rb = parsed.runtime_binding as { runtime_id?: string; acp_agent_id?: string } | undefined;
+        const rb = parsed.runtime_binding as { runtime_id?: string; acp_agent_id?: string; local_skill_blocklist?: string[] } | undefined;
         setForm({
           ...INITIAL_FORM,
           name: String(parsed.name || ""),
@@ -216,6 +231,7 @@ export function AgentsList() {
           callableAgents: Array.isArray(parsed.callable_agents) ? parsed.callable_agents as CallableEntry[] : [],
           runtimeId: rb?.runtime_id ?? "",
           acpAgentId: rb?.acp_agent_id ?? "claude-code-acp",
+          localSkillBlocklist: Array.isArray(rb?.local_skill_blocklist) ? rb.local_skill_blocklist : [],
         });
       } catch { /* keep current form if parse fails */ }
     } else {
@@ -533,7 +549,7 @@ export function AgentsList() {
                             <label className="text-xs text-fg-subtle block mb-1">ACP agent on this machine</label>
                             <select
                               value={form.acpAgentId}
-                              onChange={(e) => setForm({ ...form, acpAgentId: e.target.value })}
+                              onChange={(e) => setForm({ ...form, acpAgentId: e.target.value, localSkillBlocklist: [] })}
                               className={inputCls}
                             >
                               {(runtimes.find((r) => r.id === form.runtimeId)?.agents ?? []).map((a) => (
@@ -543,6 +559,66 @@ export function AgentsList() {
                             <p className="text-xs text-fg-subtle mt-1">
                               Each turn spawns this ACP child on the runtime. Model + skills come from the daemon-fetched bundle.
                             </p>
+                            {/* Local-skill blocklist — multi-select fed by what the
+                                daemon reported in hello.local_skills[acpAgentId].
+                                Default = all visible (empty blocklist). User unchecks
+                                to hide a global skill from this agent. */}
+                            {(() => {
+                              const localSkills =
+                                runtimes.find((r) => r.id === form.runtimeId)?.local_skills?.[form.acpAgentId] ?? [];
+                              if (!localSkills.length) return null;
+                              const allowed = new Set(localSkills.map((s) => s.id))
+                              for (const id of form.localSkillBlocklist) allowed.delete(id);
+                              return (
+                                <div className="mt-3 border border-border rounded-md p-2.5 bg-bg-surface">
+                                  <div className="flex items-center justify-between mb-1.5">
+                                    <span className="text-xs text-fg-muted">
+                                      Local skills ({allowed.size}/{localSkills.length} visible)
+                                    </span>
+                                    <button
+                                      type="button"
+                                      onClick={() => setForm({ ...form, localSkillBlocklist: [] })}
+                                      className="text-[10px] text-fg-subtle hover:text-fg underline"
+                                    >
+                                      reset
+                                    </button>
+                                  </div>
+                                  <div className="space-y-0.5 max-h-40 overflow-y-auto">
+                                    {localSkills.map((s) => {
+                                      const blocked = form.localSkillBlocklist.includes(s.id);
+                                      return (
+                                        <label
+                                          key={s.id}
+                                          className="flex items-start gap-2 text-xs cursor-pointer hover:bg-bg rounded px-1.5 py-0.5"
+                                        >
+                                          <input
+                                            type="checkbox"
+                                            checked={!blocked}
+                                            onChange={(e) => {
+                                              const next = new Set(form.localSkillBlocklist);
+                                              if (e.target.checked) next.delete(s.id);
+                                              else next.add(s.id);
+                                              setForm({ ...form, localSkillBlocklist: [...next] });
+                                            }}
+                                            className="mt-0.5 accent-brand"
+                                          />
+                                          <span className="font-mono text-fg flex-shrink-0">{s.id}</span>
+                                          <span className="text-fg-subtle">
+                                            ({s.source ?? "global"}{s.source_label ? `:${s.source_label}` : ""})
+                                          </span>
+                                          {s.name && s.name !== s.id && (
+                                            <span className="text-fg-muted truncate">— {s.name}</span>
+                                          )}
+                                        </label>
+                                      );
+                                    })}
+                                  </div>
+                                  <p className="text-[10px] text-fg-subtle mt-1.5">
+                                    Unchecked = hidden from the ACP child (daemon won't symlink the dir into the spawn cwd).
+                                  </p>
+                                </div>
+                              );
+                            })()}
                           </div>
                         )}
                       </>

--- a/apps/console/src/pages/AgentsList.tsx
+++ b/apps/console/src/pages/AgentsList.tsx
@@ -29,6 +29,12 @@ const INITIAL_FORM = {
   mcpServers: [] as McpEntry[],
   skills: [] as SkillEntry[],
   callableAgents: [] as CallableEntry[],
+  // When set, agent uses harness:"acp-proxy" — its loop runs on a user-
+  // registered local runtime via `oma bridge daemon` instead of OMA's cloud
+  // SessionDO loop. Both fields must be set together; partial = fall back to
+  // default cloud agent.
+  runtimeId: "",
+  acpAgentId: "claude-code-acp",
 };
 
 export function AgentsList() {
@@ -38,6 +44,7 @@ export function AgentsList() {
   const [allAgents, setAllAgents] = useState<Agent[]>([]);
   const [customSkills, setCustomSkills] = useState<Array<{ id: string; name: string; description: string }>>([]);
   const [modelCards, setModelCards] = useState<ModelCard[]>([]);
+  const [runtimes, setRuntimes] = useState<Array<{ id: string; hostname: string; status: string; agents: Array<{ id: string }> }>>([]);
   const [loading, setLoading] = useState(true);
   const [createError, setCreateError] = useState("");
   const [showArchived, setShowArchived] = useState(false);
@@ -64,6 +71,10 @@ export function AgentsList() {
         const mc = await api<{ data: ModelCard[] }>("/v1/model_cards");
         setModelCards(mc.data);
       } catch {}
+      try {
+        const rt = await api<{ runtimes: Array<{ id: string; hostname: string; status: string; agents: Array<{ id: string }> }> }>("/v1/runtimes");
+        setRuntimes(rt.runtimes);
+      } catch {}
     } catch {}
     setLoading(false);
   };
@@ -84,6 +95,16 @@ export function AgentsList() {
       if (form.mcpServers.length) payload.mcp_servers = form.mcpServers;
       if (form.skills.length) payload.skills = form.skills;
       if (form.callableAgents.length) payload.callable_agents = form.callableAgents;
+      // Local-runtime agent: opt into acp-proxy harness when both runtimeId
+      // and acpAgentId are set. Partial config silently falls back to the
+      // default cloud loop — same semantics as the CLI flag pair.
+      if (form.runtimeId && form.acpAgentId) {
+        payload.harness = "acp-proxy";
+        payload.runtime_binding = {
+          runtime_id: form.runtimeId,
+          acp_agent_id: form.acpAgentId,
+        };
+      }
 
       const agent = await api<Agent>("/v1/agents", {
         method: "POST",
@@ -133,14 +154,13 @@ export function AgentsList() {
       setForm({ ...INITIAL_FORM });
     } else {
       setForm({
+        ...INITIAL_FORM,
         name: tmpl.name,
         model: tmpl.model,
         system: tmpl.system,
         description: tmpl.description,
-        modelCardId: "",
         mcpServers: tmpl.mcpServers.map(m => ({ ...m })),
         skills: tmpl.skills.map(s => ({ ...s } as SkillEntry)),
-        callableAgents: [],
       });
     }
     setCreateStep("form");
@@ -184,15 +204,18 @@ export function AgentsList() {
       // code → form: try to parse back (best-effort, may lose data)
       try {
         const parsed = createMode === "yaml" ? yaml.load(codeValue) as Record<string, unknown> : JSON.parse(codeValue);
+        const rb = parsed.runtime_binding as { runtime_id?: string; acp_agent_id?: string } | undefined;
         setForm({
+          ...INITIAL_FORM,
           name: String(parsed.name || ""),
           model: String(parsed.model || "claude-sonnet-4-6"),
           system: String(parsed.system || ""),
           description: String(parsed.description || ""),
-          modelCardId: "",
-          mcpServers: Array.isArray(parsed.mcp_servers) ? parsed.mcp_servers : [],
-          skills: Array.isArray(parsed.skills) ? parsed.skills : [],
-          callableAgents: Array.isArray(parsed.callable_agents) ? parsed.callable_agents : [],
+          mcpServers: Array.isArray(parsed.mcp_servers) ? parsed.mcp_servers as McpEntry[] : [],
+          skills: Array.isArray(parsed.skills) ? parsed.skills as SkillEntry[] : [],
+          callableAgents: Array.isArray(parsed.callable_agents) ? parsed.callable_agents as CallableEntry[] : [],
+          runtimeId: rb?.runtime_id ?? "",
+          acpAgentId: rb?.acp_agent_id ?? "claude-code-acp",
         });
       } catch { /* keep current form if parse fails */ }
     } else {
@@ -463,6 +486,67 @@ export function AgentsList() {
                   <div>
                     <label className="text-sm text-fg-muted block mb-1">System Prompt</label>
                     <textarea value={form.system} onChange={(e) => setForm({ ...form, system: e.target.value })} rows={5} className={`${inputCls} resize-none font-mono text-xs leading-relaxed`} placeholder="You are a helpful assistant..." />
+                  </div>
+                  {/* Local Runtime — bind agent's loop to a user-registered
+                      machine instead of OMA's cloud SessionDO. The "no
+                      runtime" option is the default cloud agent. */}
+                  <div>
+                    <label className="text-sm text-fg-muted block mb-1">
+                      Local Runtime
+                      <span className="ml-1 text-xs text-fg-subtle">(optional)</span>
+                    </label>
+                    {runtimes.length === 0 ? (
+                      <p className="text-xs text-fg-subtle bg-bg-surface px-3 py-2 rounded-lg">
+                        No runtimes registered.{" "}
+                        <a href="/runtimes" className="underline hover:text-fg-muted">Connect a machine</a>{" "}
+                        to delegate this agent's loop to your own Claude Code (or other ACP) child.
+                      </p>
+                    ) : (
+                      <>
+                        <select
+                          value={form.runtimeId}
+                          onChange={(e) => {
+                            const rid = e.target.value;
+                            // Auto-pick the first detected ACP agent on the
+                            // chosen runtime — user doesn't have to know what
+                            // strings the daemon's manifest emits. Falls back
+                            // to whatever was set if the runtime has none
+                            // (rare; daemon detection list would be empty).
+                            const first = runtimes.find((r) => r.id === rid)?.agents?.[0]?.id;
+                            setForm({
+                              ...form,
+                              runtimeId: rid,
+                              acpAgentId: rid && first ? first : form.acpAgentId,
+                            });
+                          }}
+                          className={inputCls}
+                        >
+                          <option value="">— Cloud (run on OMA) —</option>
+                          {runtimes.map((r) => (
+                            <option key={r.id} value={r.id} disabled={r.status !== "online"}>
+                              {r.hostname} ({r.status}{r.status === "online" && r.agents.length ? ` · ${r.agents.length} agents` : ""})
+                            </option>
+                          ))}
+                        </select>
+                        {form.runtimeId && (
+                          <div className="mt-2">
+                            <label className="text-xs text-fg-subtle block mb-1">ACP agent on this machine</label>
+                            <select
+                              value={form.acpAgentId}
+                              onChange={(e) => setForm({ ...form, acpAgentId: e.target.value })}
+                              className={inputCls}
+                            >
+                              {(runtimes.find((r) => r.id === form.runtimeId)?.agents ?? []).map((a) => (
+                                <option key={a.id} value={a.id}>{a.id}</option>
+                              ))}
+                            </select>
+                            <p className="text-xs text-fg-subtle mt-1">
+                              Each turn spawns this ACP child on the runtime. Model + skills come from the daemon-fetched bundle.
+                            </p>
+                          </div>
+                        )}
+                      </>
+                    )}
                   </div>
                 </div>
               )}

--- a/apps/console/src/pages/ConnectRuntime.tsx
+++ b/apps/console/src/pages/ConnectRuntime.tsx
@@ -1,0 +1,168 @@
+import { useEffect, useMemo, useState } from "react";
+import { useApi } from "../lib/api";
+import { Button } from "../components/Button";
+
+/** Browser-side handler for `oma bridge setup`. The CLI binds a random
+ *  127.0.0.1 port and opens this URL with `?cb=http://127.0.0.1:<port>/cb&state=<nonce>`.
+ *  The user authenticates (cookie session), POSTs /v1/runtimes/connect-runtime
+ *  to mint a one-time exchange code, then this page redirects back to the
+ *  CLI's loopback listener with `?code=...&state=...`. The CLI exchanges
+ *  the code at /agents/runtime/exchange for a permanent runtime token.
+ *
+ *  Mirror of CliLogin.tsx — same shape, different mint endpoint, just one
+ *  code per setup (no per-tenant fan-out — the token belongs to the active
+ *  tenant at code-mint time). */
+
+interface MeResponse {
+  user: { id: string; email: string; name: string | null } | null;
+  tenant: { id: string; name: string };
+  tenants: Array<{ id: string; name: string; role: string }>;
+}
+
+function isLoopback(callbackUrl: string): boolean {
+  try {
+    const u = new URL(callbackUrl);
+    if (u.protocol !== "http:") return false;
+    return u.hostname === "127.0.0.1" || u.hostname === "localhost" || u.hostname === "[::1]";
+  } catch {
+    return false;
+  }
+}
+
+export function ConnectRuntime() {
+  const { api } = useApi();
+  const params = useMemo(() => new URLSearchParams(window.location.search), []);
+  const callback = params.get("cb") ?? "";
+  const state = params.get("state") ?? "";
+  const callbackOk = isLoopback(callback);
+
+  const [me, setMe] = useState<MeResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [authNeeded, setAuthNeeded] = useState(false);
+  const [working, setWorking] = useState(false);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    if (!callbackOk) {
+      setError(
+        "Invalid callback URL — only loopback addresses (127.0.0.1, localhost) are permitted.",
+      );
+      setLoading(false);
+      return;
+    }
+    if (!state || state.length < 8) {
+      setError("Missing or invalid state parameter — re-run `oma bridge setup`.");
+      setLoading(false);
+      return;
+    }
+    api<MeResponse>("/v1/me")
+      .then(setMe)
+      .catch((err) => {
+        if (/401|Unauthorized/i.test(String(err?.message))) {
+          setAuthNeeded(true);
+        } else {
+          setError(String(err?.message ?? err));
+        }
+      })
+      .finally(() => setLoading(false));
+  }, [api, callbackOk, state]);
+
+  const goLogin = () => {
+    const next = encodeURIComponent(window.location.pathname + window.location.search);
+    window.location.href = `/login?next=${next}`;
+  };
+
+  const approve = async () => {
+    if (!me) return;
+    setWorking(true);
+    setError("");
+    try {
+      const { code } = await api<{ code: string; expires_at: number }>(
+        "/v1/runtimes/connect-runtime",
+        {
+          method: "POST",
+          body: JSON.stringify({ state }),
+        },
+      );
+      const url = new URL(callback);
+      url.searchParams.set("code", code);
+      url.searchParams.set("state", state);
+      window.location.href = url.toString();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+      setWorking(false);
+    }
+  };
+
+  const cancel = () => {
+    if (callbackOk) {
+      const url = new URL(callback);
+      url.searchParams.set("error", "user_cancelled");
+      url.searchParams.set("state", state);
+      window.location.href = url.toString();
+    } else {
+      window.location.href = "/";
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-bg flex items-center justify-center px-4">
+      <div className="w-full max-w-md bg-bg-surface border border-border rounded-2xl p-8 shadow-sm">
+        <div className="flex items-center gap-3 mb-6">
+          <img src="/logo.svg" alt="openma" className="h-9 shrink-0" />
+          <div>
+            <div className="font-display text-lg font-semibold">Connect machine</div>
+            <div className="text-xs text-fg-subtle">openma local runtime</div>
+          </div>
+        </div>
+
+        {loading && <div className="text-sm text-fg-subtle">Checking session…</div>}
+
+        {!loading && error && (
+          <div className="bg-danger-subtle border border-danger/30 text-danger text-sm rounded-lg px-4 py-3 mb-4">
+            {error}
+          </div>
+        )}
+
+        {!loading && authNeeded && (
+          <>
+            <p className="text-sm text-fg-muted mb-4">Sign in to authorize this machine.</p>
+            <Button onClick={goLogin} className="w-full">
+              Sign in
+            </Button>
+          </>
+        )}
+
+        {!loading && !authNeeded && me && callbackOk && (
+          <>
+            <p className="text-sm text-fg-muted mb-2">
+              Allow this machine to attach to OMA as{" "}
+              <span className="font-mono text-fg">
+                {me.user?.email ?? me.user?.id ?? "this user"}
+              </span>{" "}
+              in workspace <span className="font-mono text-fg">{me.tenant.name}</span>?
+            </p>
+            <p className="text-xs text-fg-subtle mb-5">
+              The daemon will spawn ACP-compatible agents (Claude Code, Codex, etc.) on
+              this machine when you bind an agent to it. Revoke any time on the
+              Local Runtimes page.
+            </p>
+
+            <div className="flex gap-2">
+              <Button onClick={approve} disabled={working} className="flex-1">
+                {working ? "Authorizing…" : "Allow"}
+              </Button>
+              <button
+                onClick={cancel}
+                disabled={working}
+                className="px-4 py-2.5 rounded-lg border border-border text-sm text-fg-muted hover:bg-bg disabled:opacity-40"
+              >
+                Cancel
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/console/src/pages/RuntimesList.tsx
+++ b/apps/console/src/pages/RuntimesList.tsx
@@ -3,12 +3,26 @@ import { useApi } from "../lib/api";
 import { Button } from "../components/Button";
 import { Modal } from "../components/Modal";
 
+interface LocalSkill {
+  id: string;
+  name?: string;
+  description?: string;
+  source?: "global" | "plugin" | "project";
+  source_label?: string;
+}
+
 interface Runtime {
   id: string;
   machine_id: string;
   hostname: string;
   os: string;
   agents: Array<{ id: string; binary?: string }>;
+  /** Per-acp-agent-id list of skills daemon detected on the user's machine.
+   *  Populated from ~/.claude/skills/ + ~/.claude/plugins (asterisk)/skills/
+   *  for the Claude Code agent. Use this to show users what's locally
+   *  available + as the source for the per-agent blocklist
+   *  (AgentConfig.runtime_binding.local_skill_blocklist). */
+  local_skills?: Record<string, LocalSkill[]>;
   version: string;
   status: "online" | "offline";
   last_heartbeat: number | null;
@@ -91,14 +105,47 @@ export function RuntimesList() {
               </tr>
             </thead>
             <tbody>
-              {runtimes.map((r) => (
+              {runtimes.map((r) => {
+                const totalSkills = Object.values(r.local_skills ?? {}).reduce(
+                  (n, arr) => n + (arr?.length ?? 0),
+                  0,
+                );
+                return (
                 <tr
                   key={r.id}
-                  className="border-t border-border hover:bg-bg-surface transition-colors"
+                  className="border-t border-border hover:bg-bg-surface transition-colors align-top"
                 >
                   <td className="px-4 py-3">
                     <div className="font-medium text-fg">{r.hostname}</div>
                     <div className="text-xs text-fg-subtle font-mono">{r.id}</div>
+                    {totalSkills > 0 && (
+                      <details className="mt-2 text-xs">
+                        <summary className="cursor-pointer text-fg-muted hover:text-fg select-none">
+                          {totalSkills} local skill{totalSkills === 1 ? "" : "s"} detected
+                        </summary>
+                        <div className="mt-1.5 ml-2 space-y-1.5">
+                          {Object.entries(r.local_skills ?? {}).map(([acpId, skills]) =>
+                            !skills?.length ? null : (
+                              <div key={acpId}>
+                                <div className="text-fg-subtle text-[10px] uppercase tracking-wider mb-0.5">
+                                  for {acpId}
+                                </div>
+                                <ul className="space-y-0.5">
+                                  {skills.map((s) => (
+                                    <li key={`${acpId}/${s.source_label ?? ""}/${s.id}`} className="font-mono">
+                                      <span className="text-fg">{s.id}</span>
+                                      <span className="text-fg-subtle ml-1">
+                                        ({s.source ?? "global"}{s.source_label ? `:${s.source_label}` : ""})
+                                      </span>
+                                    </li>
+                                  ))}
+                                </ul>
+                              </div>
+                            )
+                          )}
+                        </div>
+                      </details>
+                    )}
                   </td>
                   <td className="px-4 py-3 text-fg-muted">{r.os}</td>
                   <td className="px-4 py-3">
@@ -136,7 +183,8 @@ export function RuntimesList() {
                     </button>
                   </td>
                 </tr>
-              ))}
+                );
+              })}
             </tbody>
           </table>
         </div>

--- a/apps/console/src/pages/RuntimesList.tsx
+++ b/apps/console/src/pages/RuntimesList.tsx
@@ -1,0 +1,175 @@
+import { useEffect, useState } from "react";
+import { useApi } from "../lib/api";
+import { Button } from "../components/Button";
+import { Modal } from "../components/Modal";
+
+interface Runtime {
+  id: string;
+  machine_id: string;
+  hostname: string;
+  os: string;
+  agents: Array<{ id: string; binary?: string }>;
+  version: string;
+  status: "online" | "offline";
+  last_heartbeat: number | null;
+  created_at: number;
+}
+
+/** Local Runtimes — user-registered laptops/VMs running `oma bridge daemon`.
+ *  Each runtime can host ACP-compatible agents (Claude Code, Codex, etc.).
+ *  An OMA agent with `harness: "acp-proxy"` and `runtime_binding` set delegates
+ *  its loop to one of these. */
+export function RuntimesList() {
+  const { api } = useApi();
+  const [runtimes, setRuntimes] = useState<Runtime[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [showInstructions, setShowInstructions] = useState(false);
+
+  const load = async () => {
+    setLoading(true);
+    try {
+      setRuntimes((await api<{ runtimes: Runtime[] }>("/v1/runtimes")).runtimes);
+    } catch { /* ignore */ }
+    setLoading(false);
+  };
+
+  useEffect(() => {
+    load();
+    // Auto-refresh every 15s so a freshly-attached daemon shows up without a
+    // hard reload. Cheap query — single SELECT against runtimes.
+    const t = setInterval(load, 15_000);
+    return () => clearInterval(t);
+  }, []);
+
+  const remove = async (id: string) => {
+    if (!confirm("Revoke this runtime? Daemon on that machine will stop being able to attach.")) return;
+    try {
+      await api(`/v1/runtimes/${id}`, { method: "DELETE" });
+      load();
+    } catch { /* ignore */ }
+  };
+
+  return (
+    <div className="flex-1 overflow-y-auto p-8 lg:p-10">
+      <div className="flex items-start justify-between mb-6">
+        <div>
+          <h1 className="font-display text-xl font-semibold tracking-tight text-fg">
+            Local Runtimes
+          </h1>
+          <p className="text-fg-muted text-sm">
+            Registered machines running <code className="text-xs bg-bg-surface px-1 py-0.5 rounded">oma bridge daemon</code>.
+            Bind an agent to a runtime to delegate its loop to a local Claude Code (or other ACP) child.
+          </p>
+        </div>
+        <Button onClick={() => setShowInstructions(true)}>+ Connect machine</Button>
+      </div>
+
+      {loading ? (
+        <div className="text-fg-subtle text-sm py-8 text-center">Loading…</div>
+      ) : runtimes.length === 0 ? (
+        <div className="text-center py-16 text-fg-subtle">
+          <p className="text-lg mb-1">No runtimes connected</p>
+          <p className="text-sm">
+            Run <code className="text-xs bg-bg-surface px-1 py-0.5 rounded">npx @openma/cli bridge setup</code> on the machine you want to connect.
+          </p>
+        </div>
+      ) : (
+        <div className="border border-border rounded-lg overflow-hidden">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="bg-bg-surface text-fg-subtle text-xs uppercase tracking-wider">
+                <th className="text-left px-4 py-2.5">Hostname</th>
+                <th className="text-left px-4 py-2.5">OS</th>
+                <th className="text-left px-4 py-2.5">Status</th>
+                <th className="text-left px-4 py-2.5">Agents detected</th>
+                <th className="text-left px-4 py-2.5">Heartbeat</th>
+                <th className="text-right px-4 py-2.5">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {runtimes.map((r) => (
+                <tr
+                  key={r.id}
+                  className="border-t border-border hover:bg-bg-surface transition-colors"
+                >
+                  <td className="px-4 py-3">
+                    <div className="font-medium text-fg">{r.hostname}</div>
+                    <div className="text-xs text-fg-subtle font-mono">{r.id}</div>
+                  </td>
+                  <td className="px-4 py-3 text-fg-muted">{r.os}</td>
+                  <td className="px-4 py-3">
+                    <span
+                      className={
+                        r.status === "online"
+                          ? "inline-flex items-center gap-1.5 text-success text-xs font-medium"
+                          : "inline-flex items-center gap-1.5 text-fg-subtle text-xs font-medium"
+                      }
+                    >
+                      <span
+                        className={
+                          r.status === "online"
+                            ? "w-1.5 h-1.5 rounded-full bg-success"
+                            : "w-1.5 h-1.5 rounded-full bg-fg-subtle"
+                        }
+                      />
+                      {r.status}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3 font-mono text-xs text-fg-muted">
+                    {r.agents.length === 0 ? "—" : r.agents.map((a) => a.id).join(", ")}
+                  </td>
+                  <td className="px-4 py-3 text-fg-muted text-xs">
+                    {r.last_heartbeat
+                      ? formatHeartbeat(r.last_heartbeat)
+                      : "—"}
+                  </td>
+                  <td className="px-4 py-3 text-right">
+                    <button
+                      onClick={() => remove(r.id)}
+                      className="text-xs text-fg-subtle hover:text-danger"
+                    >
+                      Revoke
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <Modal
+        open={showInstructions}
+        onClose={() => setShowInstructions(false)}
+        title="Connect a local machine"
+        footer={<Button onClick={() => setShowInstructions(false)}>Done</Button>}
+      >
+        <div className="space-y-4 text-sm">
+          <p className="text-fg-muted">
+            On the machine you want to connect, install one ACP agent and run setup:
+          </p>
+          <div className="bg-bg-surface border border-border rounded-lg p-3 font-mono text-xs space-y-1">
+            <div className="text-fg-subtle"># Install an ACP-compatible agent (Claude Code is a popular pick):</div>
+            <div className="text-fg select-all">npm install -g @zed-industries/claude-code-acp</div>
+            <div className="text-fg-subtle pt-2"># Register this machine with OMA + install the daemon:</div>
+            <div className="text-fg select-all">npx @openma/cli bridge setup</div>
+          </div>
+          <p className="text-fg-muted text-xs">
+            Setup opens this browser for OAuth, writes credentials to{" "}
+            <code className="bg-bg-surface px-1 rounded">~/.oma/bridge/</code>, and (on macOS) installs a launchd job
+            that keeps the daemon running across reboots. The runtime appears here as{" "}
+            <span className="text-success">online</span> within a few seconds of the daemon attaching.
+          </p>
+        </div>
+      </Modal>
+    </div>
+  );
+}
+
+function formatHeartbeat(unixSeconds: number): string {
+  const ago = Math.floor(Date.now() / 1000) - unixSeconds;
+  if (ago < 60) return `${ago}s ago`;
+  if (ago < 3600) return `${Math.floor(ago / 60)}m ago`;
+  if (ago < 86400) return `${Math.floor(ago / 3600)}h ago`;
+  return `${Math.floor(ago / 86400)}d ago`;
+}

--- a/apps/console/src/pages/RuntimesList.tsx
+++ b/apps/console/src/pages/RuntimesList.tsx
@@ -51,17 +51,21 @@ export function RuntimesList() {
 
   return (
     <div className="flex-1 overflow-y-auto p-8 lg:p-10">
-      <div className="flex items-start justify-between mb-6">
+      <div className="flex items-start justify-between mb-6 gap-4">
         <div>
           <h1 className="font-display text-xl font-semibold tracking-tight text-fg">
             Local Runtimes
           </h1>
           <p className="text-fg-muted text-sm">
-            Registered machines running <code className="text-xs bg-bg-surface px-1 py-0.5 rounded">oma bridge daemon</code>.
-            Bind an agent to a runtime to delegate its loop to a local Claude Code (or other ACP) child.
+            Machines running <code className="text-xs bg-bg-surface px-1 py-0.5 rounded">oma bridge daemon</code> — bind an agent to one to delegate its loop to a local Claude Code child.
           </p>
         </div>
-        <Button onClick={() => setShowInstructions(true)}>+ Connect machine</Button>
+        <Button
+          onClick={() => setShowInstructions(true)}
+          className="shrink-0 whitespace-nowrap"
+        >
+          + Connect machine
+        </Button>
       </div>
 
       {loading ? (

--- a/apps/main/migrations/0010_runtimes.sql
+++ b/apps/main/migrations/0010_runtimes.sql
@@ -1,0 +1,80 @@
+-- Local ACP runtime registration tables.
+--
+-- A "runtime" is one user laptop / VM running `oma bridge daemon`. It registers
+-- with OMA via the connect-runtime browser flow → exchange code → token. After
+-- that, the daemon holds a persistent reverse-WS to the RuntimeRoom DO and
+-- relays ACP-protocol traffic for sessions whose AgentConfig has
+-- runtime_binding pointing at this runtime's id.
+--
+-- House style: INTEGER unix-second timestamps, no FK constraints (cascade in
+-- app layer per project convention), partial UNIQUE for active-only constraints.
+
+-- ============================================================
+-- RUNTIME REGISTRATION
+-- One row per registered machine. owner_user_id + machine_id is the
+-- idempotency key — re-running `oma bridge setup` from the same UNIX
+-- user on the same machine reuses the row instead of inserting a dup.
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS "runtimes" (
+  "id"               TEXT PRIMARY KEY NOT NULL,
+  "owner_user_id"    TEXT NOT NULL,
+  "owner_tenant_id"  TEXT NOT NULL,
+  "machine_id"       TEXT NOT NULL,
+  "hostname"         TEXT NOT NULL,
+  "os"               TEXT NOT NULL,
+  "agents_json"      TEXT NOT NULL DEFAULT '[]',
+  "version"          TEXT NOT NULL,
+  "status"           TEXT NOT NULL DEFAULT 'offline',
+  "last_heartbeat"   INTEGER,
+  "created_at"       INTEGER NOT NULL
+);
+
+-- Unique per (user, machine) — re-setup from same machine reuses row.
+CREATE UNIQUE INDEX IF NOT EXISTS "idx_runtimes_user_machine"
+  ON "runtimes" ("owner_user_id", "machine_id");
+
+-- Tenant-scoped listing.
+CREATE INDEX IF NOT EXISTS "idx_runtimes_tenant"
+  ON "runtimes" ("owner_tenant_id", "created_at" DESC);
+
+-- ============================================================
+-- RUNTIME TOKENS (sk_machine_*)
+-- Bearer credential the daemon presents on /agents/runtime/_attach.
+-- token_hash is sha256(plaintext); plaintext only ever transmitted once
+-- in the /exchange response. Multiple tokens per runtime allowed (fresh
+-- mint per `oma bridge setup` run); user revokes via UI to invalidate.
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS "runtime_tokens" (
+  "id"                  TEXT PRIMARY KEY NOT NULL,
+  "runtime_id"          TEXT NOT NULL,
+  "token_hash"          TEXT NOT NULL UNIQUE,
+  "created_by_user_id"  TEXT NOT NULL,
+  "revoked_at"          INTEGER,
+  "last_used_at"        INTEGER,
+  "created_at"          INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS "idx_runtime_tokens_runtime"
+  ON "runtime_tokens" ("runtime_id", "revoked_at");
+
+-- ============================================================
+-- CONNECT-RUNTIME ONE-TIME CODES
+-- Browser POSTs /v1/runtimes/connect-runtime → returns code (5 min TTL,
+-- single-use). CLI receives via localhost callback redirect, exchanges
+-- at /agents/runtime/exchange. Code rows linger after use for short-term
+-- audit (used_at IS NOT NULL); a periodic GC sweep removes expired ones.
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS "connect_runtime_codes" (
+  "code"        TEXT PRIMARY KEY NOT NULL,
+  "user_id"     TEXT NOT NULL,
+  "tenant_id"   TEXT NOT NULL,
+  "state"       TEXT NOT NULL,
+  "expires_at"  INTEGER NOT NULL,
+  "used_at"     INTEGER
+);
+
+CREATE INDEX IF NOT EXISTS "idx_connect_runtime_codes_expires"
+  ON "connect_runtime_codes" ("expires_at");

--- a/apps/main/migrations/0011_runtime_local_skills.sql
+++ b/apps/main/migrations/0011_runtime_local_skills.sql
@@ -1,0 +1,11 @@
+-- C1: daemon hello manifest now reports local skills detected on the user's
+-- machine (Claude Code globals + plugin skills). Persisted on the runtime row
+-- so the Console can show them and per-agent settings can blocklist by id.
+--
+-- Shape (JSON object): { "<acp-agent-id>": [ { id, name?, description?,
+--   source: "global"|"plugin"|"project", source_label? } ] }
+--
+-- Default '{}' so old rows stay valid until the daemon redelivers a hello
+-- with the new shape (happens on every WS reconnect).
+
+ALTER TABLE "runtimes" ADD COLUMN "local_skills_json" TEXT NOT NULL DEFAULT '{}';

--- a/apps/main/src/auth.ts
+++ b/apps/main/src/auth.ts
@@ -18,6 +18,11 @@ export const authMiddleware = createMiddleware<{
   if (c.req.path.startsWith("/v1/internal/")) {
     return next();
   }
+  // MCP proxy authenticates via Bearer oma_* on every request — its own
+  // resolveProxyTarget validates token + session ownership in one shot.
+  if (c.req.path.startsWith("/v1/mcp-proxy/")) {
+    return next();
+  }
 
   // 1. Try API Key authentication (for CLI / SDK)
   const apiKey = c.req.header("x-api-key");

--- a/apps/main/src/index.ts
+++ b/apps/main/src/index.ts
@@ -21,6 +21,8 @@ import evalsRoutes from "./routes/evals";
 import costReportRoutes from "./routes/cost-report";
 import internalRoutes from "./routes/internal";
 import integrationsRoutes from "./routes/integrations";
+import { runtimesRoutes, runtimeDaemonRoutes, authenticateRuntimeToken } from "./routes/runtimes";
+import mcpProxyRoutes from "./routes/mcp-proxy";
 import { tickEvalRuns } from "./eval-runner";
 import { log, logError, recordEvent, errFields } from "@open-managed-agents/shared";
 
@@ -84,6 +86,35 @@ app.route("/v1/tenants", tenantsRoutes);
 app.route("/v1/evals", evalsRoutes);
 app.route("/v1/cost_report", costReportRoutes);
 app.route("/v1/integrations", integrationsRoutes);
+app.route("/v1/runtimes", runtimesRoutes);
+// MCP proxy bypasses /v1/* authMiddleware (declared in auth.ts as a
+// path-prefix skip) — auth is the Bearer oma_* the ACP child sends.
+app.route("/v1/mcp-proxy", mcpProxyRoutes);
+// Daemon-facing routes — outside /v1/* so authMiddleware doesn't run.
+// Apply tenantDbMiddleware + servicesMiddleware so daemon endpoints (like
+// /agents/runtime/sessions/:sid/bundle) can use c.get("services").
+app.use("/agents/runtime/*", tenantDbMiddleware);
+app.use("/agents/runtime/*", servicesMiddleware);
+app.route("/agents/runtime", runtimeDaemonRoutes);
+
+// /agents/runtime/_attach — WebSocket upgrade for `oma bridge daemon`. We
+// validate the runtime bearer token here, then forward to the RuntimeRoom
+// DO with x-runtime-id / x-runtime-user headers it trusts.
+app.get("/agents/runtime/_attach", async (c) => {
+  if (c.req.header("Upgrade") !== "websocket") {
+    return c.text("WebSocket only", 400);
+  }
+  if (!c.env.RUNTIME_ROOM) return c.text("RUNTIME_ROOM binding missing", 503);
+  const auth = c.req.header("authorization") ?? "";
+  const ok = await authenticateRuntimeToken(c.env, auth);
+  if (!ok) return c.text("unauthorized", 401);
+  const stub = c.env.RUNTIME_ROOM.get(c.env.RUNTIME_ROOM.idFromName(ok.runtime_id));
+  const fwd = new Request(c.req.raw);
+  fwd.headers.set("x-attach-role", "daemon");
+  fwd.headers.set("x-runtime-id", ok.runtime_id);
+  fwd.headers.set("x-runtime-user", ok.user_id);
+  return stub.fetch(fwd);
+});
 
 // Internal endpoints (NOT auth-middleware'd; secured by header secret inside
 // the route file). Called only by the integrations gateway worker via service
@@ -135,3 +166,7 @@ export default {
     // too — dockerfile/CI is now the only build path.
   },
 };
+
+// DO classes must be re-exported from the worker entry so wrangler can find
+// them by class_name in durable_objects.bindings + migrations.
+export { RuntimeRoom } from "./runtime-room";

--- a/apps/main/src/routes/agents.ts
+++ b/apps/main/src/routes/agents.ts
@@ -107,6 +107,7 @@ app.post("/", async (c) => {
     model_card_id?: string;
     aux_model?: string | { id: string; speed?: "standard" | "fast" };
     aux_model_card_id?: string;
+    runtime_binding?: AgentConfig["runtime_binding"];
   }>();
 
   if (!body.name || !body.model) {
@@ -145,6 +146,7 @@ app.post("/", async (c) => {
       model_card_id: body.model_card_id,
       aux_model: body.aux_model,
       aux_model_card_id: body.aux_model_card_id,
+      runtime_binding: body.runtime_binding,
     },
   });
   return c.json(toApiAgent(row), 201);
@@ -195,6 +197,7 @@ const updateAgent = async (c: any) => {
     aux_model_card_id?: string | null;
     metadata?: Record<string, unknown>;
     version?: number;
+    runtime_binding?: AgentConfig["runtime_binding"] | null;
   };
 
   // Validate model if model or model_card_id is being changed
@@ -242,6 +245,7 @@ const updateAgent = async (c: any) => {
         model_card_id: body.model_card_id,
         aux_model: body.aux_model,
         aux_model_card_id: body.aux_model_card_id,
+        runtime_binding: body.runtime_binding,
       },
     });
     return c.json(toApiAgent(row));

--- a/apps/main/src/routes/internal.ts
+++ b/apps/main/src/routes/internal.ts
@@ -576,6 +576,42 @@ async function fetchVaultCredentials(
   }));
 }
 
+// ─── Local ACP runtime ────────────────────────────────────────────────────
+
+/**
+ * GET /v1/internal/runtime-attach-harness?sid=<sid>&runtime_id=<rid>  (WS upgrade)
+ *
+ * Thin proxy used by AcpProxyHarness inside SessionDO. Forwards a WebSocket
+ * upgrade request to the RuntimeRoom DO addressed by `runtime_id`, tagged as
+ * a "harness" attach for `sid`. The DO holds the WS open and pipes session.*
+ * events between the daemon's WS and this one.
+ *
+ * Auth: x-internal-secret (already gated by the use("*") middleware above).
+ * The harness opens this once per turn and reads/writes ACP messages directly
+ * over the returned WS. main worker doesn't parse anything.
+ *
+ * NOTE: the daemon-facing bundle endpoint (used to render AGENTS.md +
+ * skills) lives at /agents/runtime/sessions/:sid/bundle in routes/runtimes.ts
+ * and authenticates via the runtime token, not the internal secret.
+ */
+app.get("/runtime-attach-harness", async (c) => {
+  if (c.req.header("Upgrade") !== "websocket") {
+    return c.text("WebSocket only", 400);
+  }
+  if (!c.env.RUNTIME_ROOM) return c.text("RUNTIME_ROOM binding missing", 503);
+
+  const sid = c.req.query("sid");
+  const runtimeId = c.req.query("runtime_id");
+  if (!sid || !runtimeId) return c.text("sid + runtime_id required", 400);
+
+  // Forward the upgrade to RUNTIME_ROOM with the harness attach role headers.
+  const stub = c.env.RUNTIME_ROOM.get(c.env.RUNTIME_ROOM.idFromName(runtimeId));
+  const fwd = new Request(c.req.raw);
+  fwd.headers.set("x-attach-role", "harness");
+  fwd.headers.set("x-session-id", sid);
+  return stub.fetch(fwd);
+});
+
 export default app;
 
 // Test-only exports.

--- a/apps/main/src/routes/mcp-proxy.ts
+++ b/apps/main/src/routes/mcp-proxy.ts
@@ -1,0 +1,149 @@
+/**
+ * MCP proxy — gateway between an ACP child running on a user's machine and
+ * the upstream MCP servers configured on an OMA agent. Lets the agent's
+ * model use Linear / GitHub / etc. tools without ever sending the upstream
+ * credentials to the user's machine.
+ *
+ *   ACP child (user's laptop)
+ *     │  HTTP w/ Bearer oma_*
+ *     ▼
+ *   /v1/mcp-proxy/<sid>/<server_name>   ← here
+ *     │  Same MCP-over-HTTP protocol the upstream speaks; we
+ *     │  only swap the auth header before forwarding
+ *     ▼
+ *   upstream MCP server (integrations.openma.dev or third-party)
+ *
+ * Auth surface:
+ *   - Bearer omak_*: hashed in CONFIG_KV `apikey:<sha256>` (same row API
+ *     keys created via /v1/api_keys use). Resolves to (tenant_id, user_id).
+ *   - sid in URL: must reference a row in `sessions` belonging to the same
+ *     tenant. session.archived_at IS NULL gates "this session is still alive";
+ *     deletion → proxy returns 403 immediately, no token revocation needed.
+ *   - server_name in URL: must match one of agent.mcp_servers[].name on the
+ *     session's agent_snapshot.
+ *
+ * Auth flow is intentionally cache-friendly: a single function
+ * `resolveProxyTarget(env, token, sid, serverName) → ProxyTarget | error`
+ * isolates the lookup so a future KV cache layer can drop in around it
+ * without changing call sites. We don't add the cache yet — current scale
+ * runs sub-ms per call, KV rounds-trip would be slower.
+ */
+
+import { Hono } from "hono";
+import type { Env, AgentConfig, CredentialConfig } from "@open-managed-agents/shared";
+import type { Services } from "@open-managed-agents/services";
+
+const app = new Hono<{ Bindings: Env; Variables: { services: Services } }>();
+
+interface ProxyTarget {
+  /** Real upstream MCP server URL (e.g. https://integrations.openma.dev/.../mcp). */
+  upstreamUrl: string;
+  /** Bearer token to inject on the upstream request. */
+  upstreamToken: string;
+}
+
+async function sha256(input: string): Promise<string> {
+  const buf = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(input));
+  return Array.from(new Uint8Array(buf)).map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+/**
+ * Validate the (api key, session id, mcp server name) triple and resolve
+ * the upstream URL + injection token. Returns null if anything fails — the
+ * caller turns that into a 401/403/404 with a generic message.
+ *
+ * Single function on purpose: when we add a KV cache for the (token+sid+server)
+ * tuple, the wrapper goes here, signature stays.
+ */
+async function resolveProxyTarget(
+  env: Env,
+  services: Services,
+  apiKey: string,
+  sid: string,
+  serverName: string,
+): Promise<ProxyTarget | null> {
+  // 1. Token → tenant_id, user_id (KV: apikey:<sha256>)
+  const hash = await sha256(apiKey);
+  const keyData = await env.CONFIG_KV.get(`apikey:${hash}`);
+  if (!keyData) return null;
+  const { tenant_id: tenantId } = JSON.parse(keyData) as { tenant_id: string; user_id?: string };
+  if (!tenantId) return null;
+
+  // 2. Session must exist, belong to the same tenant, not archived.
+  const session = await services.sessions.get({ tenantId, sessionId: sid }).catch(() => null);
+  if (!session) return null;
+  const sessionAny = session as {
+    archived_at?: string | null;
+    vault_ids?: string[] | null;
+    agent_snapshot?: AgentConfig;
+  };
+  if (sessionAny.archived_at) return null;
+
+  // 3. agent_snapshot must declare the requested mcp server.
+  const agent = sessionAny.agent_snapshot;
+  if (!agent) return null;
+  const server = (agent.mcp_servers ?? []).find((s) => s.name === serverName);
+  if (!server || !server.url) return null;
+
+  // 4. Resolve credential. agent.mcp_servers[].authorization_token, if set,
+  //    is the literal token we should inject. Otherwise look up an active
+  //    credential matching the server URL across the session's vault_ids.
+  if (server.authorization_token) {
+    return { upstreamUrl: server.url, upstreamToken: server.authorization_token };
+  }
+
+  const vaultIds = sessionAny.vault_ids ?? [];
+  if (vaultIds.length === 0) return null;
+  const grouped = await services.credentials
+    .listByVaults({ tenantId, vaultIds })
+    .catch(() => []);
+  for (const g of grouped) {
+    for (const c of g.credentials) {
+      const auth = (c as unknown as CredentialConfig).auth as
+        | { mcp_server_url?: string; bearer_token?: string; token?: string }
+        | undefined;
+      if (auth?.mcp_server_url !== server.url) continue;
+      const token = auth?.bearer_token ?? auth?.token;
+      if (token) return { upstreamUrl: server.url, upstreamToken: token };
+    }
+  }
+  return null;
+}
+
+// Forward both POST and GET for the MCP HTTP transport (depending on which
+// upstream protocol — JSON-RPC / SSE / etc. — the server speaks).
+app.all("/:sid/:server", async (c) => {
+  const sid = c.req.param("sid");
+  const serverName = c.req.param("server");
+  const auth = c.req.header("authorization") ?? "";
+  const apiKey = auth.startsWith("Bearer ") ? auth.slice(7) : auth;
+  if (!apiKey) return c.json({ error: "missing bearer" }, 401);
+
+  const target = await resolveProxyTarget(c.env, c.get("services"), apiKey, sid, serverName);
+  if (!target) return c.json({ error: "forbidden" }, 403);
+
+  // Build the upstream request: clone method + body, replace URL, swap
+  // authorization header. Strip any session-/proxy-specific headers so the
+  // upstream server only sees what it would have if the agent had called
+  // it directly with the real credential.
+  const upstreamHeaders = new Headers(c.req.raw.headers);
+  upstreamHeaders.set("authorization", `Bearer ${target.upstreamToken}`);
+  upstreamHeaders.delete("host");
+  upstreamHeaders.delete("cf-connecting-ip");
+  upstreamHeaders.delete("cf-ray");
+  upstreamHeaders.delete("x-forwarded-for");
+  upstreamHeaders.delete("x-forwarded-proto");
+  upstreamHeaders.delete("x-real-ip");
+
+  const upstreamReq = new Request(target.upstreamUrl, {
+    method: c.req.method,
+    headers: upstreamHeaders,
+    body: ["GET", "HEAD"].includes(c.req.method) ? undefined : c.req.raw.body,
+  });
+
+  // Stream the upstream response back as-is — MCP-over-HTTP clients
+  // expect to read the body progressively (SSE / chunked NDJSON).
+  return fetch(upstreamReq);
+});
+
+export default app;

--- a/apps/main/src/routes/runtimes.ts
+++ b/apps/main/src/routes/runtimes.ts
@@ -108,7 +108,7 @@ runtimesRoutes.get("/", async (c) => {
 
   const { results } = await c.env.AUTH_DB
     .prepare(
-      `SELECT id, machine_id, hostname, os, agents_json, version, status, last_heartbeat, created_at
+      `SELECT id, machine_id, hostname, os, agents_json, local_skills_json, version, status, last_heartbeat, created_at
        FROM "runtimes" WHERE owner_user_id = ? ORDER BY created_at DESC`,
     )
     .bind(userId)
@@ -118,6 +118,7 @@ runtimesRoutes.get("/", async (c) => {
       hostname: string;
       os: string;
       agents_json: string;
+      local_skills_json: string;
       version: string;
       status: string;
       last_heartbeat: number | null;
@@ -131,6 +132,7 @@ runtimesRoutes.get("/", async (c) => {
       hostname: r.hostname,
       os: r.os,
       agents: safeJsonParse(r.agents_json) as Array<{ id: string; binary?: string }>,
+      local_skills: safeJsonParse(r.local_skills_json ?? "{}") as Record<string, Array<{ id: string; name?: string; description?: string; source?: string; source_label?: string }>>,
       version: r.version,
       status: r.status,
       last_heartbeat: r.last_heartbeat,

--- a/apps/main/src/routes/runtimes.ts
+++ b/apps/main/src/routes/runtimes.ts
@@ -295,12 +295,10 @@ function safeJsonParse(s: string | null | undefined): unknown {
 // GET /agents/runtime/sessions/:sid/bundle?agent_id=<acp-agent-id>
 // Returns AGENTS.md + skill files for the daemon to materialize in spawn cwd.
 // Auth: Authorization: Bearer sk_machine_* — same auth the daemon uses to
-// open the WS attach. Validating that the daemon owns the requested session
-// would require resolving (token → user) → (sid → user) parity; we keep it
-// simpler by just verifying the bearer is a valid runtime token. The bundle
-// content doesn't include credentials, so the worst leak is a session's
-// AGENTS.md text. If a future agent has very sensitive system prompts,
-// tighten this to enforce session ownership via runtime_id ↔ session linkage.
+// open the WS attach. We additionally verify the requested session belongs
+// to the same tenant as the runtime token, so a leaked sk_machine_* from
+// tenant A can't enumerate tenant B's session ids and exfiltrate their
+// agent system prompts via the bundle.
 runtimeDaemonRoutes.get("/sessions/:sid/bundle", async (c) => {
   const auth = c.req.header("authorization") ?? "";
   const ok = await authenticateRuntimeToken(c.env, auth);
@@ -312,7 +310,12 @@ runtimeDaemonRoutes.get("/sessions/:sid/bundle", async (c) => {
 
   const services = c.get("services");
   const session = await services.sessions.getById({ sessionId: sid }).catch(() => null);
-  if (!session) return c.json({ error: "session not found" }, 404);
+  // Return 404 (not 403) for cross-tenant misses too — same response a
+  // legitimately-missing sid would produce, so the endpoint doesn't double
+  // as an existence oracle for sids in other tenants.
+  if (!session || session.tenant_id !== ok.tenant_id) {
+    return c.json({ error: "session not found" }, 404);
+  }
   const agent = (session as { agent_snapshot?: AgentConfig }).agent_snapshot;
   if (!agent) return c.json({ error: "session has no agent snapshot" }, 500);
 
@@ -382,18 +385,18 @@ function renderSessionBundle(
 export async function authenticateRuntimeToken(
   env: Env,
   bearer: string,
-): Promise<{ runtime_id: string; user_id: string } | null> {
+): Promise<{ runtime_id: string; user_id: string; tenant_id: string } | null> {
   const token = bearer.startsWith("Bearer ") ? bearer.slice(7) : bearer;
   if (!token.startsWith("sk_machine_")) return null;
   const hash = await sha256(token);
   const row = await env.AUTH_DB
     .prepare(
-      `SELECT t.runtime_id AS runtime_id, r.owner_user_id AS user_id
+      `SELECT t.runtime_id AS runtime_id, r.owner_user_id AS user_id, r.owner_tenant_id AS tenant_id
        FROM "runtime_tokens" t JOIN "runtimes" r ON r.id = t.runtime_id
        WHERE t.token_hash = ? AND t.revoked_at IS NULL`,
     )
     .bind(hash)
-    .first<{ runtime_id: string; user_id: string }>();
+    .first<{ runtime_id: string; user_id: string; tenant_id: string }>();
   if (!row) return null;
   // Best-effort last_used_at refresh; don't block on it.
   env.AUTH_DB

--- a/apps/main/src/routes/runtimes.ts
+++ b/apps/main/src/routes/runtimes.ts
@@ -1,0 +1,398 @@
+/**
+ * Local-runtime onboarding + management routes.
+ *
+ *   /v1/runtimes/*               — browser, requires user auth (authMiddleware)
+ *     POST /connect-runtime        → mint one-time `code` (5-min TTL, single-use)
+ *     GET  /                       → list my registered runtimes
+ *     DELETE /:id                  → revoke runtime + all its tokens
+ *
+ *   /agents/runtime/*            — daemon, no authMiddleware (token IS auth)
+ *     POST /exchange               → { code, machine_id, ... } → { runtime_id, token, agent_api_key }
+ *
+ * Setup flow:
+ *   1. CLI binds 127.0.0.1:<rand-port>, opens browser to
+ *      `https://app.openma.dev/connect-runtime?cb=...&state=...`
+ *   2. Browser (auth'd via Better Auth cookie) POSTs `/v1/runtimes/connect-runtime`
+ *      with the state echo → gets back a one-time `code`.
+ *   3. Browser redirects to `http://127.0.0.1:<port>/cb?code=...&state=...`.
+ *      Localhost server is the CLI; it grabs the code and closes.
+ *   4. CLI POSTs `/agents/runtime/exchange` with `{ code, machine_id, hostname, os, version }`.
+ *      Server validates code, inserts `runtimes` row + `runtime_tokens` row,
+ *      returns the token plaintext (only time it's ever transmitted) plus a
+ *      newly-minted user API key (`oma_*`) the daemon will hand to spawned ACP
+ *      children as their MCP authorization_token.
+ *   5. CLI writes ~/.oma/bridge/credentials.json + installs launchd plist.
+ */
+
+import { Hono } from "hono";
+import type { Env, AgentConfig } from "@open-managed-agents/shared";
+import type { Services } from "@open-managed-agents/services";
+
+/** Browser-facing routes — mounted under /v1/runtimes. */
+export const runtimesRoutes = new Hono<{
+  Bindings: Env;
+  Variables: { tenant_id: string; user_id?: string };
+}>();
+
+/** Daemon-facing routes — mounted under /agents/runtime. NO authMiddleware. */
+export const runtimeDaemonRoutes = new Hono<{
+  Bindings: Env;
+  Variables: { services: Services };
+}>();
+
+const CODE_TTL_SECONDS = 5 * 60;
+
+function generateCode(): string {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes).map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+function generateRuntimeToken(): string {
+  // sk_machine_ + 60 hex (240 bits). Stripe-style prefix so it's grep-able
+  // in user shell history if it ever leaks.
+  const bytes = new Uint8Array(30);
+  crypto.getRandomValues(bytes);
+  const hex = Array.from(bytes).map((b) => b.toString(16).padStart(2, "0")).join("");
+  return `sk_machine_${hex}`;
+}
+
+function generateAgentApiKey(): string {
+  // oma_* matches the existing API-key minting in routes/api-keys.ts so the
+  // existing authMiddleware accepts it without changes.
+  const bytes = new Uint8Array(36);
+  crypto.getRandomValues(bytes);
+  const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+  let out = "oma_";
+  for (const b of bytes) out += chars[b % chars.length];
+  return out;
+}
+
+async function sha256(input: string): Promise<string> {
+  const data = new TextEncoder().encode(input);
+  const buf = await crypto.subtle.digest("SHA-256", data);
+  return Array.from(new Uint8Array(buf)).map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+// ─── Browser-facing ───────────────────────────────────────────────────────
+
+// POST /v1/runtimes/connect-runtime — browser asks for a one-time exchange code.
+runtimesRoutes.post("/connect-runtime", async (c) => {
+  const userId = c.get("user_id");
+  const tenantId = c.get("tenant_id");
+  if (!userId || !tenantId) return c.json({ error: "unauthorized" }, 401);
+
+  const body = (await c.req.json().catch(() => ({}))) as { state?: string };
+  const state = body.state;
+  if (!state || typeof state !== "string" || state.length < 8) {
+    return c.json({ error: "state required (>= 8 chars)" }, 400);
+  }
+
+  const code = generateCode();
+  const expiresAt = Math.floor(Date.now() / 1000) + CODE_TTL_SECONDS;
+
+  await c.env.AUTH_DB
+    .prepare(
+      `INSERT INTO "connect_runtime_codes" (code, user_id, tenant_id, state, expires_at) VALUES (?, ?, ?, ?, ?)`,
+    )
+    .bind(code, userId, tenantId, state, expiresAt)
+    .run();
+
+  return c.json({ code, expires_at: expiresAt });
+});
+
+// GET /v1/runtimes — list user's runtimes.
+runtimesRoutes.get("/", async (c) => {
+  const userId = c.get("user_id");
+  if (!userId) return c.json({ error: "unauthorized" }, 401);
+
+  const { results } = await c.env.AUTH_DB
+    .prepare(
+      `SELECT id, machine_id, hostname, os, agents_json, version, status, last_heartbeat, created_at
+       FROM "runtimes" WHERE owner_user_id = ? ORDER BY created_at DESC`,
+    )
+    .bind(userId)
+    .all<{
+      id: string;
+      machine_id: string;
+      hostname: string;
+      os: string;
+      agents_json: string;
+      version: string;
+      status: string;
+      last_heartbeat: number | null;
+      created_at: number;
+    }>();
+
+  return c.json({
+    runtimes: (results ?? []).map((r) => ({
+      id: r.id,
+      machine_id: r.machine_id,
+      hostname: r.hostname,
+      os: r.os,
+      agents: safeJsonParse(r.agents_json) as Array<{ id: string; binary?: string }>,
+      version: r.version,
+      status: r.status,
+      last_heartbeat: r.last_heartbeat,
+      created_at: r.created_at,
+    })),
+  });
+});
+
+// DELETE /v1/runtimes/:id — revoke runtime + all its tokens.
+runtimesRoutes.delete("/:id", async (c) => {
+  const userId = c.get("user_id");
+  if (!userId) return c.json({ error: "unauthorized" }, 401);
+
+  const id = c.req.param("id");
+  const owned = await c.env.AUTH_DB
+    .prepare(`SELECT id FROM "runtimes" WHERE id = ? AND owner_user_id = ?`)
+    .bind(id, userId)
+    .first<{ id: string }>();
+  if (!owned) return c.json({ error: "not found" }, 404);
+
+  const now = Math.floor(Date.now() / 1000);
+  await c.env.AUTH_DB.batch([
+    c.env.AUTH_DB
+      .prepare(`UPDATE "runtime_tokens" SET revoked_at = ? WHERE runtime_id = ? AND revoked_at IS NULL`)
+      .bind(now, id),
+    c.env.AUTH_DB.prepare(`DELETE FROM "runtimes" WHERE id = ?`).bind(id),
+  ]);
+
+  return c.json({ ok: true });
+});
+
+// ─── Daemon-facing (no authMiddleware) ────────────────────────────────────
+
+// POST /agents/runtime/exchange — daemon swaps code for runtime token + agent API key.
+runtimeDaemonRoutes.post("/exchange", async (c) => {
+  const body = (await c.req.json().catch(() => ({}))) as {
+    code?: string;
+    state?: string;
+    machine_id?: string;
+    hostname?: string;
+    os?: string;
+    version?: string;
+  };
+
+  const { code, state, machine_id, hostname, os, version } = body;
+  if (!code || !state || !machine_id || !hostname || !os || !version) {
+    return c.json(
+      { error: "code, state, machine_id, hostname, os, version all required" },
+      400,
+    );
+  }
+
+  const now = Math.floor(Date.now() / 1000);
+
+  const row = await c.env.AUTH_DB
+    .prepare(
+      `SELECT user_id, tenant_id, state, expires_at, used_at FROM "connect_runtime_codes" WHERE code = ?`,
+    )
+    .bind(code)
+    .first<{ user_id: string; tenant_id: string; state: string; expires_at: number; used_at: number | null }>();
+
+  if (!row) return c.json({ error: "invalid code" }, 400);
+  if (row.used_at) return c.json({ error: "code already used" }, 400);
+  if (row.expires_at < now) return c.json({ error: "code expired" }, 400);
+  if (row.state !== state) return c.json({ error: "state mismatch" }, 400);
+
+  await c.env.AUTH_DB
+    .prepare(`UPDATE "connect_runtime_codes" SET used_at = ? WHERE code = ?`)
+    .bind(now, code)
+    .run();
+
+  // Idempotent runtime insert: re-running `oma bridge setup` from same UNIX
+  // user / same machine reuses the existing row.
+  const existing = await c.env.AUTH_DB
+    .prepare(`SELECT id FROM "runtimes" WHERE owner_user_id = ? AND machine_id = ?`)
+    .bind(row.user_id, machine_id)
+    .first<{ id: string }>();
+
+  let runtimeId: string;
+  if (existing) {
+    runtimeId = existing.id;
+    await c.env.AUTH_DB
+      .prepare(`UPDATE "runtimes" SET hostname = ?, os = ?, version = ? WHERE id = ?`)
+      .bind(hostname, os, version, runtimeId)
+      .run();
+  } else {
+    runtimeId = crypto.randomUUID();
+    await c.env.AUTH_DB
+      .prepare(
+        `INSERT INTO "runtimes" (id, owner_user_id, owner_tenant_id, machine_id, hostname, os, agents_json, version, status, last_heartbeat, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, '[]', ?, 'offline', NULL, ?)`,
+      )
+      .bind(runtimeId, row.user_id, row.tenant_id, machine_id, hostname, os, version, now)
+      .run();
+  }
+
+  // Always issue a fresh runtime token. Old tokens stay valid until explicit
+  // revoke — multiple `oma bridge setup` runs from different shells shouldn't
+  // kick each other out.
+  const tokenPlain = generateRuntimeToken();
+  const tokenHash = await sha256(tokenPlain);
+  const tokenId = crypto.randomUUID();
+  await c.env.AUTH_DB
+    .prepare(
+      `INSERT INTO "runtime_tokens" (id, runtime_id, token_hash, created_by_user_id, created_at) VALUES (?, ?, ?, ?, ?)`,
+    )
+    .bind(tokenId, runtimeId, tokenHash, row.user_id, now)
+    .run();
+
+  // Mint an agent-side API key the daemon will hand to ACP children for MCP
+  // proxy auth. Same shape as user-created keys (KV `apikey:<sha256>` row),
+  // so existing authMiddleware accepts it. Plaintext returned once.
+  const agentApiKey = await issueAgentApiKey(c.env, row.user_id, row.tenant_id, hostname);
+
+  return c.json({
+    runtime_id: runtimeId,
+    token: tokenPlain,
+    agent_api_key: agentApiKey,
+  });
+});
+
+/**
+ * Mint an `oma_*` API key for daemon-spawned ACP children. Stored same way as
+ * user-created keys (KV `apikey:<hash>`) so the existing /v1/* auth middleware
+ * accepts it. Plaintext returned to caller once and never re-issued.
+ */
+async function issueAgentApiKey(
+  env: Env,
+  userId: string,
+  tenantId: string,
+  displayLabel: string,
+): Promise<string> {
+  const plain = generateAgentApiKey();
+  const hash = await sha256(plain);
+  const id = `ak_${crypto.randomUUID().replace(/-/g, "").slice(0, 16)}`;
+  const now = new Date().toISOString();
+
+  // Mirror the schema in routes/api-keys.ts:
+  //   apikey:<hash> → { id, tenant_id, user_id, name, created_at }
+  //   t:<tenant>:apikeys → [ { id, name, prefix, hash, created_at } ]
+  await env.CONFIG_KV.put(
+    `apikey:${hash}`,
+    JSON.stringify({ id, tenant_id: tenantId, user_id: userId, name: `Local runtime (${displayLabel})`, created_at: now }),
+  );
+  const indexKey = `t:${tenantId}:apikeys`;
+  const existing = await env.CONFIG_KV.get(indexKey);
+  const index = existing ? (JSON.parse(existing) as Array<unknown>) : [];
+  index.push({ id, name: `Local runtime (${displayLabel})`, prefix: plain.slice(0, 8), hash, created_at: now });
+  await env.CONFIG_KV.put(indexKey, JSON.stringify(index));
+  return plain;
+}
+
+function safeJsonParse(s: string | null | undefined): unknown {
+  if (!s) return [];
+  try { return JSON.parse(s); } catch { return []; }
+}
+
+// ─── Daemon bundle endpoint ───────────────────────────────────────────────
+
+// GET /agents/runtime/sessions/:sid/bundle?agent_id=<acp-agent-id>
+// Returns AGENTS.md + skill files for the daemon to materialize in spawn cwd.
+// Auth: Authorization: Bearer sk_machine_* — same auth the daemon uses to
+// open the WS attach. Validating that the daemon owns the requested session
+// would require resolving (token → user) → (sid → user) parity; we keep it
+// simpler by just verifying the bearer is a valid runtime token. The bundle
+// content doesn't include credentials, so the worst leak is a session's
+// AGENTS.md text. If a future agent has very sensitive system prompts,
+// tighten this to enforce session ownership via runtime_id ↔ session linkage.
+runtimeDaemonRoutes.get("/sessions/:sid/bundle", async (c) => {
+  const auth = c.req.header("authorization") ?? "";
+  const ok = await authenticateRuntimeToken(c.env, auth);
+  if (!ok) return c.json({ error: "unauthorized" }, 401);
+
+  const sid = c.req.param("sid");
+  const acpAgentId = c.req.query("agent_id");
+  if (!acpAgentId) return c.json({ error: "agent_id query required" }, 400);
+
+  const services = c.get("services");
+  const session = await services.sessions.getById({ sessionId: sid }).catch(() => null);
+  if (!session) return c.json({ error: "session not found" }, 404);
+  const agent = (session as { agent_snapshot?: AgentConfig }).agent_snapshot;
+  if (!agent) return c.json({ error: "session has no agent snapshot" }, 500);
+
+  const files = renderSessionBundle(agent, acpAgentId);
+  return c.json({ files });
+});
+
+/**
+ * Render the spawn-cwd file bundle for a given (OMA agent config, ACP agent).
+ *
+ * The split between AGENTS.md and `.claude/skills/...` is agent-aware:
+ *   - claude-code-acp: skills get their own discoverable directory tree;
+ *     AGENTS.md only carries the system prompt + appendable_prompts.
+ *   - everyone else: no native skill mechanism we can rely on, so skills
+ *     get inlined into AGENTS.md as a `## Available Skills` section.
+ */
+function renderSessionBundle(
+  agent: AgentConfig,
+  acpAgentId: string,
+): Array<{ path: string; content: string }> {
+  const files: Array<{ path: string; content: string }> = [];
+  const skills = (agent.skills ?? []) as Array<{ skill_id: string; type: string; version?: string }>;
+  const supportsClaudeSkillsDir = acpAgentId === "claude-code-acp";
+
+  let agentsMd = `# ${agent.name ?? "OMA Agent"}\n\n`;
+  if (agent.description) agentsMd += `${agent.description}\n\n`;
+  if (agent.system) agentsMd += `## System Instructions\n\n${agent.system}\n\n`;
+  for (const p of agent.appendable_prompts ?? []) {
+    agentsMd += `## ${p}\n\n(appendable prompt: ${p})\n\n`;
+  }
+
+  if (skills.length > 0) {
+    if (supportsClaudeSkillsDir) {
+      agentsMd += `## Skills available\n\nClaude Code skills are mounted under \`.claude/skills/\`. Available:\n`;
+      for (const s of skills) agentsMd += `- ${s.skill_id} (v${s.version ?? "latest"})\n`;
+      agentsMd += "\n";
+      for (const s of skills) {
+        // v1: stub SKILL.md from agent metadata. Full skill content fetch
+        // (memory_store + skill_files) lands in a follow-up — see backlog.
+        files.push({
+          path: `.claude/skills/${s.skill_id}/SKILL.md`,
+          content: `# ${s.skill_id}\n\nSkill ${s.skill_id} (type=${s.type}, version=${s.version ?? "latest"}). Full skill content not yet bundled — see backlog.\n`,
+        });
+      }
+    } else {
+      agentsMd += `## Available Skills\n\n`;
+      for (const s of skills) {
+        agentsMd += `### ${s.skill_id}\n\nType: ${s.type}, version: ${s.version ?? "latest"}\n\n`;
+      }
+    }
+  }
+
+  files.unshift({ path: "AGENTS.md", content: agentsMd });
+  return files;
+}
+
+/**
+ * Helper for the WS /agents/runtime/_attach upgrade route in index.ts.
+ * Validates a Bearer sk_machine_* against runtime_tokens, returns the
+ * runtime row on success.
+ */
+export async function authenticateRuntimeToken(
+  env: Env,
+  bearer: string,
+): Promise<{ runtime_id: string; user_id: string } | null> {
+  const token = bearer.startsWith("Bearer ") ? bearer.slice(7) : bearer;
+  if (!token.startsWith("sk_machine_")) return null;
+  const hash = await sha256(token);
+  const row = await env.AUTH_DB
+    .prepare(
+      `SELECT t.runtime_id AS runtime_id, r.owner_user_id AS user_id
+       FROM "runtime_tokens" t JOIN "runtimes" r ON r.id = t.runtime_id
+       WHERE t.token_hash = ? AND t.revoked_at IS NULL`,
+    )
+    .bind(hash)
+    .first<{ runtime_id: string; user_id: string }>();
+  if (!row) return null;
+  // Best-effort last_used_at refresh; don't block on it.
+  env.AUTH_DB
+    .prepare(`UPDATE "runtime_tokens" SET last_used_at = unixepoch() WHERE token_hash = ?`)
+    .bind(hash)
+    .run()
+    .catch(() => {});
+  return row;
+}

--- a/apps/main/src/routes/runtimes.ts
+++ b/apps/main/src/routes/runtimes.ts
@@ -317,7 +317,12 @@ runtimeDaemonRoutes.get("/sessions/:sid/bundle", async (c) => {
   if (!agent) return c.json({ error: "session has no agent snapshot" }, 500);
 
   const files = renderSessionBundle(agent, acpAgentId);
-  return c.json({ files });
+  // Per-agent blocklist of LOCAL skills the user has on their machine
+  // — daemon enforces by NOT symlinking these into the spawn-cwd's
+  // CLAUDE_CONFIG_DIR. Always send an array (possibly empty) so the
+  // daemon doesn't have to handle three states (undefined / empty / set).
+  const local_skill_blocklist = agent.runtime_binding?.local_skill_blocklist ?? [];
+  return c.json({ files, local_skill_blocklist });
 });
 
 /**

--- a/apps/main/src/routes/sessions.ts
+++ b/apps/main/src/routes/sessions.ts
@@ -683,6 +683,27 @@ app.delete("/:id", async (c) => {
     });
   }
 
+  // Local-runtime (acp-proxy) sessions: also tell the daemon to kill its
+  // ACP child + drop the spawn cwd. Best-effort — if the runtime is offline
+  // or the binding missing, the daemon will reconcile next time it sees a
+  // 403 on session lookup. RuntimeRoom DO is addressed by runtime_id from
+  // the session's agent_snapshot.runtime_binding.
+  const agentSnap = (session as { agent_snapshot?: { runtime_binding?: { runtime_id?: string } } }).agent_snapshot;
+  const rid = agentSnap?.runtime_binding?.runtime_id;
+  if (rid && c.env.RUNTIME_ROOM) {
+    try {
+      const stub = c.env.RUNTIME_ROOM.get(c.env.RUNTIME_ROOM.idFromName(rid));
+      await (stub as unknown as {
+        sendToDaemon(msg: Record<string, unknown>): Promise<boolean>;
+      }).sendToDaemon({ type: "session.dispose", session_id: id });
+    } catch (err) {
+      logWarn(
+        { op: "session.delete.daemon_dispose", session_id: id, runtime_id: rid, err },
+        "daemon dispose forward failed; row will still be removed",
+      );
+    }
+  }
+
   // Cascade-delete the session row + every session_resources row in one
   // batch. Caller is still responsible for the per-session secret KV
   // entries (env_secret.value, github_repository.token) and for files

--- a/apps/main/src/runtime-room.ts
+++ b/apps/main/src/runtime-room.ts
@@ -154,9 +154,16 @@ export class RuntimeRoom extends DurableObject<Env> {
       const version = typeof parsed.version === "string" ? parsed.version : "unknown";
       const hostname = typeof parsed.hostname === "string" ? parsed.hostname : null;
       const os = typeof parsed.os === "string" ? parsed.os : null;
+      // local_skills is the daemon's scan of ~/.claude/skills/ +
+      // ~/.claude/plugins/*/skills/, keyed by acp agent id. Default {} when
+      // older daemons don't send it — column has DEFAULT '{}' too so writes
+      // either way produce valid JSON.
+      const localSkills = (parsed.local_skills && typeof parsed.local_skills === "object")
+        ? parsed.local_skills
+        : {};
       try {
-        const cols = ["agents_json = ?", "version = ?", "status = 'online'", "last_heartbeat = unixepoch()"];
-        const args: unknown[] = [JSON.stringify(agents), version];
+        const cols = ["agents_json = ?", "version = ?", "local_skills_json = ?", "status = 'online'", "last_heartbeat = unixepoch()"];
+        const args: unknown[] = [JSON.stringify(agents), version, JSON.stringify(localSkills)];
         if (hostname) { cols.push("hostname = ?"); args.push(hostname); }
         if (os) { cols.push("os = ?"); args.push(os); }
         args.push(this.runtimeId);

--- a/apps/main/src/runtime-room.ts
+++ b/apps/main/src/runtime-room.ts
@@ -1,0 +1,310 @@
+/**
+ * RuntimeRoom — Durable Object for one user-registered local runtime.
+ *
+ * Addressed by `idFromName(runtime_id)` so the daemon and the ACP-proxy
+ * harness inside SessionDO always land on the same instance.
+ *
+ * Two kinds of WS attached, distinguished by hibernation tag:
+ *   - "daemon"           — the long-running `oma bridge daemon` process. Exactly
+ *                          one. Reattaches with the same runtime token after WS
+ *                          drops (network blips, isolate evictions); the DO
+ *                          accepts the new attach and re-binds.
+ *   - "harness:<sid>"    — the AcpProxyHarness inside SessionDO listening for
+ *                          ACP events for a single in-flight turn. One per
+ *                          (sid, turn). Closes when the turn ends.
+ *
+ * Routing:
+ *   harness → DO   {type: session.start | session.prompt | session.cancel | session.dispose}
+ *                  → forwarded to daemon
+ *   daemon  → DO   {type: session.event | session.complete | session.error |
+ *                        session.ready | session.disposed | hello | ping}
+ *                  → fan-out to "harness:<sid>"
+ *
+ * Storage:
+ *   "session_state:<sid>"  — JSON of last terminal state (ready/error/disposed)
+ *                            so a harness that opens its WS *after* daemon
+ *                            already replied still gets the message.
+ *
+ * Auth: assumed enforced before fetch() reaches the DO. The /agents/runtime/
+ * _attach upgrade route validates the runtime bearer token and forwards as
+ * x-runtime-id / x-runtime-user headers; the harness internal route validates
+ * the internal-secret header.
+ */
+
+import { DurableObject } from "cloudflare:workers";
+import type { Env } from "@open-managed-agents/shared";
+import { log, logWarn, logError } from "@open-managed-agents/shared";
+
+type Side = "daemon" | "harness";
+
+const HARNESS_TAG_PREFIX = "harness:";
+function harnessTag(sid: string): string {
+  return `${HARNESS_TAG_PREFIX}${sid}`;
+}
+function sessionFromTag(tag: string): string | null {
+  return tag.startsWith(HARNESS_TAG_PREFIX) ? tag.slice(HARNESS_TAG_PREFIX.length) : null;
+}
+
+export class RuntimeRoom extends DurableObject<Env> {
+  /** Cached on first attach so logs / DB writes don't need a fresh lookup. */
+  private runtimeId = "";
+  private userId = "";
+
+  async fetch(request: Request): Promise<Response> {
+    if (request.headers.get("Upgrade") !== "websocket") {
+      return new Response("WebSocket only", { status: 400 });
+    }
+    const role = request.headers.get("x-attach-role"); // "daemon" | "harness"
+    if (role === "daemon") return this.attachDaemon(request);
+    if (role === "harness") return this.attachHarness(request);
+    return new Response("missing or invalid x-attach-role", { status: 400 });
+  }
+
+  private async attachDaemon(request: Request): Promise<Response> {
+    const runtimeId = request.headers.get("x-runtime-id") ?? "";
+    const userId = request.headers.get("x-runtime-user") ?? "";
+    if (!runtimeId || !userId) {
+      return new Response("missing runtime headers", { status: 400 });
+    }
+
+    // One daemon per runtime. A reconnecting daemon needs the prior WS to be
+    // reaped first — CF should fire `webSocketClose` on the old TCP long
+    // before a fresh attempt arrives, but if not we 409 the new one and let
+    // the daemon retry after the close finally lands.
+    const existing = this.ctx.getWebSockets("daemon");
+    if (existing.length > 0) {
+      try {
+        existing[0].send(JSON.stringify({ type: "ping" }));
+        return new Response("daemon already attached", { status: 409 });
+      } catch {
+        try { existing[0].close(1011, "stale"); } catch { /* already closing */ }
+      }
+    }
+
+    this.runtimeId = runtimeId;
+    this.userId = userId;
+    await this.ctx.storage.put("runtime_id", runtimeId);
+    await this.ctx.storage.put("user_id", userId);
+
+    const pair = new WebSocketPair();
+    const [client, server] = Object.values(pair);
+    this.ctx.acceptWebSocket(server, ["daemon"]);
+    log({ op: "runtime_room.daemon_attach", runtime_id: runtimeId }, "daemon attached");
+
+    await this.markOnline();
+    return new Response(null, { status: 101, webSocket: client });
+  }
+
+  private async attachHarness(request: Request): Promise<Response> {
+    const sid = request.headers.get("x-session-id") ?? "";
+    if (!sid) return new Response("missing x-session-id", { status: 400 });
+
+    await this.ensureIdentity();
+
+    const pair = new WebSocketPair();
+    const [client, server] = Object.values(pair);
+    this.ctx.acceptWebSocket(server, [harnessTag(sid)]);
+
+    const daemonUp = this.ctx.getWebSockets("daemon").length > 0;
+    try {
+      server.send(JSON.stringify({ type: "attached", daemon_online: daemonUp }));
+    } catch { /* race: harness already closed */ }
+
+    // Replay last terminal/transition state for this session if any. The
+    // harness might open its WS *after* daemon already responded with
+    // session.ready / session.error.
+    const replay = await this.ctx.storage.get<Record<string, unknown>>(this.sessionStateKey(sid));
+    if (replay) {
+      try { server.send(JSON.stringify(replay)); } catch { /* harness closed */ }
+    }
+
+    return new Response(null, { status: 101, webSocket: client });
+  }
+
+  private sessionStateKey(sid: string): string {
+    return `session_state:${sid}`;
+  }
+
+  async webSocketMessage(ws: WebSocket, message: string | ArrayBuffer): Promise<void> {
+    let parsed: { type?: string; [k: string]: unknown };
+    try {
+      const text = typeof message === "string" ? message : new TextDecoder().decode(message);
+      parsed = JSON.parse(text);
+    } catch (e) {
+      logWarn({ op: "runtime_room.bad_message", err: String(e) }, "bad ws message");
+      return;
+    }
+
+    await this.ensureIdentity();
+    const tags = this.ctx.getTags(ws);
+    const isDaemon = tags.includes("daemon");
+
+    if (isDaemon) {
+      await this.onDaemonMessage(ws, parsed);
+    } else {
+      const sid = tags.map(sessionFromTag).find((s): s is string => !!s);
+      if (!sid) return;
+      this.onHarnessMessage(sid, parsed);
+    }
+  }
+
+  private async onDaemonMessage(ws: WebSocket, parsed: { type?: string; [k: string]: unknown }): Promise<void> {
+    if (parsed.type === "hello") {
+      const agents = Array.isArray(parsed.agents) ? parsed.agents : [];
+      const version = typeof parsed.version === "string" ? parsed.version : "unknown";
+      const hostname = typeof parsed.hostname === "string" ? parsed.hostname : null;
+      const os = typeof parsed.os === "string" ? parsed.os : null;
+      try {
+        const cols = ["agents_json = ?", "version = ?", "status = 'online'", "last_heartbeat = unixepoch()"];
+        const args: unknown[] = [JSON.stringify(agents), version];
+        if (hostname) { cols.push("hostname = ?"); args.push(hostname); }
+        if (os) { cols.push("os = ?"); args.push(os); }
+        args.push(this.runtimeId);
+        await this.env.AUTH_DB
+          .prepare(`UPDATE "runtimes" SET ${cols.join(", ")} WHERE id = ?`)
+          .bind(...args)
+          .run();
+      } catch (e) {
+        logError({ op: "runtime_room.hello_db", err: String(e), runtime_id: this.runtimeId }, "hello DB update failed");
+      }
+      try { ws.send(JSON.stringify({ type: "welcome", runtime_id: this.runtimeId })); } catch { /* */ }
+      return;
+    }
+
+    if (parsed.type === "ping") {
+      try {
+        await this.env.AUTH_DB
+          .prepare(`UPDATE "runtimes" SET last_heartbeat = unixepoch(), status = 'online' WHERE id = ?`)
+          .bind(this.runtimeId)
+          .run();
+      } catch (e) {
+        logError({ op: "runtime_room.ping_db", err: String(e), runtime_id: this.runtimeId }, "ping DB update failed");
+      }
+      try { ws.send(JSON.stringify({ type: "pong" })); } catch { /* */ }
+      return;
+    }
+
+    // Session-related daemon messages — fan out to the harness for that sid.
+    //   session.ready    { session_id, acp_session_id }
+    //   session.event    { session_id, turn_id, event }
+    //   session.complete { session_id, turn_id }
+    //   session.error    { session_id, turn_id?, message }
+    //   session.disposed { session_id }
+    if (typeof parsed.type === "string" && parsed.type.startsWith("session.")) {
+      const sid = parsed.session_id as string | undefined;
+      if (!sid) {
+        logWarn({ op: "runtime_room.daemon_msg_no_sid", type: parsed.type }, "daemon message missing session_id");
+        return;
+      }
+      // Persist transition states so a harness opening its WS *after* the
+      // daemon already replied still receives the message. Per-event /
+      // per-complete are streamed and lost-on-late-attach is acceptable for v1.
+      if (parsed.type === "session.ready" || parsed.type === "session.error") {
+        await this.ctx.storage.put(this.sessionStateKey(sid), parsed);
+      }
+      if (parsed.type === "session.disposed") {
+        await this.ctx.storage.delete(this.sessionStateKey(sid));
+      }
+      this.broadcastToHarness(sid, parsed);
+      return;
+    }
+
+    log({ op: "runtime_room.unhandled_daemon_msg", type: parsed.type }, "unhandled daemon message");
+  }
+
+  private onHarnessMessage(sid: string, parsed: { type?: string; [k: string]: unknown }): void {
+    // Harness side speaks the canonical clash protocol verbatim — daemon
+    // doesn't need a translation step.
+    //   { type: "session.start", agent_id, cwd?, resume? }   → forwards as-is
+    //   { type: "session.prompt", turn_id, text }            → forwards as-is
+    //   { type: "session.cancel", turn_id }                  → forwards as-is
+    //   { type: "session.dispose" }                          → forwards as-is
+    const daemon = this.ctx.getWebSockets("daemon")[0];
+    if (!daemon) {
+      this.broadcastToHarness(sid, {
+        type: "session.error",
+        session_id: sid,
+        message: "runtime daemon offline",
+      });
+      return;
+    }
+    const out = { ...parsed, session_id: sid };
+    try {
+      daemon.send(JSON.stringify(out));
+    } catch (e) {
+      logWarn({ op: "runtime_room.forward_daemon_failed", err: String(e), session_id: sid }, "forward to daemon failed");
+    }
+  }
+
+  /** Send a message to all harness WSs subscribed to one session. */
+  private broadcastToHarness(sid: string, msg: Record<string, unknown>): void {
+    const payload = JSON.stringify(msg);
+    for (const ws of this.ctx.getWebSockets(harnessTag(sid))) {
+      try { ws.send(payload); } catch { /* dead harness; will close soon */ }
+    }
+  }
+
+  /** Tell the daemon to dispose a session. Called from internal route. */
+  async sendToDaemon(msg: Record<string, unknown>): Promise<boolean> {
+    await this.ensureIdentity();
+    const daemon = this.ctx.getWebSockets("daemon")[0];
+    if (!daemon) return false;
+    try { daemon.send(JSON.stringify(msg)); return true; }
+    catch { return false; }
+  }
+
+  async webSocketClose(ws: WebSocket, code: number, reason: string): Promise<void> {
+    await this.ensureIdentity();
+    const tags = this.ctx.getTags(ws);
+    if (tags.includes("daemon")) {
+      log({ op: "runtime_room.daemon_close", code, reason: reason || "—", runtime_id: this.runtimeId }, "daemon closed");
+      await this.markOffline();
+      return;
+    }
+    const sid = tags.map(sessionFromTag).find((s): s is string => !!s);
+    if (sid) {
+      log({ op: "runtime_room.harness_close", session_id: sid, code }, "harness closed");
+    }
+  }
+
+  async webSocketError(ws: WebSocket, error: unknown): Promise<void> {
+    await this.ensureIdentity();
+    logError({ op: "runtime_room.ws_error", err: String(error), runtime_id: this.runtimeId }, "ws error");
+    try { ws.close(1011, "ws error"); } catch { /* already closed */ }
+    const tags = this.ctx.getTags(ws);
+    if (tags.includes("daemon")) await this.markOffline();
+  }
+
+  private async ensureIdentity(): Promise<void> {
+    if (this.runtimeId && this.userId) return;
+    const stored = await this.ctx.storage.get(["runtime_id", "user_id"] as never);
+    const m = stored as unknown as Map<string, string> | undefined;
+    if (m) {
+      this.runtimeId = m.get("runtime_id") ?? "";
+      this.userId = m.get("user_id") ?? "";
+    }
+  }
+
+  private async markOnline(): Promise<void> {
+    try {
+      await this.env.AUTH_DB
+        .prepare(`UPDATE "runtimes" SET status = 'online', last_heartbeat = unixepoch() WHERE id = ?`)
+        .bind(this.runtimeId)
+        .run();
+    } catch (e) {
+      logError({ op: "runtime_room.mark_online", err: String(e), runtime_id: this.runtimeId }, "markOnline failed");
+    }
+  }
+
+  private async markOffline(): Promise<void> {
+    if (!this.runtimeId) return;
+    try {
+      await this.env.AUTH_DB
+        .prepare(`UPDATE "runtimes" SET status = 'offline' WHERE id = ?`)
+        .bind(this.runtimeId)
+        .run();
+    } catch (e) {
+      logError({ op: "runtime_room.mark_offline", err: String(e), runtime_id: this.runtimeId }, "markOffline failed");
+    }
+  }
+}

--- a/apps/main/wrangler.jsonc
+++ b/apps/main/wrangler.jsonc
@@ -15,7 +15,8 @@
       "/auth-info",
       "/health",
       "/linear/*",
-      "/linear-setup/*"
+      "/linear-setup/*",
+      "/agents/runtime/*"
     ]
   },
 
@@ -42,6 +43,12 @@
   "d1_databases": [
     { "binding": "AUTH_DB", "database_name": "openma-auth", "database_id": "dbb5f01c-7016-4157-945d-f8ff9fbda967" }
   ],
+
+  "durable_objects": {
+    "bindings": [
+      { "name": "RUNTIME_ROOM", "class_name": "RuntimeRoom" }
+    ]
+  },
 
   // Cloudflare Email Service (public beta) — transactional email
   "send_email": [
@@ -78,6 +85,10 @@
     {
       "tag": "v4",
       "deleted_classes": ["BuilderSandbox"]
+    },
+    {
+      "tag": "v5",
+      "new_sqlite_classes": ["RuntimeRoom"]
     }
   ],
 
@@ -140,6 +151,11 @@
         { "binding": "SANDBOX_sandbox_default", "service": "sandbox-default-staging" },
         { "binding": "INTEGRATIONS", "service": "managed-agents-integrations-staging" }
       ],
+      "durable_objects": {
+        "bindings": [
+          { "name": "RUNTIME_ROOM", "class_name": "RuntimeRoom" }
+        ]
+      },
       "limits": { "cpu_ms": 300000 },
       "observability": { "enabled": true },
       "analytics_engine_datasets": [

--- a/packages/acp-runtime/src/registry.ts
+++ b/packages/acp-runtime/src/registry.ts
@@ -48,6 +48,31 @@ export const KNOWN_ACP_AGENTS: KnownAgentEntry[] = [
     installHint: "npm install -g @google/gemini-cli",
     homepage: "https://github.com/google-gemini/gemini-cli",
   },
+  {
+    id: "opencode",
+    label: "OpenCode",
+    spec: { command: "opencode", args: ["acp"] },
+    installHint: "https://opencode.ai/docs/ — Go binary, install via the platform package or https://opencode.ai/install.sh",
+    homepage: "https://opencode.ai/",
+  },
+  {
+    id: "hermes",
+    label: "Hermes (Nous Research)",
+    spec: { command: "hermes", args: ["acp"] },
+    installHint: "see https://hermes-agent.nousresearch.com/docs/installation/",
+    homepage: "https://github.com/NousResearch/hermes-agent",
+  },
+  {
+    // Meta-CLI from openclaw that can wrap many non-native-ACP agents
+    // (openclaw, cursor, pi, kiro, qwen). We ship one entry pointing at
+    // openclaw because that's the most-asked-for; users can always pass
+    // their own AgentSpec to wrap a different one.
+    id: "openclaw",
+    label: "OpenClaw (via acpx)",
+    spec: { command: "acpx", args: ["openclaw"] },
+    installHint: "npm install -g acpx",
+    homepage: "https://github.com/openclaw/acpx",
+  },
 ];
 
 /**

--- a/packages/acp-runtime/src/session.ts
+++ b/packages/acp-runtime/src/session.ts
@@ -37,6 +37,11 @@ export class AcpSessionImpl implements AcpSession {
   readonly id: string;
   readonly options: SessionOptions;
 
+  /** Public read-only view of the agent-issued sessionId. Empty until init() resolves. */
+  get acpSessionId(): string {
+    return this.#sessionId ?? "";
+  }
+
   #child: ChildHandle;
   #agent!: Agent;                  // initialized in init()
   #sessionId!: string;              // ACP-side session id (different from this.id)
@@ -85,10 +90,35 @@ export class AcpSessionImpl implements AcpSession {
     );
     this.#agent = conn;
 
-    await this.#agent.initialize({
+    const initResult = await this.#agent.initialize({
       protocolVersion: 1,
       clientCapabilities: {},
     } as never);
+
+    // Try to resume an existing ACP session if asked. Agents that advertise
+    // loadSession in agentCapabilities will respond; older / leaner agents
+    // won't. We fall back to a fresh `session/new` instead of failing —
+    // losing transcript history is preferable to crashing the chat.
+    const wantsResume = this.options.resumeAcpSessionId;
+    const supportsLoad = (initResult as { agentCapabilities?: { loadSession?: boolean } })
+      ?.agentCapabilities?.loadSession === true;
+
+    if (wantsResume && supportsLoad) {
+      try {
+        await (this.#agent as unknown as { loadSession?: (p: unknown) => Promise<unknown> }).loadSession?.({
+          sessionId: wantsResume,
+          cwd: this.options.agent.cwd ?? process.cwd(),
+          mcpServers: [],
+        });
+        this.#sessionId = wantsResume;
+        return;
+      } catch (e) {
+        // Resume failed (e.g. on-disk transcript was deleted) — fall
+        // through to creating a fresh session.
+        // eslint-disable-next-line no-console
+        console.error(`[acp] session/load(${wantsResume}) failed, falling back to new:`, e);
+      }
+    }
 
     const newSession = await this.#agent.newSession({
       cwd: this.options.agent.cwd ?? process.cwd(),

--- a/packages/acp-runtime/src/spawners/node.ts
+++ b/packages/acp-runtime/src/spawners/node.ts
@@ -23,8 +23,22 @@ export class NodeSpawner implements Spawner {
     // stdio: [stdin, stdout, stderr] all piped — we own all three streams.
     // Inheriting stderr would dump child noise into the bridge's own stderr
     // and lose it from any structured log we set up; keep it captured.
+    //
+    // env merge semantics: parent env is inherited, then spec.env overrides.
+    // A spec.env entry with `undefined` value EXPLICITLY UNSETS the inherited
+    // key — used by callers who need the child to look like it's not running
+    // inside another agent (e.g. unsetting CLAUDECODE so claude-code-acp
+    // doesn't refuse to spawn nested-session-style).
+    const merged: Record<string, string | undefined> = {
+      ...process.env,
+      ...(spec.env ?? {}),
+    };
+    const env: NodeJS.ProcessEnv = {};
+    for (const [k, v] of Object.entries(merged)) {
+      if (typeof v === "string") env[k] = v;
+    }
     const child: ChildProcessWithoutNullStreams = nodeSpawn(spec.command, spec.args ?? [], {
-      env: { ...process.env, ...(spec.env ?? {}) },
+      env,
       cwd: spec.cwd,
       stdio: ["pipe", "pipe", "pipe"],
     });

--- a/packages/acp-runtime/src/types.ts
+++ b/packages/acp-runtime/src/types.ts
@@ -33,8 +33,12 @@ export interface AgentSpec {
   /** Executable name or absolute path. The spawner is responsible for $PATH lookup. */
   command: string;
   args?: string[];
-  /** Process env. Inherits the spawner's env unless explicitly overridden. */
-  env?: Record<string, string>;
+  /** Process env. Inherits the spawner's env; spec entries override. An entry
+   *  with `undefined` value EXPLICITLY UNSETS the inherited key — useful for
+   *  scrubbing variables like `CLAUDECODE` that mark the parent as already
+   *  inside a Claude Code session and would make a nested ACP child refuse
+   *  to start. */
+  env?: Record<string, string | undefined>;
   /** Working directory. Defaults to the spawner's cwd if omitted. */
   cwd?: string;
 }
@@ -121,6 +125,16 @@ export interface SessionOptions {
    * ACP request and surfaces a timeout error if exceeded. Default: 10 min.
    */
   perTurnTimeoutMs?: number;
+  /**
+   * If set, init() calls ACP `session/load` with this id instead of
+   * `session/new`. Powers cross-process resume — the agent re-hydrates
+   * a previous conversation from its on-disk transcript.
+   *
+   * Agents that don't support `session/load` (capability check at init
+   * fails) fall back to a fresh `session/new` and the caller is expected
+   * to surface the loss of history.
+   */
+  resumeAcpSessionId?: string;
 }
 
 /**
@@ -134,6 +148,8 @@ export interface SessionOptions {
 export interface AcpSession {
   /** Stable identifier for logging / pairing / multiplex routing. */
   readonly id: string;
+  /** The ACP-side session id (returned by `session/new` or echoed by `session/load`). */
+  readonly acpSessionId: string;
   /** Read-only snapshot of how this session was started. */
   readonly options: SessionOptions;
 

--- a/packages/agents-store/src/service.ts
+++ b/packages/agents-store/src/service.ts
@@ -38,6 +38,7 @@ export interface NewAgentInput {
   aux_model?: AgentConfig["aux_model"];
   aux_model_card_id?: string;
   appendable_prompts?: string[];
+  runtime_binding?: AgentConfig["runtime_binding"];
 }
 
 /** Mutable subset for `update`. Per-field `null` means "clear" — service
@@ -59,6 +60,7 @@ export interface UpdateAgentInput {
   aux_model?: AgentConfig["aux_model"] | null;
   aux_model_card_id?: string | null;
   appendable_prompts?: string[] | null;
+  runtime_binding?: AgentConfig["runtime_binding"] | null;
 }
 
 /** Default tools value when none provided — matches agents.ts:125. */
@@ -81,6 +83,7 @@ const UPDATABLE_FIELDS = [
   "aux_model_card_id",
   "metadata",
   "appendable_prompts",
+  "runtime_binding",
 ] as const;
 
 /**
@@ -147,6 +150,7 @@ export class AgentService {
       aux_model: opts.input.aux_model,
       aux_model_card_id: opts.input.aux_model_card_id,
       appendable_prompts: opts.input.appendable_prompts,
+      runtime_binding: opts.input.runtime_binding,
       version: 1,
       created_at: nowIso,
       updated_at: nowIso,

--- a/packages/api-types/src/types.ts
+++ b/packages/api-types/src/types.ts
@@ -87,6 +87,14 @@ export interface AgentConfig {
   runtime_binding?: {
     runtime_id: string;
     acp_agent_id: string;
+    /**
+     * Skill ids the user wants HIDDEN from this agent's ACP child. Default
+     * (omitted / empty) = all locally-detected skills allowed. Each id matches
+     * a skill the daemon reported in the runtime hello manifest's
+     * `local_skills[acp_agent_id]`. Daemon enforces by NOT symlinking the
+     * blocked dir into spawn cwd's CLAUDE_CONFIG_DIR.
+     */
+    local_skill_blocklist?: string[];
   };
   description?: string;
   metadata?: Record<string, unknown>;

--- a/packages/api-types/src/types.ts
+++ b/packages/api-types/src/types.ts
@@ -77,6 +77,17 @@ export interface AgentConfig {
   /** Companion to aux_model — explicit model card binding when needed. */
   aux_model_card_id?: string;
   harness?: string;
+  /**
+   * When set, agent runs on a user-registered local ACP runtime instead of
+   * OMA's cloud SessionDO loop. `harness` MUST be "acp-proxy" for this to
+   * take effect; SessionDO routes the AcpProxyHarness which proxies via the
+   * RuntimeRoom DO addressed by `runtime_id` to the daemon, which spawns the
+   * ACP child identified by `acp_agent_id` (matching KNOWN_ACP_AGENTS).
+   */
+  runtime_binding?: {
+    runtime_id: string;
+    acp_agent_id: string;
+  };
   description?: string;
   metadata?: Record<string, unknown>;
   /**

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openma/cli",
-  "version": "0.2.0-beta.1",
+  "version": "0.3.0-beta.0",
   "description": "CLI for the openma managed agents platform",
   "type": "module",
   "bin": {
@@ -11,7 +11,7 @@
     "node": ">=20"
   },
   "scripts": {
-    "build": "esbuild src/index.ts --bundle --platform=node --format=esm --outfile=dist/index.js --banner:js='#!/usr/bin/env node'",
+    "build": "esbuild src/index.ts --bundle --platform=node --format=esm --outfile=dist/index.js --banner:js=\"#!/usr/bin/env node\nimport { createRequire as __cr } from 'node:module'; const require = __cr(import.meta.url);\"",
     "dev": "tsx src/index.ts",
     "prepublishOnly": "npm run build"
   },
@@ -29,9 +29,17 @@
   "bugs": {
     "url": "https://github.com/open-ma/open-managed-agents/issues"
   },
+  "dependencies": {
+    "@agentclientprotocol/sdk": "^0.20.0",
+    "@open-managed-agents/acp-runtime": "workspace:*",
+    "ws": "^8.18.0"
+  },
   "devDependencies": {
     "@open-managed-agents/api-types": "workspace:*",
+    "@types/node": "^22.0.0",
+    "@types/ws": "^8.5.0",
     "esbuild": "^0.25.0",
-    "tsx": "^4.19.0"
+    "tsx": "^4.19.0",
+    "typescript": "^5.8.0"
   }
 }

--- a/packages/cli/src/bridge/commands/daemon.ts
+++ b/packages/cli/src/bridge/commands/daemon.ts
@@ -1,0 +1,206 @@
+/**
+ * `oma bridge daemon` — long-running reverse-WS to the control plane.
+ *
+ * Slice 1 scope: register, report manifest, heartbeat. No session spawning
+ * yet — that lands in slice 2 (handle `session.start` / `session.prompt`
+ * messages from the server, route to ACP agents, stream events back).
+ *
+ * Reconnect: exponential backoff capped at 60s. Heartbeat: 5min interval.
+ * The daemon process never exits on transport errors — only on SIGTERM /
+ * SIGINT (clean shutdown) or unrecoverable bugs (creds file missing /
+ * malformed). Under launchd, even those exits get restarted within ~10s
+ * thanks to KeepAlive=true.
+ */
+
+import { hostname } from "node:os";
+import { readCreds } from "../lib/config.js";
+import { osTag } from "../lib/platform.js";
+import { detectAll } from "@open-managed-agents/acp-runtime/registry";
+import { SessionManager } from "../lib/session-manager.js";
+import { gcOldSessions } from "../lib/session-cwd.js";
+import { printBanner, log, c } from "../lib/style.js";
+import { PKG_VERSION } from "../lib/version.js";
+import WebSocket from "ws";
+
+const HEARTBEAT_INTERVAL_MS = 5 * 60 * 1000;
+const RECONNECT_BACKOFF_MIN_MS = 1000;
+const RECONNECT_BACKOFF_MAX_MS = 60 * 1000;
+
+
+export async function runDaemon(): Promise<void> {
+  const creds = await readCreds();
+  if (!creds) {
+    process.stderr.write(
+      "✗ no credentials. Run `oma bridge setup` first.\n",
+    );
+    process.exit(2);
+  }
+
+  printBanner(`daemon — runtime ${creds.runtimeId.slice(0, 8)}… → ${creds.serverUrl}`, PKG_VERSION);
+
+  // Best-effort GC of session dirs older than 7 days. Non-blocking — if
+  // it fails the daemon still starts; user can clean ~/.oma/bridge/sessions/
+  // by hand if it ever piles up.
+  void gcOldSessions().then((r) => {
+    if (r.removed > 0) log.step(`GC: removed ${r.removed} stale session dir${r.removed === 1 ? "" : "s"}`);
+  }).catch(() => undefined);
+
+  // Convert https:// → wss:// (or http→ws for dev). The exchange flow
+  // wrote whatever scheme the user passed via --server-url to setup.
+  const wsBase = creds.serverUrl.replace(/^http(s?):\/\//, "ws$1://").replace(/\/$/, "");
+  const wsUrl = `${wsBase}/agents/runtime/_attach`;
+
+  let backoffMs = RECONNECT_BACKOFF_MIN_MS;
+  let stopping = false;
+
+  const stop = (sig: string) => {
+    if (stopping) return;
+    stopping = true;
+    log.step(`${sig} received, shutting down`);
+    // Tear down agents first so the child processes get SIGTERM-style
+    // dispose instead of being orphaned when the daemon process exits.
+    void sessions.disposeAll();
+    if (currentWs) {
+      try { currentWs.close(1000, "shutdown"); } catch { /* already closing */ }
+    }
+  };
+  process.on("SIGTERM", () => stop("SIGTERM"));
+  process.on("SIGINT", () => stop("SIGINT"));
+
+  let currentWs: WebSocket | null = null;
+  // SessionManager survives WS drops — keeps the ACP child processes alive
+  // so a brief network blip doesn't kill in-progress conversations. Each
+  // WS attach calls setSender() to point at the new socket.
+  const sessions = new SessionManager(() => {
+    /* placeholder — replaced on first attach via setSender */
+  });
+  // Wire daemon's identity into SessionManager so it can fetch session
+  // bundles from main and inject the agent API key into ACP children's MCP
+  // proxy auth (no spawn-env LLM key — user manages that themselves).
+  sessions.setSpawnEnv({
+    apiKey: creds.agentApiKey ?? "",
+    apiUrl: creds.serverUrl,
+    runtimeToken: creds.token,
+  });
+
+  while (!stopping) {
+    try {
+      const ws = new WebSocket(wsUrl, {
+        headers: { Authorization: `Bearer ${creds.token}` },
+      });
+      currentWs = ws;
+
+      await waitOpen(ws);
+      backoffMs = RECONNECT_BACKOFF_MIN_MS;
+      log.ok(`attached to ${c.cyan(wsBase)}`);
+
+      const agents = (await detectAll()).map((a) => ({
+        id: a.id,
+        binary: a.spec.command,
+      }));
+      ws.send(JSON.stringify({
+        type: "hello",
+        machine_id: creds.machineId,
+        hostname: hostname(),
+        os: osTag(),
+        version: PKG_VERSION,
+        agents,
+      }));
+      // Re-announce any sessions we were running before the WS drop.
+      // First-attach this is a no-op (no sessions yet).
+      sessions.announceAll();
+
+      const heartbeat = setInterval(() => {
+        if (ws.readyState === WebSocket.OPEN) {
+          ws.send(JSON.stringify({ type: "ping" }));
+        }
+      }, HEARTBEAT_INTERVAL_MS);
+
+      // Re-point SessionManager at the new socket. Sessions from the prior
+      // attach are still alive (their ACP children kept running across the
+      // WS drop). Re-announce them so the server's session_state cache
+      // gets refreshed and any browser that reattaches sees ready again.
+      sessions.setSender((msg) => {
+        if (ws.readyState === WebSocket.OPEN) ws.send(JSON.stringify(msg));
+      });
+
+      ws.on("message", (data: Buffer) => {
+        let msg: { type?: string; [k: string]: unknown };
+        try { msg = JSON.parse(data.toString()); } catch { return; }
+        process.stderr.write(`← server: ${msg.type ?? "?"}\n`);
+        switch (msg.type) {
+          case "welcome":
+          case "pong":
+            return;
+          case "session.start":
+            process.stderr.write(`  session.start sid=${(msg.session_id as string)?.slice(0, 8)} agent=${msg.agent_id}\n`);
+            void sessions.start(msg as never);
+            return;
+          case "session.prompt":
+            void sessions.prompt(msg as never);
+            return;
+          case "session.cancel":
+            sessions.cancel(msg.session_id as string, msg.turn_id as string);
+            return;
+          case "session.dispose":
+            void sessions.dispose(msg.session_id as string);
+            return;
+          default:
+            process.stderr.write(`! unhandled server message: ${msg.type ?? "?"}\n`);
+        }
+      });
+
+      // Wait until the WS closes (clean shutdown or transport drop).
+      await new Promise<void>((resolve) => {
+        ws.once("close", (code, reason) => {
+          clearInterval(heartbeat);
+          log.step(`WS closed  ${c.dim(`code=${code} reason=${reason?.toString() || "—"}`)}`);
+          resolve();
+        });
+      });
+
+      // Lost the WS but keep the ACP children alive — they'll be
+      // reachable again on the next successful attach. Backoff loop
+      // continues below.
+    } catch (e) {
+      log.warn(`WS attach failed: ${e instanceof Error ? e.message : String(e)}`);
+    }
+
+    if (stopping) break;
+    log.step(`reconnecting in ${backoffMs}ms`);
+    await sleep(backoffMs);
+    backoffMs = Math.min(backoffMs * 2, RECONNECT_BACKOFF_MAX_MS);
+  }
+
+  log.step("daemon exited");
+  process.exit(0);
+}
+
+function waitOpen(ws: WebSocket): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const onOpen = () => {
+      cleanup();
+      resolve();
+    };
+    const onError = (err: Error) => {
+      cleanup();
+      reject(err);
+    };
+    const onUnexpected = (_req: unknown, res: { statusCode?: number }) => {
+      cleanup();
+      reject(new Error(`unexpected response: HTTP ${res.statusCode}`));
+    };
+    const cleanup = () => {
+      ws.removeListener("open", onOpen);
+      ws.removeListener("error", onError);
+      ws.removeListener("unexpected-response", onUnexpected as never);
+    };
+    ws.once("open", onOpen);
+    ws.once("error", onError);
+    ws.once("unexpected-response", onUnexpected as never);
+  });
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/packages/cli/src/bridge/commands/daemon.ts
+++ b/packages/cli/src/bridge/commands/daemon.ts
@@ -17,6 +17,7 @@ import { readCreds } from "../lib/config.js";
 import { osTag } from "../lib/platform.js";
 import { detectAll } from "@open-managed-agents/acp-runtime/registry";
 import { SessionManager } from "../lib/session-manager.js";
+import { detectLocalSkills } from "../lib/local-skills.js";
 import { printBanner, log, c } from "../lib/style.js";
 import { PKG_VERSION } from "../lib/version.js";
 import WebSocket from "ws";
@@ -94,6 +95,16 @@ export async function runDaemon(): Promise<void> {
         id: a.id,
         binary: a.spec.command,
       }));
+      // Scan local skill dirs (~/.claude/skills/, ~/.claude/plugins/*/skills/)
+      // so the platform can show users what's available + let them blocklist
+      // specific skills per-agent. Strips the absolute `path` field — the
+      // platform doesn't need to know the user's home layout.
+      const localSkillsDetailed = await detectLocalSkills();
+      const localSkills: Record<string, Array<{ id: string; name?: string; description?: string; source: string; source_label?: string }>> = {};
+      for (const [agentId, skills] of Object.entries(localSkillsDetailed)) {
+        if (!skills) continue;
+        localSkills[agentId] = skills.map(({ path: _path, ...rest }) => rest);
+      }
       ws.send(JSON.stringify({
         type: "hello",
         machine_id: creds.machineId,
@@ -101,6 +112,7 @@ export async function runDaemon(): Promise<void> {
         os: osTag(),
         version: PKG_VERSION,
         agents,
+        local_skills: localSkills,
       }));
       // Re-announce any sessions we were running before the WS drop.
       // First-attach this is a no-op (no sessions yet).

--- a/packages/cli/src/bridge/commands/daemon.ts
+++ b/packages/cli/src/bridge/commands/daemon.ts
@@ -17,12 +17,15 @@ import { readCreds } from "../lib/config.js";
 import { osTag } from "../lib/platform.js";
 import { detectAll } from "@open-managed-agents/acp-runtime/registry";
 import { SessionManager } from "../lib/session-manager.js";
-import { gcOldSessions } from "../lib/session-cwd.js";
 import { printBanner, log, c } from "../lib/style.js";
 import { PKG_VERSION } from "../lib/version.js";
 import WebSocket from "ws";
 
-const HEARTBEAT_INTERVAL_MS = 5 * 60 * 1000;
+// CF Workers WS connections to *.workers.dev (lane URLs) idle out fast —
+// observed ~5-30s before TCP RST without keep-alive traffic. Even prod custom
+// domains drop within minutes of silence. Send a small ping every 25s so the
+// connection stays warm without burning much bandwidth or DO CPU.
+const HEARTBEAT_INTERVAL_MS = 25 * 1000;
 const RECONNECT_BACKOFF_MIN_MS = 1000;
 const RECONNECT_BACKOFF_MAX_MS = 60 * 1000;
 
@@ -37,13 +40,6 @@ export async function runDaemon(): Promise<void> {
   }
 
   printBanner(`daemon — runtime ${creds.runtimeId.slice(0, 8)}… → ${creds.serverUrl}`, PKG_VERSION);
-
-  // Best-effort GC of session dirs older than 7 days. Non-blocking — if
-  // it fails the daemon still starts; user can clean ~/.oma/bridge/sessions/
-  // by hand if it ever piles up.
-  void gcOldSessions().then((r) => {
-    if (r.removed > 0) log.step(`GC: removed ${r.removed} stale session dir${r.removed === 1 ? "" : "s"}`);
-  }).catch(() => undefined);
 
   // Convert https:// → wss:// (or http→ws for dev). The exchange flow
   // wrote whatever scheme the user passed via --server-url to setup.

--- a/packages/cli/src/bridge/commands/setup.ts
+++ b/packages/cli/src/bridge/commands/setup.ts
@@ -1,0 +1,220 @@
+/**
+ * `oma bridge setup` — one-time onboarding.
+ *
+ *   1. Bind 127.0.0.1:<rand-port> as a single-shot HTTP server.
+ *   2. Open the user's browser to https://openma.dev/connect-daemon?cb=…&state=…
+ *   3. User clicks "Allow this machine" (already auth'd via session cookie).
+ *      Browser POSTs /api/v1/runtimes/connect-daemon → gets one-time `code`.
+ *      Browser redirects to http://127.0.0.1:<port>/cb?code=…&state=…
+ *   4. Local server receives the code, returns a "✓ All set" HTML page,
+ *      shuts down.
+ *   5. CLI POSTs /agents/runtime/exchange { code, state, machine_id, … }
+ *      and persists the returned token to credentials.json.
+ *   6. (macOS) Install launchd plist, kick it off → daemon is now persistent.
+ *   7. Exit.
+ *
+ * The `state` is verified server-side (so a leaked code can't be used by a
+ * different setup attempt) AND client-side (so the localhost callback
+ * can't be poisoned by an arbitrary cross-site request to 127.0.0.1).
+ */
+
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import { spawn } from "node:child_process";
+import { hostname } from "node:os";
+import { randomBytes } from "node:crypto";
+import { writeCreds, readCreds, getOrCreateMachineId } from "../lib/config.js";
+import { paths, currentPlatform, osTag } from "../lib/platform.js";
+import { install as installLaunchd } from "../lib/launchd.js";
+import { detectAll } from "@open-managed-agents/acp-runtime/registry";
+import { printBanner, log, c } from "../lib/style.js";
+import { PKG_VERSION } from "../lib/version.js";
+
+interface SetupOpts {
+  serverUrl: string;
+  /** Browser URL — typically same host as serverUrl but on the user-facing
+   *  zone (openma.dev) rather than the API zone (app.openma.dev). */
+  browserOrigin: string;
+  /** When true, skip launchd install (useful for dev / non-macOS). */
+  noService?: boolean;
+  /** Force a fresh OAuth even if credentials.json already exists. */
+  force?: boolean;
+}
+
+
+export async function runSetup(opts: SetupOpts): Promise<void> {
+  printBanner(`setup — register this machine with ${opts.serverUrl}`, PKG_VERSION);
+
+  // Fast path: if creds already exist (and the user didn't pass --force),
+  // skip the OAuth dance and just refresh the launchd plist (binary path
+  // changes when the user upgrades the npm package — the plist must be
+  // re-generated to point at the new dist/cli.js). This makes
+  // `npx @openma/cli@beta setup` a clean upgrade flow: same one
+  // command for first install and every subsequent version bump.
+  if (!opts.force) {
+    const existing = await readCreds();
+    if (existing) {
+      log.ok(`existing credentials found  ${c.dim(paths().credsFile)}`);
+      log.hint(`runtime ${existing.runtimeId.slice(0, 8)}… (use --force to re-register)`);
+      if (!opts.noService && currentPlatform() === "darwin") {
+        await installLaunchd({ binaryPath: process.argv[1] });
+        log.ok(`launchd plist refreshed  ${c.dim(paths().serviceFile ?? "")}`);
+        log.ok(`daemon restarted  ${c.dim("logs: " + paths().logFile)}`);
+      } else {
+        log.hint("run `oma bridge daemon` to start the bridge");
+      }
+      process.stderr.write(`\n${c.bold("Up to date.")}\n\n`);
+      return;
+    }
+  }
+
+  log.step("waiting for browser to authorize");
+  const state = randomBytes(16).toString("hex");
+  const code = await waitForCallback(state, opts.browserOrigin);
+  log.ok("received code from browser");
+
+  const machineId = await getOrCreateMachineId();
+  const exchange = await postExchange(opts.serverUrl, {
+    code,
+    state,
+    machine_id: machineId,
+    hostname: hostname(),
+    os: osTag(),
+    version: PKG_VERSION,
+  });
+  log.ok(`runtime registered  ${c.dim(exchange.runtime_id.slice(0, 8) + "…")}`);
+
+  await writeCreds({
+    serverUrl: opts.serverUrl,
+    runtimeId: exchange.runtime_id,
+    token: exchange.token,
+    agentApiKey: exchange.agent_api_key,
+    machineId,
+    createdAt: Math.floor(Date.now() / 1000),
+  });
+  log.ok(`credentials written  ${c.dim(paths().credsFile)}`);
+
+  // Quick agent scan so the user can see what we'll report on first daemon
+  // startup. Manifest gets re-sent on every WS attach so this is just for
+  // setup-time feedback.
+  const agents = await detectAll();
+  if (agents.length > 0) {
+    log.ok(`agents detected  ${c.dim(agents.map((a: { id: string }) => a.id).join(", "))}`);
+  } else {
+    log.warn("no ACP agents on PATH yet");
+    log.hint("install one, e.g. `npm i -g @zed-industries/claude-code-acp`");
+  }
+
+  if (opts.noService || currentPlatform() !== "darwin") {
+    process.stderr.write("\n");
+    log.step("service install skipped");
+    log.hint("run `oma bridge daemon` to start the bridge in the foreground");
+    return;
+  }
+
+  await installLaunchd({ binaryPath: process.argv[1] });
+  log.ok(`launchd plist installed  ${c.dim(paths().serviceFile ?? "")}`);
+  log.ok(`daemon started  ${c.dim("logs: " + paths().logFile)}`);
+  process.stderr.write("\n");
+  process.stderr.write(`${c.bold("Done.")} the runtime should appear online at ${c.cyan(opts.browserOrigin)}\n\n`);
+}
+
+/** Wait for browser to redirect to localhost cb. Returns the code. */
+function waitForCallback(state: string, browserOrigin: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const timeoutMs = 5 * 60 * 1000;
+    const timer = setTimeout(() => {
+      try { server.close(); } catch { /* already closing */ }
+      reject(new Error("setup timed out — no browser callback in 5 minutes"));
+    }, timeoutMs);
+
+    const server = createServer((req, res) => {
+      const url = new URL(req.url ?? "/", `http://127.0.0.1`);
+      if (url.pathname !== "/cb") {
+        res.writeHead(404, { "content-type": "text/plain" }).end("not found");
+        return;
+      }
+      const gotState = url.searchParams.get("state") ?? "";
+      const code = url.searchParams.get("code") ?? "";
+      if (gotState !== state) {
+        res.writeHead(400, { "content-type": "text/plain" }).end("state mismatch");
+        return;
+      }
+      if (!code) {
+        res.writeHead(400, { "content-type": "text/plain" }).end("no code");
+        return;
+      }
+      res.writeHead(200, { "content-type": "text/html; charset=utf-8" }).end(
+        `<!doctype html><meta charset=utf-8><title>Connected</title>
+<style>body{font-family:system-ui;text-align:center;padding:80px;color:#333}</style>
+<h1>✓ Machine connected</h1>
+<p>You can close this tab and return to your terminal.</p>`,
+      );
+      clearTimeout(timer);
+      // Defer close so the response actually flushes.
+      setTimeout(() => { try { server.close(); } catch { /* */ } }, 100);
+      resolve(code);
+    });
+
+    server.on("error", (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+
+    server.listen(0, "127.0.0.1", () => {
+      const port = (server.address() as AddressInfo).port;
+      const cb = `http://127.0.0.1:${port}/cb`;
+      const target =
+        `${browserOrigin.replace(/\/$/, "")}/connect-daemon` +
+        `?cb=${encodeURIComponent(cb)}&state=${encodeURIComponent(state)}`;
+      process.stderr.write(`→ opening ${target}\n`);
+      openBrowser(target).catch((e) => {
+        process.stderr.write(
+          `! could not auto-open browser: ${e?.message ?? e}\n` +
+            `  please open this URL manually:\n  ${target}\n`,
+        );
+      });
+    });
+  });
+}
+
+interface ExchangeResponse {
+  runtime_id: string;
+  token: string;
+  agent_api_key?: string;
+}
+
+async function postExchange(
+  serverUrl: string,
+  body: { code: string; state: string; machine_id: string; hostname: string; os: string; version: string },
+): Promise<ExchangeResponse> {
+  const url = `${serverUrl.replace(/\/$/, "")}/agents/runtime/exchange`;
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  const text = await res.text();
+  if (!res.ok) {
+    throw new Error(`exchange failed: HTTP ${res.status}: ${text}`);
+  }
+  try {
+    return JSON.parse(text) as ExchangeResponse;
+  } catch {
+    throw new Error(`exchange returned non-JSON: ${text.slice(0, 200)}`);
+  }
+}
+
+function openBrowser(url: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const cmd =
+      process.platform === "darwin" ? "open" :
+      process.platform === "win32" ? "start" :
+      "xdg-open";
+    const args = process.platform === "win32" ? ["", url] : [url];
+    const p = spawn(cmd, args, { stdio: "ignore", detached: true, shell: process.platform === "win32" });
+    p.once("error", reject);
+    p.unref();
+    setTimeout(() => resolve(), 100);
+  });
+}

--- a/packages/cli/src/bridge/commands/setup.ts
+++ b/packages/cli/src/bridge/commands/setup.ts
@@ -2,9 +2,9 @@
  * `oma bridge setup` — one-time onboarding.
  *
  *   1. Bind 127.0.0.1:<rand-port> as a single-shot HTTP server.
- *   2. Open the user's browser to https://openma.dev/connect-daemon?cb=…&state=…
+ *   2. Open the user's browser to https://openma.dev/connect-runtime?cb=…&state=…
  *   3. User clicks "Allow this machine" (already auth'd via session cookie).
- *      Browser POSTs /api/v1/runtimes/connect-daemon → gets one-time `code`.
+ *      Browser POSTs /api/v1/runtimes/connect-runtime → gets one-time `code`.
  *      Browser redirects to http://127.0.0.1:<port>/cb?code=…&state=…
  *   4. Local server receives the code, returns a "✓ All set" HTML page,
  *      shuts down.
@@ -165,7 +165,7 @@ function waitForCallback(state: string, browserOrigin: string): Promise<string> 
       const port = (server.address() as AddressInfo).port;
       const cb = `http://127.0.0.1:${port}/cb`;
       const target =
-        `${browserOrigin.replace(/\/$/, "")}/connect-daemon` +
+        `${browserOrigin.replace(/\/$/, "")}/connect-runtime` +
         `?cb=${encodeURIComponent(cb)}&state=${encodeURIComponent(state)}`;
       process.stderr.write(`→ opening ${target}\n`);
       openBrowser(target).catch((e) => {

--- a/packages/cli/src/bridge/commands/status.ts
+++ b/packages/cli/src/bridge/commands/status.ts
@@ -1,0 +1,63 @@
+/**
+ * `oma bridge status` — print local creds + (best-effort) ping the server
+ * to verify the runtime is reachable and the token is still valid.
+ *
+ * No daemon process discovery (would require platform-specific PID files
+ * or `launchctl list` parsing). Status is "do you have a creds file" +
+ * "does the server still know about you" — for "is the daemon process
+ * actually running" the user can check `launchctl list | grep oma`
+ * (macOS) or look at the logs.
+ */
+
+import { readCreds } from "../lib/config.js";
+import { paths } from "../lib/platform.js";
+import { printBanner, log, c, sym } from "../lib/style.js";
+import { PKG_VERSION } from "../lib/version.js";
+
+export async function runStatus(): Promise<void> {
+  printBanner("status", PKG_VERSION);
+  const p = paths();
+  const creds = await readCreds();
+
+  if (!creds) {
+    log.warn("not set up — run `oma bridge setup` to register this machine");
+    log.hint(`looked for ${p.credsFile}`);
+    process.exit(1);
+  }
+
+  const row = (k: string, v: string) =>
+    process.stderr.write(`  ${c.dim(k.padEnd(11))} ${v}\n`);
+  row("server",     creds.serverUrl);
+  row("runtime_id", creds.runtimeId);
+  row("machine_id", creds.machineId);
+  row("registered", new Date(creds.createdAt * 1000).toISOString());
+  row("creds file", c.dim(p.credsFile));
+  row("log file",   c.dim(p.logFile));
+  if (p.serviceFile) row("service",    c.dim(p.serviceFile));
+
+  process.stderr.write("\n");
+  log.step("probing server");
+  try {
+    const wsUrl = `${creds.serverUrl.replace(/^http(s?):\/\//, "ws$1://").replace(/\/$/, "")}/agents/runtime/_attach`;
+    const WebSocket = (await import("ws")).default;
+    await new Promise<void>((resolve, reject) => {
+      const ws = new WebSocket(wsUrl, {
+        headers: { Authorization: `Bearer ${creds.token}` },
+      });
+      ws.once("open", () => {
+        log.ok("token accepted (server reachable)");
+        ws.close(1000, "status probe");
+        resolve();
+      });
+      ws.once("unexpected-response", (_req, res) => {
+        reject(new Error(`HTTP ${res.statusCode}`));
+      });
+      ws.once("error", reject);
+      setTimeout(() => reject(new Error("timeout")), 8000);
+    });
+  } catch (e) {
+    process.stderr.write(`  ${sym.err()} ${c.red(`probe failed: ${e instanceof Error ? e.message : String(e)}`)}\n`);
+    process.exit(1);
+  }
+  process.stderr.write("\n");
+}

--- a/packages/cli/src/bridge/commands/uninstall.ts
+++ b/packages/cli/src/bridge/commands/uninstall.ts
@@ -1,0 +1,67 @@
+/**
+ * `oma bridge uninstall` — tear down launchd / systemd unit, remove
+ * credentials, attempt server-side revoke. Best-effort: each step
+ * continues on failure so a partially-broken install can still be cleaned.
+ *
+ * Server-side revoke is best-effort because:
+ *   - The user may have already deleted the runtime via web UI (DELETE
+ *     /api/v1/runtimes/:id), in which case our token is gone too and the
+ *     call returns 401.
+ *   - The user may not have network when uninstalling (laptop in airplane
+ *     mode).
+ *
+ * Either way, the local side is what matters: stop the service, delete the
+ * creds. Stale rows on server eventually GC themselves (sweeper marks
+ * runtimes offline after no heartbeat; user can delete manually).
+ */
+
+import { uninstall as uninstallLaunchd } from "../lib/launchd.js";
+import { readCreds, deleteCreds } from "../lib/config.js";
+import { paths, currentPlatform } from "../lib/platform.js";
+import { printBanner, log, c, sym } from "../lib/style.js";
+import { PKG_VERSION } from "../lib/version.js";
+
+export async function runUninstall(): Promise<void> {
+  printBanner("uninstall — remove daemon + local credentials", PKG_VERSION);
+
+  // Step 1: stop the service first, so it isn't in the middle of writing
+  // to creds file when we delete it.
+  if (currentPlatform() === "darwin") {
+    try {
+      const r = await uninstallLaunchd();
+      if (r.removed) log.ok(`launchd plist removed  ${c.dim(paths().serviceFile ?? "")}`);
+      else process.stderr.write(`${sym.dot()} ${c.dim("launchd plist not present")}\n`);
+    } catch (e) {
+      log.warn(`launchd uninstall failed: ${e instanceof Error ? e.message : String(e)}`);
+    }
+  }
+
+  // Step 2: best-effort server-side revoke.
+  const creds = await readCreds();
+  if (creds) {
+    const url = `${creds.serverUrl.replace(/\/$/, "")}/api/v1/runtimes/${creds.runtimeId}`;
+    try {
+      const res = await fetch(url, {
+        method: "DELETE",
+        headers: { "x-runtime-token": creds.token },
+        // Server's DELETE requires user auth via session cookie / API token
+        // — our runtime token isn't accepted there. Best-effort call;
+        // expected 401. Browser-side revoke (Settings → Remove) is the
+        // supported path.
+      });
+      process.stderr.write(`${sym.dot()} ${c.dim(`server revoke: HTTP ${res.status} (browser is the canonical revoke path)`)}\n`);
+    } catch (e) {
+      process.stderr.write(`${sym.dot()} ${c.dim(`server revoke skipped: ${e instanceof Error ? e.message : String(e)}`)}\n`);
+    }
+  }
+
+  // Step 3: delete creds.
+  try {
+    await deleteCreds();
+    log.ok(`credentials removed  ${c.dim(paths().credsFile)}`);
+  } catch (e) {
+    log.warn(`creds removal failed: ${e instanceof Error ? e.message : String(e)}`);
+  }
+
+  process.stderr.write(`\n${c.bold("Done.")}\n\n`);
+}

--- a/packages/cli/src/bridge/lib/claude-config-dir.ts
+++ b/packages/cli/src/bridge/lib/claude-config-dir.ts
@@ -1,0 +1,111 @@
+/**
+ * Build a per-session `.claude-config/` directory the spawned Claude Code
+ * child reads via `CLAUDE_CONFIG_DIR=<cwd>/.claude-config`. Lets us hide
+ * specific local skills from a given OMA agent without touching the user's
+ * real `~/.claude/`.
+ *
+ * Strategy: symlink everything from `~/.claude/` over EXCEPT the skills tree,
+ * then rebuild `skills/` filtering out any id present in the blocklist.
+ *
+ *   ~/.claude/                  →   <cwd>/.claude-config/
+ *     settings.json             →     settings.json (symlink)
+ *     credentials.json          →     credentials.json (symlink)
+ *     agents/                   →     agents/ (symlink)
+ *     commands/                 →     commands/ (symlink)
+ *     plugins/                  →     plugins/ (symlink, atomic)
+ *     ...                       →     ... (symlink, atomic)
+ *     skills/<id>/              →     skills/<id>/ (symlink, only if NOT blocklisted)
+ *
+ * Blocklist is a Set of skill ids (the bare directory name). v1 filters only
+ * `~/.claude/skills/<id>/` — the common case where users drop custom skills
+ * by hand. Plugin-bundled skills come along with the wholesale `plugins/`
+ * symlink and aren't filterable yet (their layout is
+ * `plugins/cache/<marketplace>/<plugin>/<ver>/skills/<id>/` — would need a
+ * recursive walk to filter individually). Add when a real user hits this.
+ *
+ * For non–claude-code-acp agents this isn't called; their skill ecosystems
+ * don't share Claude Code's filesystem layout. Add per-agent helpers when
+ * codex / opencode / gemini grow analogous mechanisms.
+ *
+ * Best-effort throughout: a missing source dir, a stale symlink left over
+ * from a previous spawn, or a permission error on one entry must not abort
+ * the spawn — we log and keep going. Worst case the child sees a stale
+ * `.claude-config/` from the previous turn, which is still safer than
+ * crashing the daemon between user prompts.
+ */
+
+import { mkdir, readdir, rm, symlink } from "node:fs/promises";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+const CLAUDE_HOME = join(homedir(), ".claude");
+
+/**
+ * Materialize `<cwd>/.claude-config/` for a Claude Code spawn.
+ *
+ * Returns the absolute path the caller should pass as `CLAUDE_CONFIG_DIR`.
+ * Always returns the path even on partial failures — the spawn should still
+ * happen; the child will just see whatever symlinks succeeded.
+ */
+export async function setupClaudeConfigDir(
+  cwd: string,
+  blocklist: ReadonlySet<string>,
+): Promise<string> {
+  const cfgDir = join(cwd, ".claude-config");
+  await mkdir(cfgDir, { recursive: true });
+
+  await mirrorClaudeHome(cfgDir);
+  await rebuildSkills(cfgDir, blocklist);
+
+  return cfgDir;
+}
+
+/**
+ * Symlink every top-level entry in `~/.claude/` into `<cfgDir>/` EXCEPT
+ * `skills/`, which we rebuild with the blocklist applied.
+ *
+ * Idempotent: clears any pre-existing entry at the destination first so a
+ * second spawn (e.g. session.start re-fired after a daemon restart)
+ * replaces stale links pointing at deleted plugins.
+ */
+async function mirrorClaudeHome(cfgDir: string): Promise<void> {
+  let entries: string[] = [];
+  try { entries = await readdir(CLAUDE_HOME); } catch { return; }
+  for (const entry of entries) {
+    if (entry === "skills") continue;
+    const dst = join(cfgDir, entry);
+    await rm(dst, { recursive: true, force: true }).catch(() => {});
+    try {
+      await symlink(join(CLAUDE_HOME, entry), dst);
+    } catch (e) {
+      process.stderr.write(
+        `  ! claude-config symlink ${entry} failed (non-fatal): ${(e as Error).message}\n`,
+      );
+    }
+  }
+}
+
+/**
+ * Build `<cfgDir>/skills/` from `~/.claude/skills/` minus blocklisted ids.
+ * Each retained skill is one symlink to the real directory — we never copy
+ * skill content, so updates the user makes to `~/.claude/skills/<id>/` are
+ * visible to the spawned child immediately.
+ */
+async function rebuildSkills(cfgDir: string, blocklist: ReadonlySet<string>): Promise<void> {
+  const dst = join(cfgDir, "skills");
+  await rm(dst, { recursive: true, force: true }).catch(() => {});
+  await mkdir(dst, { recursive: true });
+
+  const src = join(CLAUDE_HOME, "skills");
+  let ids: string[] = [];
+  try { ids = await readdir(src); } catch { return; }
+  for (const id of ids) {
+    if (id.startsWith(".")) continue;
+    if (blocklist.has(id)) continue;
+    await symlink(join(src, id), join(dst, id)).catch((e) => {
+      process.stderr.write(
+        `  ! claude-config skill symlink ${id} failed (non-fatal): ${(e as Error).message}\n`,
+      );
+    });
+  }
+}

--- a/packages/cli/src/bridge/lib/config.ts
+++ b/packages/cli/src/bridge/lib/config.ts
@@ -1,0 +1,88 @@
+/**
+ * Credentials + machine-id persistence.
+ *
+ * `credentials.json` is mode 0600 (owner read/write only) — the runtime
+ * token is a long-lived bearer credential and we don't want any
+ * user/group on the box reading it. The directory is mode 0700 so the
+ * file's permissions can't be evaded by traversing the parent.
+ *
+ * `machine-id` is just a UUID generated on first run and persisted —
+ * survives daemon reinstalls but is per-user (same machine, different
+ * unix user → different machine_id, by design; runtimes are per-user).
+ */
+
+import { mkdir, readFile, writeFile, chmod } from "node:fs/promises";
+import { dirname } from "node:path";
+import { randomUUID } from "node:crypto";
+import { paths } from "./platform.js";
+
+export interface Credentials {
+  /** API root, e.g. "https://app.openma.dev". WS attach swaps https→wss. */
+  serverUrl: string;
+  /** Runtime row id returned by /agents/runtime/exchange. */
+  runtimeId: string;
+  /** sk_machine_… — bearer token for /agents/runtime/_attach. */
+  token: string;
+  /**
+   * `oma_*` API key the daemon hands to spawned ACP children as the
+   * `mcpServers[].authorization_token` so they can call OMA's mcp-proxy.
+   * Issued by the server during /exchange so the user never needs a
+   * separate login step on the daemon machine.
+   */
+  agentApiKey?: string;
+  /** Echoed for diagnostics; daemon also reads machineIdFile directly. */
+  machineId: string;
+  /** When this machine was first registered (unix seconds). */
+  createdAt: number;
+}
+
+export async function readCreds(): Promise<Credentials | null> {
+  // We deliberately do NOT migrate from any "legacy" config dir. The shared
+  // `~/.config/oma/credentials.json` belongs to `oma auth login` and has a
+  // different shape (Pattern A multi-tenant token bag); reusing those bytes
+  // here would silently overwrite the user's CLI auth.
+  try {
+    const text = await readFile(paths().credsFile, "utf-8");
+    return JSON.parse(text) as Credentials;
+  } catch (e: unknown) {
+    if ((e as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw e;
+  }
+}
+
+export async function writeCreds(creds: Credentials): Promise<void> {
+  const file = paths().credsFile;
+  await mkdir(dirname(file), { recursive: true, mode: 0o700 });
+  await writeFile(file, JSON.stringify(creds, null, 2), { mode: 0o600 });
+  // chmod again in case the file already existed with looser perms.
+  await chmod(file, 0o600);
+}
+
+export async function deleteCreds(): Promise<void> {
+  const { unlink } = await import("node:fs/promises");
+  try {
+    await unlink(paths().credsFile);
+  } catch (e: unknown) {
+    if ((e as NodeJS.ErrnoException).code !== "ENOENT") throw e;
+  }
+}
+
+/**
+ * Get-or-create the per-user machine fingerprint. Generated once and
+ * persisted; survives daemon reinstalls but is not tied to hardware
+ * (so a `~` restore from backup keeps the same id, which is what we
+ * want — the user's runtime continues to be "the same machine").
+ */
+export async function getOrCreateMachineId(): Promise<string> {
+  const file = paths().machineIdFile;
+  try {
+    const id = (await readFile(file, "utf-8")).trim();
+    if (id.length >= 32) return id;
+  } catch (e: unknown) {
+    if ((e as NodeJS.ErrnoException).code !== "ENOENT") throw e;
+  }
+  const id = randomUUID();
+  await mkdir(dirname(file), { recursive: true, mode: 0o700 });
+  await writeFile(file, id + "\n", { mode: 0o600 });
+  return id;
+}

--- a/packages/cli/src/bridge/lib/launchd.ts
+++ b/packages/cli/src/bridge/lib/launchd.ts
@@ -1,0 +1,108 @@
+/**
+ * macOS launchd plist install/uninstall.
+ *
+ * KeepAlive=true → if the daemon crashes / is killed, launchd restarts it
+ * within ~10s. RunAtLoad=true → launchd starts it on load (boot or `load`).
+ * StandardOutPath / StandardErrorPath → logs go to ~/Library/Logs/oma/
+ * so users can `tail -f` without dealing with `log show` filters.
+ *
+ * The plist invokes the same `oma bridge` binary that's on PATH (the one
+ * the user installed with `npm i -g @openma/cli`). If the user
+ * uninstalls the npm package, the plist will still try to start it on next
+ * load and fail — `oma bridge uninstall` removes the plist explicitly.
+ */
+
+import { mkdir, writeFile, unlink } from "node:fs/promises";
+import { dirname } from "node:path";
+import { spawn } from "node:child_process";
+import { paths, currentPlatform } from "./platform.js";
+
+export interface InstallOptions {
+  /** Absolute path to the daemon binary (the bin entry of @openma/cli). */
+  binaryPath: string;
+}
+
+function buildPlist(opts: InstallOptions): string {
+  const p = paths();
+  // launchd's xml is unforgiving; use a single template literal with no
+  // accidental whitespace inside <string> elements.
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>${p.serviceLabel}</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>${opts.binaryPath}</string>
+    <string>daemon</string>
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>ThrottleInterval</key>
+  <integer>10</integer>
+  <key>StandardOutPath</key>
+  <string>${p.logFile}</string>
+  <key>StandardErrorPath</key>
+  <string>${p.logFile}</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+  </dict>
+</dict>
+</plist>
+`;
+}
+
+export async function install(opts: InstallOptions): Promise<void> {
+  if (currentPlatform() !== "darwin") {
+    throw new Error(
+      `launchd install only supported on macOS. Run \`oma bridge daemon\` in foreground or wire your own systemd unit.`,
+    );
+  }
+  const p = paths();
+  if (!p.serviceFile) throw new Error("no service file path on this platform");
+
+  await mkdir(dirname(p.logFile), { recursive: true });
+  await mkdir(dirname(p.serviceFile), { recursive: true });
+
+  await writeFile(p.serviceFile, buildPlist(opts), "utf-8");
+
+  // Reload — `unload` is best-effort (plist may not be loaded yet); the
+  // load that follows is the one that must succeed.
+  await runLaunchctl(["unload", p.serviceFile]).catch(() => undefined);
+  await runLaunchctl(["load", "-w", p.serviceFile]);
+}
+
+export async function uninstall(): Promise<{ removed: boolean }> {
+  if (currentPlatform() !== "darwin") {
+    return { removed: false };
+  }
+  const p = paths();
+  if (!p.serviceFile) return { removed: false };
+
+  await runLaunchctl(["unload", p.serviceFile]).catch(() => undefined);
+  try {
+    await unlink(p.serviceFile);
+    return { removed: true };
+  } catch (e: unknown) {
+    if ((e as NodeJS.ErrnoException).code === "ENOENT") return { removed: false };
+    throw e;
+  }
+}
+
+function runLaunchctl(args: string[]): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const p = spawn("launchctl", args, { stdio: ["ignore", "pipe", "pipe"] });
+    let stderr = "";
+    p.stderr.on("data", (chunk) => (stderr += chunk.toString()));
+    p.once("error", reject);
+    p.once("exit", (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`launchctl ${args.join(" ")} exited ${code}: ${stderr.trim()}`));
+    });
+  });
+}

--- a/packages/cli/src/bridge/lib/local-skills.ts
+++ b/packages/cli/src/bridge/lib/local-skills.ts
@@ -1,0 +1,137 @@
+/**
+ * Detect ACP-compatible local skills installed on the user's machine.
+ *
+ * Currently scans Claude Code skill paths only (other ACP agents have their
+ * own conventions; codex / gemini / opencode each store skills/plugins
+ * differently). Add new agent types as detection grows.
+ *
+ * Output is sent to the platform in the daemon's `hello` manifest so the
+ * Console can show "what's available locally" and so per-agent settings
+ * can blocklist specific skills (the platform tells us which to hide via
+ * the bundle response on each session.start, and we filter by NOT
+ * symlinking blocklisted dirs into the spawn cwd's CLAUDE_CONFIG_DIR).
+ */
+
+import { readdir, readFile, stat } from "node:fs/promises";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+export interface LocalSkill {
+  /** Directory name — used as the stable id the platform stores in
+   *  AgentConfig.runtime_binding.local_skill_blocklist. Also the name
+   *  the ACP agent uses to refer to the skill. */
+  id: string;
+  /** Display name pulled from SKILL.md frontmatter / first H1, fallback to id. */
+  name?: string;
+  /** First non-empty paragraph of SKILL.md, capped to ~200 chars for UI display. */
+  description?: string;
+  /** Where the skill came from — affects how Console labels it. */
+  source: "global" | "plugin" | "project";
+  /** When source=plugin, the plugin name (e.g. "openclaw"). */
+  source_label?: string;
+  /** Absolute path on disk — daemon-only, not persisted server-side. */
+  path: string;
+}
+
+/** Manifest shape returned to platform: keyed by ACP agent id so each
+ *  agent kind can have its own skill ecosystem. */
+export type LocalSkillManifest = Partial<Record<string, LocalSkill[]>>;
+
+const HOME = homedir();
+
+/**
+ * Scan all known skill locations on this machine. Each skill is detected
+ * exactly once (deduped by id within an agent kind; later entries shadow
+ * earlier — same precedence claude-code uses, project > plugin > global).
+ */
+export async function detectLocalSkills(): Promise<LocalSkillManifest> {
+  return {
+    "claude-code-acp": await detectClaudeCodeSkills(),
+  };
+}
+
+async function detectClaudeCodeSkills(): Promise<LocalSkill[]> {
+  const seen = new Map<string, LocalSkill>();
+
+  // ~/.claude/skills/<id>/SKILL.md — global skills the user installed by hand
+  // or via `claude /skills`.
+  for (const skill of await scanSkillsDir(join(HOME, ".claude", "skills"), "global")) {
+    seen.set(skill.id, skill);
+  }
+
+  // ~/.claude/plugins/<plugin>/skills/<id>/SKILL.md — skills bundled with
+  // installed plugins. Same ACP agent sees these alongside globals; we keep
+  // the source label so the Console can show the user where each came from.
+  const pluginsRoot = join(HOME, ".claude", "plugins");
+  let plugins: string[] = [];
+  try { plugins = await readdir(pluginsRoot); } catch { /* no plugins dir */ }
+  for (const plugin of plugins) {
+    const pluginSkillsDir = join(pluginsRoot, plugin, "skills");
+    for (const skill of await scanSkillsDir(pluginSkillsDir, "plugin", plugin)) {
+      // Plugin skills don't override globals with the same id — claude-code
+      // would also see both, so report both. Use a synthetic id with plugin
+      // prefix to dedupe in the map but keep the original id for the wire.
+      const key = `${plugin}/${skill.id}`;
+      seen.set(key, skill);
+    }
+  }
+
+  return [...seen.values()];
+}
+
+async function scanSkillsDir(
+  dir: string,
+  source: LocalSkill["source"],
+  source_label?: string,
+): Promise<LocalSkill[]> {
+  let entries: string[];
+  try { entries = await readdir(dir); } catch { return []; }
+  const out: LocalSkill[] = [];
+  for (const id of entries) {
+    if (id.startsWith(".")) continue;
+    const skillDir = join(dir, id);
+    let st;
+    try { st = await stat(skillDir); } catch { continue; }
+    if (!st.isDirectory()) continue;
+    const meta = await readSkillMeta(join(skillDir, "SKILL.md"));
+    out.push({
+      id,
+      name: meta.name ?? id,
+      description: meta.description,
+      source,
+      source_label,
+      path: skillDir,
+    });
+  }
+  return out;
+}
+
+async function readSkillMeta(file: string): Promise<{ name?: string; description?: string }> {
+  let text: string;
+  try { text = await readFile(file, "utf-8"); } catch { return {}; }
+  // YAML frontmatter (---\nname: ...\ndescription: ...\n---)
+  const fm = text.match(/^---\s*\n([\s\S]*?)\n---/);
+  let name: string | undefined;
+  let description: string | undefined;
+  if (fm) {
+    const nm = fm[1].match(/^name:\s*(.+)$/m);
+    if (nm) name = nm[1].trim().replace(/^["']|["']$/g, "");
+    const dm = fm[1].match(/^description:\s*(.+)$/m);
+    if (dm) description = dm[1].trim().replace(/^["']|["']$/g, "");
+    text = text.slice(fm[0].length);
+  }
+  // Fallback: first H1 = name, first non-blank paragraph after = description
+  if (!name) {
+    const h1 = text.match(/^#\s+(.+)$/m);
+    if (h1) name = h1[1].trim();
+  }
+  if (!description) {
+    const para = text
+      .replace(/^#.*$/gm, "")
+      .split(/\n\s*\n/)
+      .map((p) => p.trim())
+      .find((p) => p.length > 0);
+    if (para) description = para.slice(0, 200) + (para.length > 200 ? "…" : "");
+  }
+  return { name, description };
+}

--- a/packages/cli/src/bridge/lib/platform.ts
+++ b/packages/cli/src/bridge/lib/platform.ts
@@ -1,0 +1,68 @@
+/**
+ * OS paths for daemon state, logs, service files, and per-session cwd.
+ *
+ * Single convention across platforms: `~/.oma/bridge/` is the user-level root,
+ * matching every other modern AI tool (`~/.claude`, `~/.codex`, `~/.gemini`,
+ * `~/.cursor`). XDG and Library/Application-Support paths were noisier and
+ * inconsistent; the one downside (slightly less Linux-purist) is acceptable.
+ *
+ * Service files (launchd plist / systemd user unit) stay in their
+ * platform-canonical locations because the OS scans those directories —
+ * we can't move them.
+ *
+ * Windows isn't supported in v1 for service mode — daemon command still
+ * runs in foreground; users wire their own startup later.
+ */
+
+import { homedir, platform } from "node:os";
+import { join } from "node:path";
+
+export type Platform = "darwin" | "linux" | "win32" | "unknown";
+
+export function currentPlatform(): Platform {
+  const p = platform();
+  if (p === "darwin" || p === "linux" || p === "win32") return p;
+  return "unknown";
+}
+
+export interface Paths {
+  /** `~/.oma/bridge` — root of all daemon state on every platform. */
+  configDir: string;
+  /** Credentials file (server_url, runtime_id, token, machine_id). */
+  credsFile: string;
+  /** Stable per-user machine fingerprint; persisted on first run. */
+  machineIdFile: string;
+  /** Daemon log file. */
+  logFile: string;
+  /** Per-session cwd root. Each spawned ACP agent gets a subdir under this. */
+  sessionsDir: string;
+  /** launchd plist (macOS) / systemd user unit (linux). null on win32. */
+  serviceFile: string | null;
+  /** Service identifier — reverse-DNS style. */
+  serviceLabel: string;
+}
+
+const SERVICE_LABEL = "dev.openma.bridge";
+
+export function paths(): Paths {
+  const home = homedir();
+  const p = currentPlatform();
+  const configDir = join(home, ".oma/bridge");
+  const credsFile = join(configDir, "credentials.json");
+  const machineIdFile = join(configDir, "machine-id");
+  const sessionsDir = join(configDir, "sessions");
+  const logFile = join(configDir, "logs", "bridge.log");
+
+  let serviceFile: string | null = null;
+  if (p === "darwin") {
+    serviceFile = join(home, "Library", "LaunchAgents", `${SERVICE_LABEL}.plist`);
+  } else if (p === "linux") {
+    serviceFile = join(home, ".config", "systemd", "user", `${SERVICE_LABEL}.service`);
+  }
+  return { configDir, credsFile, machineIdFile, sessionsDir, logFile, serviceFile, serviceLabel: SERVICE_LABEL };
+}
+
+/** "darwin/arm64" — sent to server as the runtime's `os` field. */
+export function osTag(): string {
+  return `${platform()}/${process.arch}`;
+}

--- a/packages/cli/src/bridge/lib/session-cwd.ts
+++ b/packages/cli/src/bridge/lib/session-cwd.ts
@@ -1,0 +1,108 @@
+/**
+ * Per-session working directory management.
+ *
+ * Every spawned ACP agent runs with cwd = `~/.oma/bridge/sessions/<session-id>/`
+ * — never the user's pwd. Three reasons:
+ *
+ *   1. Spawn-cwd injection. The OMA-rendered bundle (AGENTS.md + skill files)
+ *      lands in this dir before each session.start, so the ACP agent reads
+ *      our prompt + skills via its native discovery convention. We can't
+ *      drop those into the user's project root.
+ *   2. Isolation. Two parallel sessions don't see each other's transcripts
+ *      or tool-call state.
+ *   3. Stable transcript paths. Resume-from-disk needs the cwd to be the
+ *      same next time; the user's pwd is whatever terminal they ran
+ *      `npx` from this morning.
+ *
+ * Cleanup is GC'd, not eager — a 7-day-old session dir is removed on the
+ * next daemon startup. Eager rm-on-dispose would lose the transcript that
+ * powers Resume.
+ *
+ * The bundle (AGENTS.md + .claude/skills/...) is fetched per session.start
+ * from main's `/v1/internal/runtime-session-bundle?sid=...&agent_id=...`,
+ * NOT bundled into the daemon binary. That keeps prompts / skills owned by
+ * the OMA platform per-tenant rather than baked into the npm-published CLI.
+ */
+
+import { mkdir, readdir, rm, stat, writeFile } from "node:fs/promises";
+import { createHash } from "node:crypto";
+import { dirname, join } from "node:path";
+import { paths } from "./platform.js";
+
+const GC_AGE_SECONDS = 7 * 24 * 60 * 60;
+const DIR_NAME_LEN = 12;
+
+/**
+ * Derive a short, filesystem-friendly dir name from any session id. UUIDs
+ * are 36 chars and look unwieldy when listed in `~/.oma/bridge/sessions/`;
+ * 12 hex chars (48 bits) are short enough to scan visually but still
+ * have enough entropy to avoid practical collisions. Deterministic so
+ * the same session_id always maps to the same dir (resume / GC work).
+ */
+function dirNameFor(sessionId: string): string {
+  if (/^[a-f0-9]{1,12}$/i.test(sessionId)) return sessionId.toLowerCase();
+  return createHash("sha256").update(sessionId).digest("hex").slice(0, DIR_NAME_LEN);
+}
+
+/**
+ * Returns the cwd path for a session; creates it if it doesn't already exist.
+ * Bundle materialization is the caller's job — call writeBundle() with the
+ * `files: [{path, content}]` array fetched from main's
+ * `/v1/internal/runtime-session-bundle` before issuing session/new.
+ */
+export async function ensureSessionCwd(sessionId: string): Promise<string> {
+  const cwd = join(paths().sessionsDir, dirNameFor(sessionId));
+  await mkdir(cwd, { recursive: true });
+  return cwd;
+}
+
+/**
+ * Drop bundle files from main into a session cwd. Each entry's `path` is
+ * relative to cwd, can include subdirectories (mkdir -p applied). Existing
+ * files at the same path are overwritten — bundle is the source of truth
+ * for AGENTS.md / `.claude/skills/...` content, and we want each session
+ * spawn to reflect the latest agent config.
+ */
+export async function writeBundle(
+  cwd: string,
+  files: Array<{ path: string; content: string }>,
+): Promise<void> {
+  for (const f of files) {
+    if (f.path.startsWith("/") || f.path.includes("..")) continue; // refuse traversal
+    const dst = join(cwd, f.path);
+    await mkdir(dirname(dst), { recursive: true });
+    await writeFile(dst, f.content);
+  }
+}
+
+/**
+ * Best-effort: drop session directories not touched in `GC_AGE_SECONDS`.
+ * Called by the daemon on startup so reboots reclaim disk without an
+ * explicit timer. Errors are swallowed — a stuck dir is preferable to a
+ * crashed daemon.
+ */
+export async function gcOldSessions(): Promise<{ removed: number }> {
+  const root = paths().sessionsDir;
+  let entries: string[];
+  try {
+    entries = await readdir(root);
+  } catch (e: unknown) {
+    if ((e as NodeJS.ErrnoException).code === "ENOENT") return { removed: 0 };
+    return { removed: 0 };
+  }
+  const cutoff = Math.floor(Date.now() / 1000) - GC_AGE_SECONDS;
+  let removed = 0;
+  for (const entry of entries) {
+    const full = join(root, entry);
+    try {
+      const st = await stat(full);
+      if (!st.isDirectory()) continue;
+      if (Math.floor(st.mtimeMs / 1000) > cutoff) continue;
+      await rm(full, { recursive: true, force: true });
+      removed += 1;
+    } catch {
+      /* skip */
+    }
+  }
+  return { removed };
+}

--- a/packages/cli/src/bridge/lib/session-cwd.ts
+++ b/packages/cli/src/bridge/lib/session-cwd.ts
@@ -14,22 +14,24 @@
  *      same next time; the user's pwd is whatever terminal they ran
  *      `npx` from this morning.
  *
- * Cleanup is GC'd, not eager — a 7-day-old session dir is removed on the
- * next daemon startup. Eager rm-on-dispose would lose the transcript that
- * powers Resume.
+ * Lifecycle: dir lifetime is bound to the OMA session. Cleanup happens when
+ * the platform tells the daemon `session.dispose` (which fires on
+ * `DELETE /v1/sessions/:id`). The daemon does NOT auto-GC by age — leaving
+ * a stale dir is preferable to deleting transcripts the user might still
+ * want to resume / inspect, and only the platform knows when a session
+ * is truly dead.
  *
  * The bundle (AGENTS.md + .claude/skills/...) is fetched per session.start
- * from main's `/v1/internal/runtime-session-bundle?sid=...&agent_id=...`,
- * NOT bundled into the daemon binary. That keeps prompts / skills owned by
+ * from main's `/agents/runtime/sessions/:sid/bundle?agent_id=...`, NOT
+ * bundled into the daemon binary. That keeps prompts / skills owned by
  * the OMA platform per-tenant rather than baked into the npm-published CLI.
  */
 
-import { mkdir, readdir, rm, stat, writeFile } from "node:fs/promises";
+import { mkdir, rm, writeFile } from "node:fs/promises";
 import { createHash } from "node:crypto";
 import { dirname, join } from "node:path";
 import { paths } from "./platform.js";
 
-const GC_AGE_SECONDS = 7 * 24 * 60 * 60;
 const DIR_NAME_LEN = 12;
 
 /**
@@ -37,7 +39,7 @@ const DIR_NAME_LEN = 12;
  * are 36 chars and look unwieldy when listed in `~/.oma/bridge/sessions/`;
  * 12 hex chars (48 bits) are short enough to scan visually but still
  * have enough entropy to avoid practical collisions. Deterministic so
- * the same session_id always maps to the same dir (resume / GC work).
+ * the same session_id always maps to the same dir (resume / cleanup work).
  */
 function dirNameFor(sessionId: string): string {
   if (/^[a-f0-9]{1,12}$/i.test(sessionId)) return sessionId.toLowerCase();
@@ -48,7 +50,7 @@ function dirNameFor(sessionId: string): string {
  * Returns the cwd path for a session; creates it if it doesn't already exist.
  * Bundle materialization is the caller's job — call writeBundle() with the
  * `files: [{path, content}]` array fetched from main's
- * `/v1/internal/runtime-session-bundle` before issuing session/new.
+ * `/agents/runtime/sessions/:sid/bundle` before issuing session/new.
  */
 export async function ensureSessionCwd(sessionId: string): Promise<string> {
   const cwd = join(paths().sessionsDir, dirNameFor(sessionId));
@@ -76,33 +78,15 @@ export async function writeBundle(
 }
 
 /**
- * Best-effort: drop session directories not touched in `GC_AGE_SECONDS`.
- * Called by the daemon on startup so reboots reclaim disk without an
- * explicit timer. Errors are swallowed — a stuck dir is preferable to a
- * crashed daemon.
+ * Remove a session's spawn cwd. Called when the platform tells the daemon
+ * `session.dispose` — i.e. the user deleted the session in OMA. Best-effort:
+ * a stuck dir is preferable to a crashed daemon, so errors are swallowed.
  */
-export async function gcOldSessions(): Promise<{ removed: number }> {
-  const root = paths().sessionsDir;
-  let entries: string[];
+export async function removeSessionCwd(sessionId: string): Promise<void> {
+  const cwd = join(paths().sessionsDir, dirNameFor(sessionId));
   try {
-    entries = await readdir(root);
-  } catch (e: unknown) {
-    if ((e as NodeJS.ErrnoException).code === "ENOENT") return { removed: 0 };
-    return { removed: 0 };
+    await rm(cwd, { recursive: true, force: true });
+  } catch {
+    /* swallow — non-fatal */
   }
-  const cutoff = Math.floor(Date.now() / 1000) - GC_AGE_SECONDS;
-  let removed = 0;
-  for (const entry of entries) {
-    const full = join(root, entry);
-    try {
-      const st = await stat(full);
-      if (!st.isDirectory()) continue;
-      if (Math.floor(st.mtimeMs / 1000) > cutoff) continue;
-      await rm(full, { recursive: true, force: true });
-      removed += 1;
-    } catch {
-      /* skip */
-    }
-  }
-  return { removed };
 }

--- a/packages/cli/src/bridge/lib/session-manager.ts
+++ b/packages/cli/src/bridge/lib/session-manager.ts
@@ -36,7 +36,7 @@ import { AcpRuntimeImpl } from "@open-managed-agents/acp-runtime";
 import { NodeSpawner } from "@open-managed-agents/acp-runtime/node-spawner";
 import { KNOWN_ACP_AGENTS } from "@open-managed-agents/acp-runtime/registry";
 import type { AcpSession } from "@open-managed-agents/acp-runtime";
-import { ensureSessionCwd, writeBundle } from "./session-cwd.js";
+import { ensureSessionCwd, removeSessionCwd, writeBundle } from "./session-cwd.js";
 
 export interface SessionStartParams {
   session_id: string;
@@ -242,17 +242,29 @@ export class SessionManager {
   }
 
   async dispose(session_id: string): Promise<void> {
+    await this.#killChild(session_id);
+    // Drop the spawn cwd — session is dead at the platform; transcripts /
+    // AGENTS.md / .claude/skills/ are no longer load-bearing.
+    await removeSessionCwd(session_id);
+    this.#send({ type: "session.disposed", session_id });
+  }
+
+  /** Best-effort cleanup on daemon shutdown. KEEPS spawn cwds — sessions are
+   *  still live at the platform; the daemon coming back tomorrow needs the
+   *  same dirs to spawn fresh ACP children with the same transcripts. */
+  async disposeAll(): Promise<void> {
+    const ids = [...this.#sessions.keys()];
+    await Promise.all(ids.map((id) => this.#killChild(id)));
+  }
+
+  /** Kill the ACP child + drop in-memory state. Does NOT touch the spawn
+   *  cwd — caller decides whether the cwd should outlive this. */
+  async #killChild(session_id: string): Promise<void> {
     const sess = this.#sessions.get(session_id);
     if (!sess) return;
     for (const ctrl of sess.turns.values()) ctrl.abort();
     await sess.acp.dispose().catch(() => undefined);
     this.#sessions.delete(session_id);
-    this.#send({ type: "session.disposed", session_id });
-  }
-
-  async disposeAll(): Promise<void> {
-    const ids = [...this.#sessions.keys()];
-    await Promise.all(ids.map((id) => this.dispose(id)));
   }
 
   async #fetchBundle(sid: string, acpAgentId: string): Promise<SessionBundle | null> {

--- a/packages/cli/src/bridge/lib/session-manager.ts
+++ b/packages/cli/src/bridge/lib/session-manager.ts
@@ -1,0 +1,295 @@
+/**
+ * SessionManager — owns the ACP child processes the daemon is currently
+ * running on this machine. Slice-2 minimum: one ACP runtime per session
+ * (i.e. one child process per session).
+ *
+ * Wire protocol (over the daemon ↔ control-plane WS, see daemon.ts):
+ *
+ *   Server → Daemon
+ *     session.start    { session_id, agent_id, cwd?, resume? }
+ *     session.prompt   { session_id, turn_id, text }
+ *     session.cancel   { session_id, turn_id }
+ *     session.dispose  { session_id }
+ *
+ *   Daemon → Server
+ *     session.ready    { session_id, acp_session_id }
+ *     session.event    { session_id, turn_id, event }
+ *     session.complete { session_id, turn_id }
+ *     session.error    { session_id, turn_id?, message }
+ *     session.disposed { session_id }
+ *
+ * Idempotency: session.start is idempotent. If a session is already running
+ * for the given session_id, we reply with session.ready immediately and skip
+ * the spawn. This lets the harness on the cloud side fire session.start at
+ * the top of every turn without keeping its own "first turn" state.
+ *
+ * OMA-specific:
+ *   - On session.start we fetch the spawn-cwd bundle (AGENTS.md + skills)
+ *     from main's `/v1/internal/runtime-session-bundle?sid=&agent_id=` and
+ *     materialize files into the session cwd before issuing session/new.
+ *   - The OMA `oma_*` PAT is passed to the ACP child as `mcpServers[].
+ *     authorization_token` for each remote MCP server in the agent config.
+ *     URLs in the bundle are already rewritten to point at OMA's mcp-proxy.
+ */
+
+import { AcpRuntimeImpl } from "@open-managed-agents/acp-runtime";
+import { NodeSpawner } from "@open-managed-agents/acp-runtime/node-spawner";
+import { KNOWN_ACP_AGENTS } from "@open-managed-agents/acp-runtime/registry";
+import type { AcpSession } from "@open-managed-agents/acp-runtime";
+import { ensureSessionCwd, writeBundle } from "./session-cwd.js";
+
+export interface SessionStartParams {
+  session_id: string;
+  agent_id: string;
+  cwd?: string;
+  resume?: { acp_session_id: string };
+}
+
+export interface SessionPromptParams {
+  session_id: string;
+  turn_id: string;
+  text: string;
+}
+
+export type ManagerOut =
+  | { type: "session.ready"; session_id: string; acp_session_id: string }
+  | { type: "session.event"; session_id: string; turn_id: string; event: unknown }
+  | { type: "session.complete"; session_id: string; turn_id: string }
+  | { type: "session.error"; session_id: string; turn_id?: string; message: string }
+  | { type: "session.disposed"; session_id: string };
+
+export type Sender = (msg: ManagerOut) => void;
+
+interface ActiveSession {
+  acp: AcpSession;
+  acpSessionId: string;
+  turns: Map<string, AbortController>;
+}
+
+export interface SessionManagerEnv {
+  /** OMA `oma_*` PAT — server-side auth for /v1/* calls and as the bearer
+   *  the spawned ACP child sends to OMA's mcp-proxy. */
+  apiKey: string;
+  /** OMA server URL, e.g. https://app.openma.dev. Used to fetch session
+   *  bundle and as the base for mcp-proxy URLs we send into mcpServers. */
+  apiUrl: string;
+  /** Runtime token (`sk_machine_*`) — daemon's bearer for /agents/runtime/*
+   *  endpoints. The bundle fetch authenticates with this. */
+  runtimeToken: string;
+}
+
+interface BundleFile { path: string; content: string }
+interface SessionBundle { files: BundleFile[] }
+
+export class SessionManager {
+  #send: Sender;
+  #spawner = new NodeSpawner();
+  #runtime = new AcpRuntimeImpl(this.#spawner);
+  #sessions = new Map<string, ActiveSession>();
+  #env: SessionManagerEnv = { apiKey: "", apiUrl: "", runtimeToken: "" };
+
+  constructor(send: Sender) {
+    this.#send = send;
+  }
+
+  setSpawnEnv(env: SessionManagerEnv): void {
+    this.#env = env;
+  }
+
+  setSender(send: Sender): void {
+    this.#send = send;
+  }
+
+  has(session_id: string): boolean {
+    return this.#sessions.has(session_id);
+  }
+
+  /** Re-announce alive sessions to the server (used after WS reconnect). */
+  announceAll(): void {
+    for (const [session_id, sess] of this.#sessions) {
+      this.#send({ type: "session.ready", session_id, acp_session_id: sess.acpSessionId });
+    }
+  }
+
+  async start(p: SessionStartParams): Promise<void> {
+    // Idempotent: if we already have this session, just re-ack ready.
+    const existing = this.#sessions.get(p.session_id);
+    if (existing) {
+      this.#send({
+        type: "session.ready",
+        session_id: p.session_id,
+        acp_session_id: existing.acpSessionId,
+      });
+      return;
+    }
+
+    const agent = KNOWN_ACP_AGENTS.find((a) => a.id === p.agent_id);
+    if (!agent) {
+      this.#send({
+        type: "session.error",
+        session_id: p.session_id,
+        message: `unknown ACP agent: ${p.agent_id}`,
+      });
+      return;
+    }
+
+    const sessionCwd = await ensureSessionCwd(p.session_id);
+
+    // Fetch spawn-cwd bundle (AGENTS.md + .claude/skills/...) from main and
+    // materialize before starting the ACP child. Bundle errors are non-fatal
+    // — we still spawn; the agent just won't see OMA's prompt/skills.
+    try {
+      const bundle = await this.#fetchBundle(p.session_id, p.agent_id);
+      if (bundle) await writeBundle(sessionCwd, bundle.files);
+    } catch (e) {
+      process.stderr.write(`  ! bundle fetch failed (non-fatal): ${(e as Error).message}\n`);
+    }
+
+    process.stderr.write(
+      `  → SessionManager.start ${agent.spec.command} cwd=${sessionCwd}\n`,
+    );
+
+    try {
+      const session = await this.#runtime.start({
+        agent: {
+          ...agent.spec,
+          cwd: sessionCwd,
+          env: scrubAcpSpawnEnv({ ...(agent.spec.env ?? {}) }),
+        },
+        resumeAcpSessionId: p.resume?.acp_session_id,
+      });
+      this.#sessions.set(p.session_id, {
+        acp: session,
+        acpSessionId: session.acpSessionId,
+        turns: new Map(),
+      });
+      this.#send({
+        type: "session.ready",
+        session_id: p.session_id,
+        acp_session_id: session.acpSessionId,
+      });
+    } catch (e) {
+      this.#send({
+        type: "session.error",
+        session_id: p.session_id,
+        message: e instanceof Error ? e.message : String(e),
+      });
+    }
+  }
+
+  async prompt(p: SessionPromptParams): Promise<void> {
+    const sess = this.#sessions.get(p.session_id);
+    if (!sess) {
+      this.#send({
+        type: "session.error",
+        session_id: p.session_id,
+        turn_id: p.turn_id,
+        message: "no such session",
+      });
+      return;
+    }
+    const ctrl = new AbortController();
+    sess.turns.set(p.turn_id, ctrl);
+    let promptErr: string | null = null;
+    try {
+      for await (const ev of sess.acp.prompt(p.text, { abortSignal: ctrl.signal })) {
+        if (ctrl.signal.aborted) break;
+        const t = (ev as { type?: string; error?: string } | null | undefined)?.type;
+        // AcpSession yields sentinel events at the end of the stream:
+        //   { type: "promptComplete", response }  → ACP returned cleanly
+        //   { type: "promptError", error }        → ACP returned a JSON-RPC error
+        // The latter often carries the *only* signal that the turn failed
+        // (e.g. wrong model id, auth missing) — silently skipping it would
+        // make session.complete arrive as if everything worked.
+        if (t === "promptComplete") continue;
+        if (t === "promptError") {
+          promptErr = (ev as { error?: string }).error ?? "ACP prompt error (no message)";
+          continue;
+        }
+        this.#send({
+          type: "session.event",
+          session_id: p.session_id,
+          turn_id: p.turn_id,
+          event: ev,
+        });
+      }
+      if (promptErr) {
+        this.#send({
+          type: "session.error",
+          session_id: p.session_id,
+          turn_id: p.turn_id,
+          message: promptErr,
+        });
+      } else {
+        this.#send({ type: "session.complete", session_id: p.session_id, turn_id: p.turn_id });
+      }
+    } catch (e) {
+      this.#send({
+        type: "session.error",
+        session_id: p.session_id,
+        turn_id: p.turn_id,
+        message: e instanceof Error ? e.message : String(e),
+      });
+    } finally {
+      sess.turns.delete(p.turn_id);
+    }
+  }
+
+  cancel(session_id: string, turn_id: string): void {
+    const sess = this.#sessions.get(session_id);
+    if (!sess) return;
+    sess.turns.get(turn_id)?.abort();
+  }
+
+  async dispose(session_id: string): Promise<void> {
+    const sess = this.#sessions.get(session_id);
+    if (!sess) return;
+    for (const ctrl of sess.turns.values()) ctrl.abort();
+    await sess.acp.dispose().catch(() => undefined);
+    this.#sessions.delete(session_id);
+    this.#send({ type: "session.disposed", session_id });
+  }
+
+  async disposeAll(): Promise<void> {
+    const ids = [...this.#sessions.keys()];
+    await Promise.all(ids.map((id) => this.dispose(id)));
+  }
+
+  async #fetchBundle(sid: string, acpAgentId: string): Promise<SessionBundle | null> {
+    if (!this.#env.apiUrl || !this.#env.runtimeToken) return null;
+    const url = new URL(
+      `${this.#env.apiUrl.replace(/\/$/, "")}/agents/runtime/sessions/${encodeURIComponent(sid)}/bundle`,
+    );
+    url.searchParams.set("agent_id", acpAgentId);
+    const res = await fetch(url.toString(), {
+      headers: { Authorization: `Bearer ${this.#env.runtimeToken}` },
+    });
+    if (!res.ok) {
+      throw new Error(`bundle ${res.status}: ${(await res.text()).slice(0, 200)}`);
+    }
+    return (await res.json()) as SessionBundle;
+  }
+}
+
+/**
+ * Strip env vars that signal "you're already inside another Claude-flavored
+ * session". claude-code-acp aborts session/new with "cannot be launched
+ * inside another Claude Code session" when CLAUDECODE is inherited (e.g.
+ * user runs `oma bridge daemon` from a Claude Code terminal). The same
+ * precaution applies to other ACP agents that may detect parent shells.
+ *
+ * Sets the keys to `undefined` rather than deleting from the object so
+ * NodeSpawner's "undefined → unset inherited" semantics removes them from
+ * the child's process.env (the parent already has them set, and a normal
+ * delete would fall back to inheritance).
+ */
+function scrubAcpSpawnEnv(
+  base: Record<string, string | undefined>,
+): Record<string, string | undefined> {
+  return {
+    ...base,
+    CLAUDECODE: undefined,
+    CLAUDE_CODE_ENTRYPOINT: undefined,
+    CLAUDE_CODE_SSE_PORT: undefined,
+  };
+}

--- a/packages/cli/src/bridge/lib/session-manager.ts
+++ b/packages/cli/src/bridge/lib/session-manager.ts
@@ -37,6 +37,7 @@ import { NodeSpawner } from "@open-managed-agents/acp-runtime/node-spawner";
 import { KNOWN_ACP_AGENTS } from "@open-managed-agents/acp-runtime/registry";
 import type { AcpSession } from "@open-managed-agents/acp-runtime";
 import { ensureSessionCwd, removeSessionCwd, writeBundle } from "./session-cwd.js";
+import { setupClaudeConfigDir } from "./claude-config-dir.js";
 
 export interface SessionStartParams {
   session_id: string;
@@ -79,7 +80,14 @@ export interface SessionManagerEnv {
 }
 
 interface BundleFile { path: string; content: string }
-interface SessionBundle { files: BundleFile[] }
+interface SessionBundle {
+  files: BundleFile[];
+  /** Per-agent local-skill blocklist — daemon hides any skill with id in
+   *  this list from the spawn by NOT symlinking it into CLAUDE_CONFIG_DIR.
+   *  Bare directory ids (no plugin prefix); a global skill and a plugin
+   *  skill that share the same id are both hidden. */
+  local_skill_blocklist?: string[];
+}
 
 export class SessionManager {
   #send: Sender;
@@ -138,15 +146,38 @@ export class SessionManager {
     // Fetch spawn-cwd bundle (AGENTS.md + .claude/skills/...) from main and
     // materialize before starting the ACP child. Bundle errors are non-fatal
     // — we still spawn; the agent just won't see OMA's prompt/skills.
+    let blocklist: string[] = [];
     try {
       const bundle = await this.#fetchBundle(p.session_id, p.agent_id);
-      if (bundle) await writeBundle(sessionCwd, bundle.files);
+      if (bundle) {
+        await writeBundle(sessionCwd, bundle.files);
+        blocklist = bundle.local_skill_blocklist ?? [];
+      }
     } catch (e) {
       process.stderr.write(`  ! bundle fetch failed (non-fatal): ${(e as Error).message}\n`);
     }
 
+    // For Claude Code we redirect ~/.claude → <cwd>/.claude-config so the
+    // user's per-agent local-skill blocklist actually filters what the
+    // child sees. Other ACP agents don't share Claude Code's filesystem
+    // layout — leave their env untouched.
+    const extraEnv: Record<string, string | undefined> = {};
+    if (p.agent_id === "claude-code-acp") {
+      try {
+        const cfgDir = await setupClaudeConfigDir(sessionCwd, new Set(blocklist));
+        extraEnv.CLAUDE_CONFIG_DIR = cfgDir;
+      } catch (e) {
+        process.stderr.write(
+          `  ! CLAUDE_CONFIG_DIR setup failed (non-fatal, child sees real ~/.claude): ${(e as Error).message}\n`,
+        );
+      }
+    }
+
     process.stderr.write(
-      `  → SessionManager.start ${agent.spec.command} cwd=${sessionCwd}\n`,
+      `  → SessionManager.start ${agent.spec.command} cwd=${sessionCwd}` +
+        (extraEnv.CLAUDE_CONFIG_DIR ? ` cfg=${extraEnv.CLAUDE_CONFIG_DIR}` : "") +
+        (blocklist.length ? ` blocklist=${blocklist.length}` : "") +
+        "\n",
     );
 
     try {
@@ -154,7 +185,7 @@ export class SessionManager {
         agent: {
           ...agent.spec,
           cwd: sessionCwd,
-          env: scrubAcpSpawnEnv({ ...(agent.spec.env ?? {}) }),
+          env: scrubAcpSpawnEnv({ ...(agent.spec.env ?? {}), ...extraEnv }),
         },
         resumeAcpSessionId: p.resume?.acp_session_id,
       });

--- a/packages/cli/src/bridge/lib/style.ts
+++ b/packages/cli/src/bridge/lib/style.ts
@@ -1,0 +1,72 @@
+/**
+ * Tiny ANSI styling + logo banner.
+ *
+ * No deps (chalk would pull in ~100KB for what amounts to 12 escape codes).
+ * Auto-disables color when stderr isn't a TTY (so the launchd log file
+ * doesn't get filled with garbage like `[1m` everywhere).
+ */
+
+const isTty = !!process.stderr.isTTY && !process.env.NO_COLOR;
+
+function wrap(open: string, close: string) {
+  return (s: string) => (isTty ? `\x1b[${open}m${s}\x1b[${close}m` : s);
+}
+
+export const c = {
+  bold:    wrap("1",  "22"),
+  dim:     wrap("2",  "22"),
+  red:     wrap("31", "39"),
+  green:   wrap("32", "39"),
+  yellow:  wrap("33", "39"),
+  blue:    wrap("34", "39"),
+  magenta: wrap("35", "39"),
+  cyan:    wrap("36", "39"),
+  gray:    wrap("90", "39"),
+};
+
+/**
+ * "C/" lockup. A chunky 5-line block that reads as a stylized C with a
+ * forward slash baked into its right edge — same vibe as the web logo.
+ *
+ * Exported so other commands can reuse the exact same banner — single
+ * source of truth for "what does oma bridge look like at startup".
+ */
+export function logo(): string {
+  // Built with light-shade + full-block characters so it renders the
+  // same width across most terminal fonts. The "/" is the right cap.
+  const lines = [
+    "  ▄▄████▄  ▗▌",
+    "  █       ▟▘",
+    "  █      ▟▘",
+    "  █     ▟▘",
+    "  █▄▄▄▟▘",
+  ];
+  return lines.map((l) => c.cyan(c.bold(l))).join("\n");
+}
+
+/** "oma bridge — <subtitle>" header line, used right after the logo. */
+export function header(subtitle: string, version: string): string {
+  return `${c.bold("oma bridge")}  ${c.dim(`v${version}`)}\n${c.gray(subtitle)}`;
+}
+
+/** Print the standard banner (logo + header) once at command start. */
+export function printBanner(subtitle: string, version: string): void {
+  process.stderr.write(`\n${logo()}\n\n${header(subtitle, version)}\n\n`);
+}
+
+export const sym = {
+  ok:    () => c.green("✓"),
+  warn:  () => c.yellow("!"),
+  err:   () => c.red("✗"),
+  arrow: () => c.cyan("→"),
+  dot:   () => c.gray("·"),
+};
+
+/** Stderr writers with the matching prefix symbol. */
+export const log = {
+  step:  (s: string) => process.stderr.write(`${sym.arrow()} ${s}\n`),
+  ok:    (s: string) => process.stderr.write(`${sym.ok()} ${s}\n`),
+  warn:  (s: string) => process.stderr.write(`${sym.warn()} ${c.yellow(s)}\n`),
+  err:   (s: string) => process.stderr.write(`${sym.err()} ${c.red(s)}\n`),
+  hint:  (s: string) => process.stderr.write(`  ${c.gray(s)}\n`),
+};

--- a/packages/cli/src/bridge/lib/version.ts
+++ b/packages/cli/src/bridge/lib/version.ts
@@ -1,0 +1,17 @@
+/**
+ * Single source of truth for the daemon's version string.
+ *
+ * tsup chunks may live one or two levels deep relative to package.json
+ * after bundling, so we try both paths. Final fallback is "0.0.0-dev"
+ * — only ever shown if running from source via tsx without tsup.
+ */
+import { createRequire } from "node:module";
+
+const req = createRequire(import.meta.url);
+
+export const PKG_VERSION: string = (() => {
+  for (const path of ["../package.json", "../../package.json"]) {
+    try { return (req(path) as { version: string }).version; } catch { /* try next */ }
+  }
+  return "0.0.0-dev";
+})();

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -358,8 +358,13 @@ async function tailSession(config: Config, sessionId: string): Promise<void> {
 // ─── Helpers ───
 
 function flag(args: string[], name: string): string | undefined {
-  const idx = args.indexOf(name);
-  return idx !== -1 ? args[idx + 1] : undefined;
+  // Accepts both `--name value` and `--name=value` forms.
+  const eqPrefix = `${name}=`;
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === name) return args[i + 1];
+    if (args[i].startsWith(eqPrefix)) return args[i].slice(eqPrefix.length);
+  }
+  return undefined;
 }
 
 function table(rows: string[][]) {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -720,14 +720,27 @@ const commands: Cmd[] = [
   {
     group: "Agents", match: ["agents", "create"],
     usage: "oma agents create <name> [--model <id>]", desc: "Create agent",
-    http: "POST   /v1/agents {name, model, system, tools, skills?, mcp_servers?, callable_agents?}",
+    http: "POST   /v1/agents {name, model, system, tools, skills?, mcp_servers?, callable_agents?, runtime_binding?}",
     async run(config, args) {
       const name = flag(args, "--name") || args.find(a => !a.startsWith("--"));
       const model = flag(args, "--model") || "claude-sonnet-4-6";
       const system = flag(args, "--system") || "";
-      if (!name) { console.error("Usage: oma agents create <name> [--model <id>] [--system <prompt>]"); process.exit(1); }
-      const agent = await apiFetch<{ id: string; name: string }>(config, "/v1/agents", { method: "POST", body: JSON.stringify({ name, model, system, tools: [{ type: "agent_toolset_20260401" }] }) });
-      console.log(`Agent created: ${agent.name} (${agent.id})`);
+      if (!name) { console.error("Usage: oma agents create <name> [--model <id>] [--system <prompt>] [--runtime <id> --acp-agent <agent-id>]"); process.exit(1); }
+      // Local-runtime agent: routes turns to a user-registered `oma bridge daemon`
+      // running an ACP-compatible child (Claude Code etc.). Both flags must be
+      // present to opt in — partial config silently drops the binding.
+      const runtimeId = flag(args, "--runtime");
+      const acpAgentId = flag(args, "--acp-agent");
+      const useAcpProxy = !!(runtimeId && acpAgentId);
+      const body: Record<string, unknown> = {
+        name, model, system, tools: [{ type: "agent_toolset_20260401" }],
+      };
+      if (useAcpProxy) {
+        body.harness = "acp-proxy";
+        body.runtime_binding = { runtime_id: runtimeId, acp_agent_id: acpAgentId };
+      }
+      const agent = await apiFetch<{ id: string; name: string }>(config, "/v1/agents", { method: "POST", body: JSON.stringify(body) });
+      console.log(`Agent created: ${agent.name} (${agent.id})${useAcpProxy ? `  [acp-proxy → ${acpAgentId} on ${runtimeId.slice(0, 8)}…]` : ""}`);
     },
   },
   {
@@ -746,6 +759,47 @@ const commands: Cmd[] = [
     usage: "oma agents delete <id>", desc: "Delete agent",
     http: "DELETE /v1/agents/:id",
     async run(config, args) { await apiFetch(config, `/v1/agents/${args[0]}`, { method: "DELETE" }); console.log(`Agent deleted: ${args[0]}`); },
+  },
+
+  // Runtimes — user-registered local machines running `oma bridge daemon`.
+  // Used as the spawn host for ACP-proxy agents (claude-code etc.).
+  {
+    group: "Runtimes", match: ["runtime", "list"],
+    usage: "oma runtime list", desc: "List registered local runtimes",
+    http: "GET    /v1/runtimes",
+    async run(config) {
+      const { runtimes } = await apiFetch<{ runtimes: Array<{
+        id: string; hostname: string; os: string; status: string;
+        version: string; agents: Array<{ id: string }>; last_heartbeat: number | null;
+      }> }>(config, "/v1/runtimes");
+      if (config.json) { console.log(JSON.stringify(runtimes, null, 2)); return; }
+      if (!runtimes.length) {
+        console.log("No runtimes. Register one with `oma bridge setup` on the target machine.");
+        return;
+      }
+      table([
+        ["ID", "HOSTNAME", "OS", "STATUS", "VER", "AGENTS", "HEARTBEAT"],
+        ...runtimes.map((r) => [
+          r.id.slice(0, 8) + "…",
+          r.hostname,
+          r.os,
+          r.status,
+          r.version,
+          r.agents.map((a) => a.id).join(",") || "—",
+          r.last_heartbeat ? new Date(r.last_heartbeat * 1000).toISOString().slice(11, 19) : "—",
+        ]),
+      ]);
+    },
+  },
+  {
+    group: "Runtimes", match: ["runtime", "rm"], needsArg: true,
+    usage: "oma runtime rm <id>", desc: "Revoke a runtime + all its tokens",
+    http: "DELETE /v1/runtimes/:id",
+    async run(config, args) {
+      await apiFetch(config, `/v1/runtimes/${args[0]}`, { method: "DELETE" });
+      console.log(`Runtime revoked: ${args[0]}`);
+      console.log("The daemon will stop reconnecting after a few backoff cycles.");
+    },
   },
 
   // Sessions
@@ -1908,6 +1962,50 @@ async function main() {
   let args = process.argv.slice(2);
   if (!args.length || ["-h", "--help", "help"].includes(args[0])) { usage(); process.exit(0); }
   if (args[0] === "api") { apiRef(args[1]); return; }
+
+  // Bridge subcommands (oma bridge {setup,daemon,status,uninstall}) are
+  // self-contained — they don't need the api-key config and have their own
+  // argv parsing. Dispatch early to keep the main commands array unaware.
+  if (args[0] === "bridge") {
+    const sub = args[1] ?? "";
+    process.argv.splice(2, 2); // strip "bridge" + subname so commands' parseArgs sees flags only
+    switch (sub) {
+      case "setup": {
+        const { runSetup } = await import("./bridge/commands/setup.js");
+        await runSetup({
+          serverUrl: flag(args, "--server-url") ?? "https://app.openma.dev",
+          browserOrigin: flag(args, "--browser-origin") ?? "https://app.openma.dev",
+          noService: args.includes("--no-service"),
+          force: args.includes("--force"),
+        });
+        return;
+      }
+      case "daemon": {
+        const { runDaemon } = await import("./bridge/commands/daemon.js");
+        await runDaemon();
+        return;
+      }
+      case "status": {
+        const { runStatus } = await import("./bridge/commands/status.js");
+        await runStatus();
+        return;
+      }
+      case "uninstall": {
+        const { runUninstall } = await import("./bridge/commands/uninstall.js");
+        await runUninstall();
+        return;
+      }
+      default:
+        console.error(
+          "oma bridge — pair a local ACP agent with OMA\n\n" +
+          "  oma bridge setup [--server-url=…] [--no-service] [--force]\n" +
+          "  oma bridge daemon\n" +
+          "  oma bridge status\n" +
+          "  oma bridge uninstall\n",
+        );
+        process.exit(sub ? 1 : 0);
+    }
+  }
 
   // Strip --json from args so subcommand matchers don't see it.
   const wantJson = args.includes("--json");

--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -88,4 +88,14 @@ export interface Env {
   // Workers, point this at a Hyperdrive connection string for production;
   // direct DSN works in local dev / Node deployments.
   DATABASE_URL?: string;
+  /** Local-ACP-runtime control plane DO. Pairs the user's `oma bridge daemon`
+   *  WebSocket with the ACP-proxy harness inside SessionDO so a session can
+   *  delegate its agent loop to a Claude Code (or other ACP) child running
+   *  on the user's machine. Bound only on apps/main. */
+  RUNTIME_ROOM?: DurableObjectNamespace;
+  /** Service binding from per-env sandbox workers back to the main worker.
+   *  AcpProxyHarness uses this to call /v1/internal/runtime-turn — going
+   *  through HTTP keeps the auth surface narrow (one internal-secret-gated
+   *  endpoint) and avoids a cross-script DO binding. Bound on apps/agent. */
+  MAIN?: Fetcher;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -330,16 +330,35 @@ importers:
   packages/cf-billing: {}
 
   packages/cli:
+    dependencies:
+      '@agentclientprotocol/sdk':
+        specifier: ^0.20.0
+        version: 0.20.0(zod@4.3.6)
+      '@open-managed-agents/acp-runtime':
+        specifier: workspace:*
+        version: link:../acp-runtime
+      ws:
+        specifier: ^8.18.0
+        version: 8.18.0
     devDependencies:
       '@open-managed-agents/api-types':
         specifier: workspace:*
         version: link:../api-types
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.17
+      '@types/ws':
+        specifier: ^8.5.0
+        version: 8.18.1
       esbuild:
         specifier: ^0.25.0
         version: 0.25.12
       tsx:
         specifier: ^4.19.0
         version: 4.21.0
+      typescript:
+        specifier: ^5.8.0
+        version: 5.9.3
 
   packages/credentials-store:
     dependencies:
@@ -2010,6 +2029,9 @@ packages:
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
@@ -4417,6 +4439,10 @@ snapshots:
     dependencies:
       zod: 3.25.76
 
+  '@agentclientprotocol/sdk@0.20.0(zod@4.3.6)':
+    dependencies:
+      zod: 4.3.6
+
   '@ai-sdk/anthropic@3.0.69(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
@@ -5683,6 +5709,10 @@ snapshots:
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 25.6.0
 
   '@ungap/structured-clone@1.3.0': {}
 

--- a/scripts/lane-generate.mjs
+++ b/scripts/lane-generate.mjs
@@ -195,6 +195,9 @@ delete agent.routes;
 delete agent.triggers;
 agent.services = [
   { binding: "INTEGRATIONS", service: NAMES.integrations },
+  // MAIN binding so AcpProxyHarness can call /v1/internal/runtime-attach-harness
+  // on the lane's main worker (not prod's). Required for local-runtime sessions.
+  { binding: "MAIN", service: NAMES.main },
 ];
 writeJson(`apps/agent/wrangler.lane-${LANE}.jsonc`, agent);
 


### PR DESCRIPTION
## Summary

- **ACP local runtime**: register a user laptop running `oma bridge daemon` as an OMA "runtime", spawn ACP-compatible agents (Claude Code today; codex/opencode wired but not functional yet) per-session, relay events through the new `AcpProxyHarness` and `RuntimeRoom` DO. AgentConfig opts in via `harness: "acp-proxy"` + `runtime_binding`. SessionDO / events / SSE / recovery / Console all reuse the existing meta-harness path — no changes to consumers of OMA agents.
- **Per-agent local-skill blocklist** (C-series, three commits): daemon detects `~/.claude/skills/<id>/` globals, reports manifest in WS hello frame; per-agent setting hides selected skills from a session by building a filtered `<cwd>/.claude-config/` tree of symlinks and spawning the child with `CLAUDE_CONFIG_DIR` pointing at it.
- **IDOR fix on the daemon-facing bundle endpoint**: was only checking that the bearer was a valid runtime token; now also enforces `session.tenant_id === auth.tenant_id` (returns 404 on mismatch so it isn't an existence oracle).

## Verified end-to-end on lane `mvp-smoke`

- Daemon attached, hello manifest reported 50 local skills, `GET /v1/runtimes` returns them
- `PUT /v1/agents/<id>` round-trips `runtime_binding.local_skill_blocklist`
- Console "+ New agent" form: pick runtime → multi-select panel renders; uncheck `agent-browser`+`audit` → submit → `GET /v1/agents/<new>` returns the blocklist
- Live ACP child has `CLAUDE_CONFIG_DIR=…/.claude-config` set; on disk: 48/50 skills symlinked, blocked ids absent, `settings.json`/`plugins/` symlinked atomically; full prompt round-trip works ("OK" came back through claude-code-acp)
- Bundle endpoint: legit sid → 200, missing sid → 404, no auth → 401

## Known gaps before GA

- **CLI not yet npm-published** (`@openma/cli@0.3.0-beta.0`); `npx @openma/cli bridge setup` currently fetches the older registry version
- **codex / opencode listed in `KNOWN_ACP_AGENTS` but don't actually work** (codex doesn't speak ACP natively as of v0.123) — Console picker shouldn't offer them; remove or disable before publish
- **No edit-blocklist UI** on agent detail page — can only set on create or via API
- **Plugin-bundled skills not filterable** in v1 (passes through via wholesale `plugins/` symlink); deferred until a real user hits it
- **macOS-only daemon install** — Linux users can run the daemon but no systemd unit / uninstall

## Production deploy notes

- `apps/main/migrations/0011_runtime_local_skills.sql` (additive ADD COLUMN with DEFAULT) must apply before main worker rolls — lane CI does `wrangler d1 migrations apply` first; verify prod pipeline does the same
- Agent worker needs `services: [{ binding: "MAIN", service: "managed-agents" }]` in production wrangler config (lane fix in commit 45fc228)
- New DO class `RuntimeRoom` requires migration `v5: { new_sqlite_classes: ["RuntimeRoom"] }` in main wrangler

## Test plan

- [ ] Apply migration 0011 to prod D1
- [ ] Verify prod main wrangler has RUNTIME_ROOM DO + new migration tag
- [ ] Verify prod agent wrangler has MAIN service binding
- [ ] Smoke: connect a personal laptop to prod via `oma bridge setup`, observe runtime online in Console
- [ ] Smoke: bind an agent to it with empty blocklist, send a turn, observe response
- [ ] Smoke: set blocklist on the same agent, recreate session, confirm blocked skill absent in `<cwd>/.claude-config/skills`

🤖 Generated with [Claude Code](https://claude.com/claude-code)