### PR TITLE
feat(slack): per_channel granularity + treat-bot-like-human signals

### DIFF
--- a/apps/main/migrations/0012_slack_per_channel.sql
+++ b/apps/main/migrations/0012_slack_per_channel.sql
@@ -1,0 +1,24 @@
+-- Slack per_channel session granularity support.
+--
+-- Adds three nullable columns to slack_thread_sessions:
+--   pending_scan_until — debounce watermark for channel-scope scan turns. When
+--                        set to a future ms timestamp, an "armed" channel-scan
+--                        has already been dispatched and incoming top-level
+--                        messages within the window are silently throttled.
+--                        Cleared by the agent (via provider helper) once the
+--                        scheduled wakeup runs the actual conversations.history
+--                        sweep. Self-healing: once the timestamp lapses, the
+--                        next top-level message re-arms it.
+--   last_scan_at       — ms timestamp of the most recent completed scan turn.
+--                        Agent reads this on wake to bound `oldest=` in
+--                        conversations.history calls.
+--   channel_name       — cached channel display name. Updated on
+--                        channel_rename without waking the agent; the agent
+--                        reads it from session metadata on next wake.
+--
+-- All three are nullable. Existing per_thread rows leave them NULL — the
+-- per_thread dispatch path doesn't touch them, so no backfill is needed.
+
+ALTER TABLE "slack_thread_sessions" ADD COLUMN "pending_scan_until" INTEGER;
+ALTER TABLE "slack_thread_sessions" ADD COLUMN "last_scan_at"       INTEGER;
+ALTER TABLE "slack_thread_sessions" ADD COLUMN "channel_name"       TEXT;

--- a/packages/integrations-adapters-cf/src/d1/slack/session-scope-repo.ts
+++ b/packages/integrations-adapters-cf/src/d1/slack/session-scope-repo.ts
@@ -1,8 +1,8 @@
 import type {
   SessionScope,
-  SessionScopeRepo,
   SessionScopeStatus,
 } from "@open-managed-agents/integrations-core";
+import type { SlackSessionScopeRepo } from "@open-managed-agents/slack";
 
 interface Row {
   tenant_id: string;
@@ -11,14 +11,21 @@ interface Row {
   session_id: string;
   status: string;
   created_at: number;
+  pending_scan_until: number | null;
+  last_scan_at: number | null;
+  channel_name: string | null;
 }
 
 /**
  * D1 session-scope repo for Slack. Table `slack_thread_sessions`. The
- * scope_key column stores `${channel_id}:${thread_ts ?? event_ts}` — the
- * provider composes it before calling getByScope/insert.
+ * scope_key column stores `${channel_id}:${thread_ts ?? event_ts}` for
+ * `per_thread` granularity, or `channel:${channel_id}` for `per_channel`.
+ *
+ * The three nullable columns `pending_scan_until` / `last_scan_at` /
+ * `channel_name` are only meaningful for per_channel rows; per_thread rows
+ * leave them NULL.
  */
-export class D1SlackSessionScopeRepo implements SessionScopeRepo {
+export class D1SlackSessionScopeRepo implements SlackSessionScopeRepo {
   constructor(private readonly db: D1Database) {}
 
   async getByScope(publicationId: string, scopeKey: string): Promise<SessionScope | null> {
@@ -39,10 +46,21 @@ export class D1SlackSessionScopeRepo implements SessionScopeRepo {
     const result = await this.db
       .prepare(
         `INSERT OR IGNORE INTO slack_thread_sessions
-           (tenant_id, publication_id, scope_key, session_id, status, created_at)
-         VALUES (?, ?, ?, ?, ?, ?)`,
+           (tenant_id, publication_id, scope_key, session_id, status, created_at,
+            pending_scan_until, last_scan_at, channel_name)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       )
-      .bind(row.tenantId, row.publicationId, row.scopeKey, row.sessionId, row.status, row.createdAt)
+      .bind(
+        row.tenantId,
+        row.publicationId,
+        row.scopeKey,
+        row.sessionId,
+        row.status,
+        row.createdAt,
+        row.pendingScanUntil ?? null,
+        row.lastScanAt ?? null,
+        row.channelName ?? null,
+      )
       .run();
     return (result.meta?.changes ?? 0) > 0;
   }
@@ -72,6 +90,66 @@ export class D1SlackSessionScopeRepo implements SessionScopeRepo {
     return (results ?? []).map((r) => this.toDomain(r));
   }
 
+  async armPendingScan(
+    publicationId: string,
+    scopeKey: string,
+    until: number,
+    now: number,
+  ): Promise<{ armed: boolean; currentUntil: number | null }> {
+    // Conditional UPDATE: only set pending_scan_until if the row is not
+    // currently armed (or its armed window has lapsed). Returning .meta.changes
+    // tells us whether we actually claimed the slot. Two concurrent dispatchers
+    // are serialized by D1's row lock; at most one observes `changes > 0`.
+    const result = await this.db
+      .prepare(
+        `UPDATE slack_thread_sessions
+         SET pending_scan_until = ?
+         WHERE publication_id = ? AND scope_key = ?
+           AND (pending_scan_until IS NULL OR pending_scan_until <= ?)`,
+      )
+      .bind(until, publicationId, scopeKey, now)
+      .run();
+
+    if ((result.meta?.changes ?? 0) > 0) {
+      return { armed: true, currentUntil: null };
+    }
+
+    // Either the row didn't exist, or someone else has it armed. Read back to
+    // distinguish — and so the caller knows when the existing window expires.
+    const row = await this.db
+      .prepare(
+        `SELECT pending_scan_until FROM slack_thread_sessions
+         WHERE publication_id = ? AND scope_key = ?`,
+      )
+      .bind(publicationId, scopeKey)
+      .first<{ pending_scan_until: number | null }>();
+    return { armed: false, currentUntil: row?.pending_scan_until ?? null };
+  }
+
+  async clearPendingScan(publicationId: string, scopeKey: string): Promise<void> {
+    await this.db
+      .prepare(
+        `UPDATE slack_thread_sessions SET pending_scan_until = NULL
+         WHERE publication_id = ? AND scope_key = ?`,
+      )
+      .bind(publicationId, scopeKey)
+      .run();
+  }
+
+  async updateChannelName(
+    publicationId: string,
+    scopeKey: string,
+    channelName: string,
+  ): Promise<void> {
+    await this.db
+      .prepare(
+        `UPDATE slack_thread_sessions SET channel_name = ?
+         WHERE publication_id = ? AND scope_key = ?`,
+      )
+      .bind(channelName, publicationId, scopeKey)
+      .run();
+  }
+
   private toDomain(row: Row): SessionScope {
     return {
       tenantId: row.tenant_id,
@@ -80,6 +158,9 @@ export class D1SlackSessionScopeRepo implements SessionScopeRepo {
       sessionId: row.session_id,
       status: row.status as SessionScopeStatus,
       createdAt: row.created_at,
+      pendingScanUntil: row.pending_scan_until,
+      lastScanAt: row.last_scan_at,
+      channelName: row.channel_name,
     };
   }
 }

--- a/packages/integrations-adapters-cf/src/d1/slack/session-scope-repo.ts
+++ b/packages/integrations-adapters-cf/src/d1/slack/session-scope-repo.ts
@@ -150,6 +150,17 @@ export class D1SlackSessionScopeRepo implements SlackSessionScopeRepo {
       .run();
   }
 
+  async closeAllForPublication(publicationId: string): Promise<void> {
+    await this.db
+      .prepare(
+        `UPDATE slack_thread_sessions
+         SET status = 'completed', pending_scan_until = NULL
+         WHERE publication_id = ? AND status = 'active'`,
+      )
+      .bind(publicationId)
+      .run();
+  }
+
   private toDomain(row: Row): SessionScope {
     return {
       tenantId: row.tenant_id,

--- a/packages/integrations-core/src/domain.ts
+++ b/packages/integrations-core/src/domain.ts
@@ -217,7 +217,7 @@ export type SessionScopeStatus =
    *  but we keep the row so audits can spot repeated failures. */
   | "failed";
 
-export type SessionGranularity = "per_issue" | "per_thread" | "per_event";
+export type SessionGranularity = "per_issue" | "per_thread" | "per_event" | "per_channel";
 
 export interface Installation {
   id: string;
@@ -341,12 +341,31 @@ export interface SessionScope {
   /**
    * Provider-native key identifying the conversational scope this session is
    * bound to. Linear stores the issue id (e.g. `iss_…`); Slack stores
-   * `${channel_id}:${thread_ts ?? event_ts}`. Opaque to core.
+   * `${channel_id}:${thread_ts ?? event_ts}` (per_thread) or `channel:${channel_id}`
+   * (per_channel). Opaque to core.
    */
   scopeKey: string;
   sessionId: SessionId;
   status: SessionScopeStatus;
   createdAt: number;
+  /**
+   * For Slack per_channel: when set to a future ms timestamp, a debounced
+   * channel-scan turn has already been dispatched and the next top-level
+   * messages within this window should be silently throttled. The agent's
+   * scheduleWakeup will fire around this time and re-scan via
+   * conversations.history. Cleared once the scan turn completes.
+   */
+  pendingScanUntil?: number | null;
+  /**
+   * For Slack per_channel: timestamp of the last completed scan turn — agent
+   * uses this as `oldest` in `conversations.history` to bound its re-read.
+   */
+  lastScanAt?: number | null;
+  /**
+   * For Slack per_channel: cached channel display name. Updated on
+   * channel_rename without waking the agent; agent reads it on next wake.
+   */
+  channelName?: string | null;
 }
 
 export interface SetupLink {

--- a/packages/slack/src/config.ts
+++ b/packages/slack/src/config.ts
@@ -1,6 +1,8 @@
 // SlackProvider configuration. Cleanly separated from runtime ports so the
 // provider remains pure and testable.
 
+import type { SessionGranularity } from "@open-managed-agents/integrations-core";
+
 /**
  * Slack-specific capability keys gating Web API operations. Stored as opaque
  * strings at the core boundary (CapabilityKey = string) so providers don't
@@ -44,11 +46,21 @@ export interface SlackConfig {
    * (which may only further restrict) are stored on the Publication row.
    */
   defaultCapabilities: ReadonlyArray<SlackCapabilityKey>;
+
+  /**
+   * Default session granularity for new publications. `per_channel` makes the
+   * bot a "channel-scoped colleague" — one long-lived session per channel,
+   * top-level messages debounce-arm a scan turn, lifecycle events route to
+   * the same session. `per_thread` (the legacy default) opens a fresh session
+   * per thread. Defaults to `per_channel` if absent.
+   */
+  defaultSessionGranularity?: SessionGranularity;
 }
 
 /**
  * Bot scopes for an OMA agent published into Slack. Covers the common path:
- * receive @-mentions and DMs, post messages, react, fetch user/team metadata.
+ * receive @-mentions and DMs, post messages, react, fetch user/team metadata,
+ * observe channel-membership lifecycle for `per_channel` granularity.
  *
  * - app_mentions:read     — receive `app_mention` events
  * - chat:write            — chat.postMessage as the bot
@@ -57,6 +69,8 @@ export interface SlackConfig {
  * - groups:history        — read private channel messages
  * - im:history            — read direct messages
  * - mpim:history          — read multi-person DMs
+ * - channels:read         — receive `member_joined_channel` / `channel_*` for public channels
+ * - groups:read           — same for private channels
  * - reactions:read/write  — observe + add reactions
  * - users:read            — fetch user profiles (display name, avatar)
  * - users:read.email      — email lookup (handoff/notification flows)
@@ -70,6 +84,8 @@ export const DEFAULT_SLACK_BOT_SCOPES: ReadonlyArray<string> = [
   "groups:history",
   "im:history",
   "mpim:history",
+  "channels:read",
+  "groups:read",
   "reactions:read",
   "reactions:write",
   "users:read",
@@ -101,8 +117,9 @@ export const DEFAULT_SLACK_USER_SCOPES: ReadonlyArray<string> = [
 /**
  * Bot events the App subscribes to via Event Subscriptions. Set in the
  * manifest's settings.event_subscriptions.bot_events. Covers @-mentions,
- * messages in all conversation kinds, the AI assistant pane handshake, and
- * revocation signals.
+ * messages in all conversation kinds, the AI assistant pane handshake,
+ * channel-membership lifecycle, archive/rename, reactions on bot messages,
+ * and revocation signals.
  */
 export const DEFAULT_SLACK_SUBSCRIBED_EVENTS: ReadonlyArray<string> = [
   "app_mention",
@@ -113,6 +130,15 @@ export const DEFAULT_SLACK_SUBSCRIBED_EVENTS: ReadonlyArray<string> = [
   "assistant_thread_started",
   "tokens_revoked",
   "app_uninstalled",
+  // Channel-membership lifecycle for per_channel granularity.
+  "member_joined_channel",
+  "member_left_channel",
+  "channel_archive",
+  "channel_unarchive",
+  "channel_rename",
+  // Reactions — provider drops anything not on a bot-authored message.
+  "reaction_added",
+  "reaction_removed",
 ] as const;
 
 export const ALL_SLACK_CAPABILITIES: ReadonlyArray<SlackCapabilityKey> = [

--- a/packages/slack/src/index.ts
+++ b/packages/slack/src/index.ts
@@ -47,4 +47,4 @@ export {
   type RawEventInner,
 } from "./webhook/parse";
 export { SlackApiClient, SlackApiError, type AuthTestResult } from "./api/client";
-export type { SlackInstallationRepo } from "./ports";
+export type { SlackInstallationRepo, SlackSessionScopeRepo } from "./ports";

--- a/packages/slack/src/ports.ts
+++ b/packages/slack/src/ports.ts
@@ -6,7 +6,10 @@
 // repo doesn't implement it; the SlackContainer wires its own
 // SlackInstallationRepo implementation.
 
-import type { InstallationRepo } from "@open-managed-agents/integrations-core";
+import type {
+  InstallationRepo,
+  SessionScopeRepo,
+} from "@open-managed-agents/integrations-core";
 
 export interface SlackInstallationRepo extends InstallationRepo {
   /**
@@ -25,4 +28,45 @@ export interface SlackInstallationRepo extends InstallationRepo {
 
   /** Returns the bot xoxb- vault id for outbound injection on slack.com/api. */
   getBotVaultId(id: string): Promise<string | null>;
+}
+
+/**
+ * Slack-specific session scope methods on top of the generic SessionScopeRepo.
+ * These exist for `per_channel` granularity — debounced channel-scope scan
+ * dispatch + cached channel display name. Linear/GitHub providers don't need
+ * these and Linear's IssueSessionRepo is a separate type entirely.
+ */
+export interface SlackSessionScopeRepo extends SessionScopeRepo {
+  /**
+   * Atomically check-and-set the debounce watermark on a channel scope row.
+   *
+   * - If the row's `pending_scan_until` is NULL or `<= now`: UPDATE to `until`
+   *   and return `{ armed: true, currentUntil: null }`. The caller should
+   *   dispatch a `[signal:channel_scan_armed]` event to the agent.
+   * - Otherwise: return `{ armed: false, currentUntil: existingValue }`. The
+   *   caller should drop this event silently (a scan is already armed).
+   *
+   * Concurrent callers are serialized by D1's row-level locking — one wins,
+   * the other reads the winner's value and gets `armed: false`.
+   *
+   * No-op (returns `{ armed: false, currentUntil: null }`) when the
+   * (publication_id, scope_key) row doesn't yet exist; callers should ensure
+   * the channel session row exists before arming.
+   */
+  armPendingScan(
+    publicationId: string,
+    scopeKey: string,
+    until: number,
+    now: number,
+  ): Promise<{ armed: boolean; currentUntil: number | null }>;
+
+  /** Clear the debounce watermark — no-op if not currently armed. */
+  clearPendingScan(publicationId: string, scopeKey: string): Promise<void>;
+
+  /** Update the cached channel display name on a channel-scope row. */
+  updateChannelName(
+    publicationId: string,
+    scopeKey: string,
+    channelName: string,
+  ): Promise<void>;
 }

--- a/packages/slack/src/ports.ts
+++ b/packages/slack/src/ports.ts
@@ -69,4 +69,13 @@ export interface SlackSessionScopeRepo extends SessionScopeRepo {
     scopeKey: string,
     channelName: string,
   ): Promise<void>;
+
+  /**
+   * Mark every active scope row for a publication as completed and clear any
+   * pending scan watermark. Called from the `tokens_revoked` / `app_uninstalled`
+   * lifecycle path when the whole installation is gone — without this, stale
+   * `active` rows linger and any agent scheduleWakeups would burn turns
+   * 401-ing against a revoked token.
+   */
+  closeAllForPublication(publicationId: string): Promise<void>;
 }

--- a/packages/slack/src/provider.ts
+++ b/packages/slack/src/provider.ts
@@ -545,9 +545,14 @@ export class SlackProvider implements IntegrationProvider {
       return { handled: false, reason: "unparseable" };
     }
 
-    // Revocation events — flip the installation, no dispatch.
+    // Revocation events — flip the installation, close all channel-scope
+    // sessions for the publication so dangling scheduleWakeups don't burn
+    // turns 401-ing against a now-revoked token. No agent dispatch needed
+    // (the wakeups themselves will cascade through and discover their
+    // sessions are completed).
     if (event.kind === "tokens_revoked" || event.kind === "app_uninstalled") {
       await this.container.installations.markRevoked(installation.id, this.container.clock.nowMs());
+      await this.container.sessionScopes.closeAllForPublication(pub.id);
       await this.container.webhookEvents.attachPublication(env.event_id, pub.id);
       return { handled: true, reason: event.kind, publicationId: pub.id, tenantId: installation.tenantId };
     }

--- a/packages/slack/src/provider.ts
+++ b/packages/slack/src/provider.ts
@@ -43,7 +43,7 @@ import {
   parseTokenResponse,
 } from "./oauth/protocol";
 import { buildManifest, buildManifestLaunchUrl } from "./oauth/manifest";
-import type { SlackInstallationRepo } from "./ports";
+import type { SlackInstallationRepo, SlackSessionScopeRepo } from "./ports";
 import {
   buildBaseString,
   isTimestampFresh,
@@ -69,12 +69,69 @@ const SLACK_MCP_URL = "https://mcp.slack.com/mcp";
 const SLACK_API_URL = "https://slack.com/api";
 
 /**
- * SlackProvider's container differs from the base Container in one place:
- * `installations` is a SlackInstallationRepo (extends InstallationRepo with
- * getUserToken / setBotVaultId).
+ * For `per_channel` granularity: how long after the first new top-level
+ * message we hold the "armed" flag before allowing another scan-arm dispatch.
+ * The agent receives the armed signal immediately and is expected to call
+ * scheduleWakeup with roughly this same delay; on wake it reads
+ * conversations.history for everything that arrived during the window.
  */
-export interface SlackContainer extends Omit<Container, "installations"> {
+const PER_CHANNEL_DEBOUNCE_WINDOW_MS = 90_000;
+
+/**
+ * Routing intent for per_channel dispatch. classifyDispatch sets this so
+ * dispatchEvent knows which signal to render and which lifecycle action to
+ * take. For per_thread / per_event (legacy) paths intent is undefined.
+ */
+type DispatchIntent =
+  | "joined_channel"     // member_joined_channel for bot, or first wake of a fresh channel session
+  | "scan_arm"           // top-level message in per_channel — debounce + signal
+  | "direct_invocation"  // @ / DM / thread reply (per_channel routes to channel session)
+  | "reaction_on_bot"    // reaction on a bot-authored message
+  | "close_session"      // member_left_channel for bot, or channel_archive
+  | "reopen_session";    // channel_unarchive
+
+type ClassifyDecision =
+  | { kind: "dispatch"; intent?: DispatchIntent }
+  | { kind: "drop"; reason: string }
+  /** channel_rename: update the cached channel_name on the scope row but don't wake the agent. */
+  | { kind: "metadata_only"; channelName: string };
+
+/**
+ * The kind of signal embedded in the rendered user.message text. Drives the
+ * agent's behavior — each kind's prompt phrasing is documented in
+ * renderEventAsUserMessage. Distinct from DispatchIntent because intents
+ * describe routing actions (close session, arm scan) while signals describe
+ * what the agent perceives.
+ */
+type SignalKind =
+  | "joined_channel"
+  | "channel_scan_armed"
+  | "direct_invocation"
+  | "reaction_on_bot_message"
+  | "session_closed";
+
+/** Optional context fields passed to renderEventAsUserMessage / buildSessionEvent. */
+interface SignalExtras {
+  /** Cached channel display name (without `#`), if known. */
+  channelName?: string | null;
+  /** Debounce window the agent should match in scheduleWakeup, in ms. */
+  debounceMs?: number;
+  /** ms timestamp of last completed scan; renderer formats as Slack `oldest=`. */
+  lastScanAt?: number | null;
+  /** Whether this is a reopen rather than a fresh join. */
+  reopened?: boolean;
+}
+
+/**
+ * SlackProvider's container differs from the base Container in two places:
+ * `installations` is a SlackInstallationRepo (extends InstallationRepo with
+ * getUserToken / setBotVaultId), and `sessionScopes` is a SlackSessionScopeRepo
+ * (extends SessionScopeRepo with armPendingScan / clearPendingScan /
+ * updateChannelName for per_channel granularity).
+ */
+export interface SlackContainer extends Omit<Container, "installations" | "sessionScopes"> {
   installations: SlackInstallationRepo;
+  sessionScopes: SlackSessionScopeRepo;
 }
 
 export class SlackProvider implements IntegrationProvider {
@@ -359,7 +416,7 @@ export class SlackProvider implements IntegrationProvider {
       capabilities: new Set(
         this.config.defaultCapabilities ?? ALL_SLACK_CAPABILITIES,
       ),
-      sessionGranularity: "per_thread",
+      sessionGranularity: this.config.defaultSessionGranularity ?? "per_channel",
     });
     await this.container.apps.setPublicationId(app.id, publication.id);
 
@@ -515,14 +572,37 @@ export class SlackProvider implements IntegrationProvider {
       return { handled: false, reason: "publication_not_live" };
     }
 
+    // metadata_only — channel_rename: update the cached channel_name on the
+    // scope row without waking the agent. Agent reads it from session
+    // metadata on its next natural wake (scan / mention / etc.).
+    if (decision.kind === "metadata_only") {
+      if (event.channelId) {
+        const scopeKey = `channel:${event.channelId}`;
+        await this.container.sessionScopes.updateChannelName(
+          pub.id,
+          scopeKey,
+          decision.channelName,
+        );
+      }
+      await this.container.webhookEvents.attachPublication(env.event_id, pub.id);
+      return {
+        handled: true,
+        reason: "metadata_only",
+        publicationId: pub.id,
+        tenantId: installation.tenantId,
+      };
+    }
+
     await this.container.webhookEvents.attachPublication(env.event_id, pub.id);
 
     // Defer the actual session create/resume to satisfy Slack's 3-sec budget.
     // The route handler attaches this to executionCtx.waitUntil(...).
     const deferred = async () => {
       try {
-        const sessionId = await this.dispatchEvent(pub, installation.id, event);
-        await this.container.webhookEvents.attachSession(env.event_id, sessionId);
+        const sessionId = await this.dispatchEvent(pub, installation.id, event, decision.intent);
+        if (sessionId) {
+          await this.container.webhookEvents.attachSession(env.event_id, sessionId);
+        }
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         await this.container.webhookEvents.attachError(env.event_id, msg.slice(0, 200));
@@ -542,7 +622,8 @@ export class SlackProvider implements IntegrationProvider {
     publication: Publication,
     installationId: string,
     event: NormalizedSlackEvent,
-  ): Promise<string> {
+    intent?: DispatchIntent,
+  ): Promise<string | null> {
     // Both vaults — user token (xoxp-) for mcp.slack.com + bot token (xoxb-)
     // for direct slack.com/api calls.
     const installation = await this.container.installations.get(installationId);
@@ -555,23 +636,193 @@ export class SlackProvider implements IntegrationProvider {
 
     const mcpServers = [{ name: "slack", url: SLACK_MCP_URL }];
 
-    const sessionEvent = {
-      type: "user.message" as const,
-      content: [
-        { type: "text" as const, text: this.renderEventAsUserMessage(event) },
-      ],
-      metadata: {
-        slack: {
-          workspaceId: event.workspaceId,
-          channelId: event.channelId,
-          threadTs: event.threadTs,
-          eventTs: event.eventTs,
-          userId: event.userId,
-          eventKind: event.kind,
-          deliveryId: event.deliveryId,
-        },
-      },
-    };
+    // ─── per_channel granularity ──────────────────────────────────────
+    // One session per (publication, channel_id). All channel events route
+    // to it via intent. Top-level scan-arms throttle on a D1 watermark.
+    if (publication.sessionGranularity === "per_channel" && event.channelId) {
+      const scopeKey = `channel:${event.channelId}`;
+      const existing = await this.container.sessionScopes.getByScope(
+        publication.id,
+        scopeKey,
+      );
+
+      // close_session (bot kicked / channel archived) — flip status, clear
+      // the debounce watermark, send a final session_closed signal so the
+      // agent can cancel its own scheduleWakeups before going dormant.
+      if (intent === "close_session") {
+        if (!existing) return null;
+        await this.container.sessionScopes.updateStatus(
+          publication.id,
+          scopeKey,
+          "completed",
+        );
+        await this.container.sessionScopes.clearPendingScan(publication.id, scopeKey);
+        if (existing.status === "active") {
+          const sessionEvent = this.buildSessionEvent(
+            event,
+            "session_closed",
+            { channelName: existing.channelName ?? null },
+          );
+          await this.container.sessions.resume(
+            publication.userId,
+            existing.sessionId,
+            sessionEvent,
+          );
+        }
+        return existing.sessionId;
+      }
+
+      // scan_arm — debounce check on the scope row. If already armed within
+      // window, drop silently. If armed fresh, resume with the signal.
+      if (intent === "scan_arm") {
+        // Lazy-create the scope row if missing — bot may have been added to
+        // the channel before per_channel rolled out, so member_joined_channel
+        // wasn't received. First top-level message bootstraps the session.
+        if (!existing) {
+          const newId = await this.createChannelSession(
+            publication,
+            event,
+            scopeKey,
+            "joined_channel",
+            vaultIds,
+            mcpServers,
+          );
+          // Arm immediately — the bootstrap turn establishes context, the
+          // agent should already start its first scheduleWakeup loop.
+          await this.container.sessionScopes.armPendingScan(
+            publication.id,
+            scopeKey,
+            this.container.clock.nowMs() + PER_CHANNEL_DEBOUNCE_WINDOW_MS,
+            this.container.clock.nowMs(),
+          );
+          return newId;
+        }
+        if (existing.status !== "active") return null;
+        const now = this.container.clock.nowMs();
+        const armResult = await this.container.sessionScopes.armPendingScan(
+          publication.id,
+          scopeKey,
+          now + PER_CHANNEL_DEBOUNCE_WINDOW_MS,
+          now,
+        );
+        if (!armResult.armed) {
+          // Already armed; throttle silently. Surface as a soft drop reason
+          // on the webhook event so operators can see throttle hits in logs.
+          await this.container.webhookEvents.attachError(
+            event.deliveryId,
+            "throttled_pending_scan",
+          );
+          return existing.sessionId;
+        }
+        const sessionEvent = this.buildSessionEvent(event, "channel_scan_armed", {
+          debounceMs: PER_CHANNEL_DEBOUNCE_WINDOW_MS,
+          lastScanAt: existing.lastScanAt ?? null,
+          channelName: existing.channelName ?? null,
+        });
+        await this.container.sessions.resume(
+          publication.userId,
+          existing.sessionId,
+          sessionEvent,
+        );
+        return existing.sessionId;
+      }
+
+      // direct_invocation / reaction_on_bot — both require resuming a live
+      // channel session. Lazy-create if missing (bot may pre-date per_channel
+      // rollout in this channel).
+      if (intent === "direct_invocation" || intent === "reaction_on_bot") {
+        const signalKind =
+          intent === "direct_invocation" ? "direct_invocation" : "reaction_on_bot_message";
+        const sessionEvent = this.buildSessionEvent(event, signalKind, {
+          channelName: existing?.channelName ?? null,
+        });
+        if (existing && existing.status === "active") {
+          await this.container.sessions.resume(
+            publication.userId,
+            existing.sessionId,
+            sessionEvent,
+          );
+          return existing.sessionId;
+        }
+        // Lazy bootstrap on a missing or inactive scope. Reuse joined_channel
+        // signal as the initial event — agent gets onboarding context, then
+        // sees the actual trigger as a follow-up resume.
+        const newId = await this.createChannelSession(
+          publication,
+          event,
+          scopeKey,
+          "joined_channel",
+          vaultIds,
+          mcpServers,
+        );
+        // Follow-up resume with the actual trigger signal so the agent sees
+        // both: "you're new here" + "and X just happened".
+        await this.container.sessions.resume(publication.userId, newId, sessionEvent);
+        return newId;
+      }
+
+      // joined_channel — bot was added (or re-bootstrapped via reopen).
+      // Reopen path also lands here: existing row may be `completed` and we
+      // flip it back to `active`.
+      if (intent === "joined_channel" || intent === "reopen_session") {
+        if (existing) {
+          if (existing.status !== "active") {
+            await this.container.sessionScopes.updateStatus(
+              publication.id,
+              scopeKey,
+              "active",
+            );
+          }
+          await this.container.sessionScopes.clearPendingScan(
+            publication.id,
+            scopeKey,
+          );
+          const sessionEvent = this.buildSessionEvent(event, "joined_channel", {
+            channelName: existing.channelName ?? null,
+            reopened: intent === "reopen_session",
+          });
+          await this.container.sessions.resume(
+            publication.userId,
+            existing.sessionId,
+            sessionEvent,
+          );
+          return existing.sessionId;
+        }
+        return await this.createChannelSession(
+          publication,
+          event,
+          scopeKey,
+          "joined_channel",
+          vaultIds,
+          mcpServers,
+        );
+      }
+
+      // Per_channel intent fell through — defensive: treat as direct
+      // invocation. Should never happen if classifyDispatch is exhaustive.
+      const sessionEvent = this.buildSessionEvent(event, "direct_invocation", {
+        channelName: existing?.channelName ?? null,
+      });
+      if (existing && existing.status === "active") {
+        await this.container.sessions.resume(
+          publication.userId,
+          existing.sessionId,
+          sessionEvent,
+        );
+        return existing.sessionId;
+      }
+      return await this.createChannelSession(
+        publication,
+        event,
+        scopeKey,
+        "direct_invocation",
+        vaultIds,
+        mcpServers,
+      );
+    }
+
+    // ─── per_thread granularity (legacy) ──────────────────────────────
+    const sessionEvent = this.buildSessionEvent(event, null, {});
 
     if (publication.sessionGranularity === "per_thread" && event.scopeKey) {
       const existing = await this.container.sessionScopes.getByScope(
@@ -651,56 +902,214 @@ export class SlackProvider implements IntegrationProvider {
   }
 
   /**
-   * Classify whether an inbound event should reach the agent. Slack delivers
-   * a noisy stream of overlapping signals; this is the single place that
-   * decides "drop" vs "dispatch" so that handleWebhook + dispatchEvent stay
-   * narrow.
-   *
-   * Rules (in order):
-   *   1. `app_mention` → dispatch. Canonical signal that the bot was invoked.
-   *      Wins over the simultaneous `message` Slack also delivers for the
-   *      same Slack message ts.
-   *   2. `assistant_thread_started` → dispatch. Explicit AI-pane open.
-   *   3. `message` in a DM (channel_type === "im") → dispatch. The DM IS
-   *      addressed to the bot; no @-mention is needed.
-   *   4. `message` whose text contains `<@bot_user_id>` → drop. Slack
-   *      always also delivers `app_mention` for these; treating both would
-   *      double-record the user.message in the OMA session.
-   *   5. `message` continuing an active thread (scopeKey already bound) →
-   *      dispatch. The bot was previously invoked here; the user is
-   *      following up.
-   *   6. Anything else → drop. Random channel chatter the bot happened to
-   *      see because it's a member of the channel; not addressed to it.
+   * Create a fresh per_channel session and bind the scope row. Handles the
+   * insert race the same way per_thread does — if a concurrent dispatcher
+   * won, abandon ours and route to the winner.
    */
-  private async classifyDispatch(
+  private async createChannelSession(
     publication: Publication,
     event: NormalizedSlackEvent,
-    botUserId: string | null,
-  ): Promise<{ kind: "dispatch" } | { kind: "drop"; reason: string }> {
-    if (event.kind === "app_mention" || event.kind === "assistant_thread_started") {
-      return { kind: "dispatch" };
-    }
-    if (event.kind !== "message") {
-      // Anything else (tokens_revoked, app_uninstalled, unknown) is handled
-      // upstream; if it reaches here, drop defensively.
-      return { kind: "drop", reason: "unsupported_event_kind" };
-    }
-    if (event.channelType === "im") return { kind: "dispatch" };
-    if (botUserId && event.text && event.text.includes(`<@${botUserId}>`)) {
-      // Slack will also deliver app_mention for this message.
-      return { kind: "drop", reason: "redundant_with_app_mention" };
-    }
-    if (event.scopeKey) {
-      const existing = await this.container.sessionScopes.getByScope(
-        publication.id,
-        event.scopeKey,
+    scopeKey: string,
+    signalKind: SignalKind,
+    vaultIds: string[],
+    mcpServers: { name: string; url: string }[],
+  ): Promise<string> {
+    const sessionEvent = this.buildSessionEvent(event, signalKind, {});
+    const created = await this.container.sessions.create({
+      userId: publication.userId,
+      agentId: publication.agentId,
+      environmentId: publication.environmentId,
+      vaultIds,
+      mcpServers,
+      metadata: {
+        slack: {
+          workspaceId: event.workspaceId,
+          channelId: event.channelId,
+          granularity: "per_channel",
+        },
+      },
+      initialEvent: sessionEvent,
+    });
+    const inserted = await this.container.sessionScopes.insert({
+      tenantId: publication.tenantId,
+      publicationId: publication.id,
+      scopeKey,
+      sessionId: created.sessionId,
+      status: "active",
+      createdAt: this.container.clock.nowMs(),
+    });
+    if (inserted) return created.sessionId;
+    // Race lost: re-read winner, route this event to it, abandon ours.
+    const winner = await this.container.sessionScopes.getByScope(publication.id, scopeKey);
+    if (winner && winner.status === "active") {
+      await this.container.sessions.resume(
+        publication.userId,
+        winner.sessionId,
+        sessionEvent,
       );
-      if (existing && existing.status === "active") return { kind: "dispatch" };
+      return winner.sessionId;
     }
-    return { kind: "drop", reason: "not_addressed_to_bot" };
+    return created.sessionId;
   }
 
-  private renderEventAsUserMessage(event: NormalizedSlackEvent): string {
+  /**
+   * Build the SessionEventInput for a Slack event, with signal-aware text and
+   * metadata. signalKind === null means legacy per_thread/per_event rendering
+   * (no signal framing); pass a SignalKind for per_channel paths.
+   */
+  private buildSessionEvent(
+    event: NormalizedSlackEvent,
+    signalKind: SignalKind | null,
+    extras: SignalExtras,
+  ): {
+    type: "user.message";
+    content: { type: "text"; text: string }[];
+    metadata: { slack: Record<string, unknown> };
+  } {
+    return {
+      type: "user.message",
+      content: [
+        { type: "text", text: this.renderEventAsUserMessage(event, signalKind, extras) },
+      ],
+      metadata: {
+        slack: {
+          workspaceId: event.workspaceId,
+          channelId: event.channelId,
+          threadTs: event.threadTs,
+          eventTs: event.eventTs,
+          userId: event.userId,
+          eventKind: event.kind,
+          deliveryId: event.deliveryId,
+          ...(signalKind ? { signalKind } : {}),
+          ...(extras.channelName ? { channelName: extras.channelName } : {}),
+          ...(event.reactionName ? { reactionName: event.reactionName } : {}),
+          ...(event.itemTs ? { itemTs: event.itemTs } : {}),
+          ...(event.itemUserId ? { itemUserId: event.itemUserId } : {}),
+        },
+      },
+    };
+  }
+
+  /**
+   * Render a Slack event as the user-facing text the agent will see. The
+   * `signalKind` parameter is the load-bearing piece for per_channel
+   * granularity — the agent's behavior on each kind is shaped by what we
+   * write here.
+   *
+   * Signals are wrapped in `<oma_signal>` XML to make explicit they are
+   * out-of-band system events from the integration runtime, NOT user-typed
+   * content. Agent must NEVER quote, paraphrase, or reference the signal
+   * framing in any reply that goes back to Slack — leaking internal
+   * vocabulary (signal names, "scan window", scheduleWakeup mechanics) to
+   * end users breaks the abstraction.
+   */
+  private renderEventAsUserMessage(
+    event: NormalizedSlackEvent,
+    signalKind: SignalKind | null,
+    extras: SignalExtras,
+  ): string {
+    const channelLabel = extras.channelName
+      ? `#${extras.channelName}${event.channelId ? ` (${event.channelId})` : ""}`
+      : event.channelId ?? "<unknown channel>";
+
+    if (signalKind === "joined_channel") {
+      const verb = extras.reopened ? "added back to" : "added to";
+      return [
+        `<oma_signal kind="joined_channel">`,
+        `You (the bot) were ${verb} ${channelLabel} in workspace ${event.workspaceId}.`,
+        ``,
+        `Required actions for this turn:`,
+        `1. Call slack \`conversations.info\` to read this channel's topic and purpose.`,
+        `2. Call slack \`conversations.history\` (limit ~20) to see what's been discussed recently.`,
+        `3. Decide whether to post a brief self-introduction. Skip if the channel already knows you, has a clear purpose mismatch, or feels noisy/inappropriate to chime in.`,
+        ``,
+        `Future signals you'll receive in this channel:`,
+        `- \`channel_scan_armed\`: new top-level activity. You schedule a delayed wakeup; do NOT post.`,
+        `- \`direct_invocation\`: explicit @-mention or DM. Respond promptly.`,
+        `- \`reaction_on_bot_message\`: feedback signal. Usually stay silent.`,
+        ``,
+        `Important: this signal is an internal runtime event. Do NOT quote or reference any of the above wording in messages you post to Slack — humans don't need to see internal mechanics.`,
+        `</oma_signal>`,
+      ].join("\n");
+    }
+
+    if (signalKind === "channel_scan_armed") {
+      const debounceSec = Math.round((extras.debounceMs ?? PER_CHANNEL_DEBOUNCE_WINDOW_MS) / 1000);
+      const oldest = extras.lastScanAt
+        ? `${(extras.lastScanAt / 1000).toFixed(6)}`
+        : `<channel-session-creation-time>`;
+      return [
+        `<oma_signal kind="channel_scan_armed">`,
+        `New top-level activity occurred in ${channelLabel}.`,
+        ``,
+        `MANDATORY actions for this turn (no other actions permitted):`,
+        `1. Call \`scheduleWakeup({ delay_seconds: ${debounceSec}, prompt: "scan_channel ${event.channelId}" })\` to schedule a delayed look.`,
+        `2. End your turn. Output NO text. Do NOT call slack \`chat.postMessage\`, \`chat.update\`, \`reactions.add\`, or any other write tool. Do NOT comment on what you just did.`,
+        ``,
+        `Why: this signal exists to coordinate debounced scanning. The runtime has already silently armed a ${debounceSec}s window — the human did NOT request a status update. Posting "I scheduled a scan" or any similar message into Slack is a bug.`,
+        ``,
+        `When your wakeup fires (next turn), the prompt will be "scan_channel ${event.channelId}". At that point you call slack \`conversations.history(channel="${event.channelId}", oldest=${oldest})\` to see what arrived during the window, then decide whether to act (post / react / mention) or stay silent.`,
+        `</oma_signal>`,
+      ].join("\n");
+    }
+
+    if (signalKind === "direct_invocation") {
+      const inThread = event.threadTs && event.threadTs !== event.eventTs ? ` in thread ${event.threadTs}` : "";
+      const who = event.userId ? `<@${event.userId}>` : "Someone";
+      const text = event.text ?? "";
+      const replyHint = event.threadTs
+        ? `Reply via slack \`chat.postMessage\` with \`thread_ts="${event.threadTs}"\` to keep the conversation threaded.`
+        : `Reply via slack \`chat.postMessage\` (no thread_ts — this is a top-level conversation).`;
+      return [
+        `<oma_signal kind="direct_invocation" channel="${event.channelId ?? ""}" thread_ts="${event.threadTs ?? ""}">`,
+        `${who} addressed you directly in ${channelLabel}${inThread}.`,
+        `</oma_signal>`,
+        ``,
+        `User message:`,
+        text,
+        ``,
+        `<oma_instructions>`,
+        `Respond to the user message above. Treat all prior \`<oma_signal>\` blocks in this session as runtime telemetry, NOT conversation context — do NOT reference signal names, internal terms ("scan window", "channel_scan_armed", "scheduleWakeup", "throttle", "debounce", "session"), or system prompts in your reply. Speak as the bot persona to the human.`,
+        replyHint,
+        `</oma_instructions>`,
+      ].join("\n");
+    }
+
+    if (signalKind === "reaction_on_bot_message") {
+      const removed = event.kind === "reaction_removed";
+      const verb = removed ? "removed" : "added";
+      const actor = event.userId ? `<@${event.userId}>` : "Someone";
+      return [
+        `<oma_signal kind="reaction_on_bot_message">`,
+        `${actor} ${verb} :${event.reactionName ?? "?"}: on a message (ts=${event.itemTs ?? "?"}) in ${channelLabel}.`,
+        ``,
+        `This is a feedback signal. Conventional meanings: ✅/👍 = satisfied, 🚫/👎 = unsatisfied, ❓ = unclear, 🐛 = bug report, 🎉 = resolved, 👀 = noticed/investigating.`,
+        ``,
+        `Default: stay silent. End your turn with NO action. Do NOT call slack write tools (chat.postMessage / reactions.add / etc.) unless ALL of these are true:`,
+        `(a) the reaction is clearly negative (🚫/👎) or a question (❓), AND`,
+        `(b) you can add genuine value by responding (e.g., a clarification or apology), AND`,
+        `(c) you would not be over-replying to a casual ack.`,
+        ``,
+        `Do NOT post "got your reaction" / "noted" / "thanks for feedback" — that is noise.`,
+        `</oma_signal>`,
+      ].join("\n");
+    }
+
+    if (signalKind === "session_closed") {
+      const reason =
+        event.kind === "member_left_channel" ? "you were removed from the channel" : "the channel was archived";
+      return [
+        `<oma_signal kind="session_closed">`,
+        `Final wakeup for ${channelLabel}: ${reason}.`,
+        ``,
+        `MANDATORY actions for this turn:`,
+        `1. Cancel any wakeups you scheduled for this channel — call \`cancelWakeup\` on each id you remember, OR simply end the turn and let them lapse (they'll fail with channel_not_found, which is fine).`,
+        `2. End your turn with NO further action. Do NOT post a farewell — you cannot post into the channel anyway.`,
+        `</oma_signal>`,
+      ].join("\n");
+    }
+
+    // Legacy / per_thread / per_event rendering — same as before.
     const lines: string[] = [];
     const where = event.channelId
       ? `${event.channelId}${event.threadTs ? ` (thread ${event.threadTs})` : ""}`
@@ -709,6 +1118,165 @@ export class SlackProvider implements IntegrationProvider {
     if (event.userId) lines.push(`From: ${event.userId}`);
     if (event.text) lines.push(`\n${event.text}`);
     return lines.join("\n");
+  }
+
+  /**
+   * Classify whether an inbound event should reach the agent. Slack delivers
+   * a noisy stream of overlapping signals; this is the single place that
+   * decides "drop" vs "dispatch" vs "metadata_only" so that handleWebhook +
+   * dispatchEvent stay narrow.
+   *
+   * Rules (in order — first match wins):
+   *   0.  `member_joined_channel` — dispatch with intent `joined_channel`
+   *       only when joiner is the bot itself. Other users joining a channel
+   *       the bot is in is not the bot's business.
+   *   0.1 `member_left_channel` — dispatch with intent `close_session` only
+   *       when the leaver is the bot. Cleans up the channel session.
+   *   0.2 `channel_archive` — dispatch with intent `close_session` if there's
+   *       an active per_channel session for this channel; else drop.
+   *   0.3 `channel_unarchive` — dispatch with intent `reopen_session` if any
+   *       per_channel session has ever existed for this channel; else drop.
+   *   0.4 `channel_rename` — return `metadata_only` so handleWebhook updates
+   *       the cached channel name without waking the agent.
+   *   0.5 `reaction_added` / `reaction_removed` — dispatch with intent
+   *       `reaction_on_bot` only when the reacted-on message was authored by
+   *       the bot. Reactions on other people's messages are noise.
+   *   1.  `app_mention` — dispatch. Canonical signal that the bot was invoked.
+   *       Wins over the simultaneous `message` Slack also delivers for the
+   *       same Slack message ts. Intent `direct_invocation` for per_channel.
+   *   2.  `assistant_thread_started` — dispatch. Explicit AI-pane open.
+   *       Intent `direct_invocation` for per_channel (the pane is the
+   *       conversational surface; treat the open as a direct invocation).
+   *   3.  `message` in a DM (channel_type === "im") → dispatch. The DM IS
+   *       addressed to the bot; no @-mention is needed.
+   *   4.  `message` whose text contains `<@bot_user_id>` → drop. Slack
+   *       always also delivers `app_mention` for these; treating both would
+   *       double-record the user.message in the OMA session.
+   *   5.  `per_channel` + `isTopLevel` `message` → dispatch with intent
+   *       `scan_arm`. dispatchEvent will check the debounce watermark and
+   *       only resume the session if not already armed.
+   *   6.  `message` continuing an active thread (scopeKey already bound) →
+   *       dispatch. The bot was previously invoked here; the user is
+   *       following up. Intent `direct_invocation` for per_channel.
+   *   7.  Anything else → drop. Random channel chatter the bot happened to
+   *       see because it's a member of the channel; not addressed to it.
+   */
+  private async classifyDispatch(
+    publication: Publication,
+    event: NormalizedSlackEvent,
+    botUserId: string | null,
+  ): Promise<ClassifyDecision> {
+    const isPerChannel = publication.sessionGranularity === "per_channel";
+
+    // ─── Lifecycle events (rules 0.x) ──────────────────────────────────
+
+    if (event.kind === "member_joined_channel") {
+      if (event.userId && event.userId === botUserId) {
+        return { kind: "dispatch", intent: "joined_channel" };
+      }
+      return { kind: "drop", reason: "non_bot_member_joined" };
+    }
+
+    if (event.kind === "member_left_channel") {
+      if (event.userId && event.userId === botUserId) {
+        return { kind: "dispatch", intent: "close_session" };
+      }
+      return { kind: "drop", reason: "non_bot_member_left" };
+    }
+
+    if (event.kind === "channel_archive" || event.kind === "channel_unarchive") {
+      if (!event.channelId) return { kind: "drop", reason: "missing_channel_id" };
+      const scopeKey = `channel:${event.channelId}`;
+      const existing = await this.container.sessionScopes.getByScope(
+        publication.id,
+        scopeKey,
+      );
+      if (event.kind === "channel_archive") {
+        if (existing && existing.status === "active") {
+          return { kind: "dispatch", intent: "close_session" };
+        }
+        return { kind: "drop", reason: "no_active_channel_session" };
+      }
+      // unarchive: any prior scope row is enough to revive
+      if (existing) {
+        return { kind: "dispatch", intent: "reopen_session" };
+      }
+      return { kind: "drop", reason: "no_prior_channel_session" };
+    }
+
+    if (event.kind === "channel_rename") {
+      if (!event.channelId || !event.channelName) {
+        return { kind: "drop", reason: "missing_channel_id_or_name" };
+      }
+      const scopeKey = `channel:${event.channelId}`;
+      const existing = await this.container.sessionScopes.getByScope(
+        publication.id,
+        scopeKey,
+      );
+      if (!existing) return { kind: "drop", reason: "no_channel_session" };
+      return { kind: "metadata_only", channelName: event.channelName };
+    }
+
+    if (event.kind === "reaction_added" || event.kind === "reaction_removed") {
+      // For per_channel granularity: dispatch if we have an active session in
+      // this channel. Reactions in channels the bot inhabits are perceived
+      // regardless of message authorship — `treat agent like human`.
+      // For per_thread (legacy): only dispatch reactions where item_user
+      // matches the bot user. Note: mcp.slack.com posts via the user xoxp-
+      // token, so Slack reports item_user as the installer (not the bot
+      // user) for bot-authored messages — the per_thread match path is
+      // unreliable but kept for backward compat.
+      if (isPerChannel && event.channelId) {
+        const scopeKey = `channel:${event.channelId}`;
+        const existing = await this.container.sessionScopes.getByScope(
+          publication.id,
+          scopeKey,
+        );
+        if (existing && existing.status === "active") {
+          return { kind: "dispatch", intent: "reaction_on_bot" };
+        }
+      }
+      if (event.itemUserId && event.itemUserId === botUserId) {
+        return { kind: "dispatch", intent: "reaction_on_bot" };
+      }
+      return { kind: "drop", reason: "reaction_not_on_bot_message" };
+    }
+
+    // ─── Conversation events (rules 1-7) ───────────────────────────────
+
+    if (event.kind === "app_mention") {
+      return { kind: "dispatch", intent: isPerChannel ? "direct_invocation" : undefined };
+    }
+    if (event.kind === "assistant_thread_started") {
+      return { kind: "dispatch", intent: isPerChannel ? "direct_invocation" : undefined };
+    }
+    if (event.kind !== "message") {
+      // Anything else (tokens_revoked, app_uninstalled, unknown) is handled
+      // upstream; if it reaches here, drop defensively.
+      return { kind: "drop", reason: "unsupported_event_kind" };
+    }
+    if (event.channelType === "im") {
+      return { kind: "dispatch", intent: isPerChannel ? "direct_invocation" : undefined };
+    }
+    if (botUserId && event.text && event.text.includes(`<@${botUserId}>`)) {
+      // Slack will also deliver app_mention for this message.
+      return { kind: "drop", reason: "redundant_with_app_mention" };
+    }
+    // per_channel: top-level message in a channel the bot is a member of →
+    // arm a debounced scan turn. dispatchEvent does the throttle check.
+    if (isPerChannel && event.isTopLevel && event.channelId) {
+      return { kind: "dispatch", intent: "scan_arm" };
+    }
+    if (event.scopeKey) {
+      const existing = await this.container.sessionScopes.getByScope(
+        publication.id,
+        event.scopeKey,
+      );
+      if (existing && existing.status === "active") {
+        return { kind: "dispatch", intent: isPerChannel ? "direct_invocation" : undefined };
+      }
+    }
+    return { kind: "drop", reason: "not_addressed_to_bot" };
   }
 
   /**

--- a/packages/slack/src/webhook/parse.ts
+++ b/packages/slack/src/webhook/parse.ts
@@ -6,6 +6,9 @@
 //   https://docs.slack.dev/apis/events-api/
 //   https://docs.slack.dev/reference/events/
 //   https://docs.slack.dev/reference/events/url_verification/
+//   https://docs.slack.dev/reference/events/member_joined_channel/
+//   https://docs.slack.dev/reference/events/reaction_added/
+//   https://docs.slack.dev/reference/events/channel_archive/
 //   https://docs.slack.dev/ai/developing-ai-apps  (assistant_thread_*)
 
 /**
@@ -52,7 +55,8 @@ export interface RawEventInner {
   type: string;
   user?: string;
   text?: string;
-  channel?: string;
+  /** For most events. For channel_rename it's a nested object {id,name,...}. */
+  channel?: string | { id?: string; name?: string; [k: string]: unknown };
   /** Top-level message ts. */
   ts?: string;
   /** Set when the message is in a thread. */
@@ -71,6 +75,16 @@ export interface RawEventInner {
   };
   /** tokens_revoked / app_uninstalled events. */
   tokens?: { oauth?: string[]; bot?: string[] };
+  /** reaction_added / reaction_removed payload shape. */
+  reaction?: string;
+  item?: {
+    type?: string;
+    channel?: string;
+    ts?: string;
+    [k: string]: unknown;
+  };
+  /** reaction_added: Slack id of the user who *authored* item.message. */
+  item_user?: string;
   [k: string]: unknown;
 }
 
@@ -82,7 +96,14 @@ export type SlackEventKind =
   | "message"
   | "assistant_thread_started"
   | "tokens_revoked"
-  | "app_uninstalled";
+  | "app_uninstalled"
+  | "member_joined_channel"
+  | "member_left_channel"
+  | "channel_archive"
+  | "channel_unarchive"
+  | "channel_rename"
+  | "reaction_added"
+  | "reaction_removed";
 
 export interface NormalizedSlackEvent {
   kind: SlackEventKind | null;
@@ -100,7 +121,7 @@ export interface NormalizedSlackEvent {
    *   - "channel" public channel
    *   - "group"   private channel
    *   - "mpim"    multi-person DM
-   *   - null      no channel (tokens_revoked / app_uninstalled)
+   *   - null      no channel (tokens_revoked / app_uninstalled / lifecycle events)
    */
   channelType: "im" | "channel" | "group" | "mpim" | null;
   /** thread_ts if in a thread, falls back to ts (top-level message). */
@@ -110,7 +131,8 @@ export interface NormalizedSlackEvent {
   /**
    * Conversation scope key for per-thread session granularity:
    *   `${channel_id}:${thread_ts ?? event_ts}`
-   * Null when there's no channel/ts (uninstall events).
+   * Null when there's no channel/ts (uninstall events). For per_channel
+   * granularity the provider composes its own key (`channel:${channel_id}`).
    */
   scopeKey: string | null;
   userId: string | null;
@@ -119,6 +141,23 @@ export interface NormalizedSlackEvent {
   isBotMessage: boolean;
   /** Raw event type for logging (e.g. "app_mention", "message"). */
   eventType: string;
+  /**
+   * True for non-thread top-level messages (`thread_ts` is absent or equals
+   * the message's own `ts`) of kind `message` or `app_mention`. False for
+   * thread replies and non-message events. Only meaningful for `per_channel`
+   * granularity, which uses this to decide scan-arm dispatch.
+   *
+   * Excludes message edits/deletes (subtype `message_changed` / `_deleted`).
+   */
+  isTopLevel: boolean;
+  /** reaction_added / reaction_removed: name of the emoji (no colons). */
+  reactionName: string | null;
+  /** reaction_added / reaction_removed: ts of the message that was reacted to. */
+  itemTs: string | null;
+  /** reaction_added / reaction_removed: Slack id of the message's author. */
+  itemUserId: string | null;
+  /** channel_rename: the channel's new display name (no `#`). */
+  channelName: string | null;
 }
 
 /** Parses Slack's raw envelope into our normalized shape. Pure function. */
@@ -131,7 +170,7 @@ export function parseWebhook(raw: RawSlackEnvelope): NormalizedSlackEvent | null
   const kind = mapEventKind(inner.type);
   if (kind === null) {
     // Unknown event type — record for idempotency but don't dispatch.
-    const channelId = typeof inner.channel === "string" ? inner.channel : null;
+    const channelId = pickChannelId(inner);
     return {
       kind: null,
       deliveryId: env.event_id,
@@ -145,6 +184,11 @@ export function parseWebhook(raw: RawSlackEnvelope): NormalizedSlackEvent | null
       text: pickString(inner, "text"),
       isBotMessage: detectBotMessage(inner),
       eventType: typeof inner.type === "string" ? inner.type : "",
+      isTopLevel: false,
+      reactionName: null,
+      itemTs: null,
+      itemUserId: null,
+      channelName: null,
     };
   }
 
@@ -163,6 +207,11 @@ export function parseWebhook(raw: RawSlackEnvelope): NormalizedSlackEvent | null
       text: null,
       isBotMessage: false,
       eventType: inner.type,
+      isTopLevel: false,
+      reactionName: null,
+      itemTs: null,
+      itemUserId: null,
+      channelName: null,
     };
   }
 
@@ -184,11 +233,121 @@ export function parseWebhook(raw: RawSlackEnvelope): NormalizedSlackEvent | null
       text: null,
       isBotMessage: false,
       eventType: inner.type,
+      isTopLevel: false,
+      reactionName: null,
+      itemTs: null,
+      itemUserId: null,
+      channelName: null,
+    };
+  }
+
+  // member_joined_channel / member_left_channel — payload `{ user, channel }`.
+  // These are channel-membership lifecycle events; the provider gates dispatch
+  // on `userId === installation.botUserId` (only act on the bot's own joins).
+  if (kind === "member_joined_channel" || kind === "member_left_channel") {
+    const channelId = pickChannelId(inner);
+    return {
+      kind,
+      deliveryId: env.event_id,
+      workspaceId: env.team_id,
+      channelId,
+      channelType: pickChannelType(inner, channelId),
+      threadTs: null,
+      eventTs: pickString(inner, "event_ts"),
+      scopeKey: null,
+      userId: pickString(inner, "user"),
+      text: null,
+      isBotMessage: false,
+      eventType: inner.type,
+      isTopLevel: false,
+      reactionName: null,
+      itemTs: null,
+      itemUserId: null,
+      channelName: null,
+    };
+  }
+
+  // channel_archive / channel_unarchive — payload `{ channel, user }`. The
+  // user is whoever triggered the archive (may not be the bot); dispatch
+  // gates on whether *we have an active per_channel session* in this channel.
+  if (kind === "channel_archive" || kind === "channel_unarchive") {
+    const channelId = pickChannelId(inner);
+    return {
+      kind,
+      deliveryId: env.event_id,
+      workspaceId: env.team_id,
+      channelId,
+      channelType: pickChannelType(inner, channelId),
+      threadTs: null,
+      eventTs: pickString(inner, "event_ts"),
+      scopeKey: null,
+      userId: pickString(inner, "user"),
+      text: null,
+      isBotMessage: false,
+      eventType: inner.type,
+      isTopLevel: false,
+      reactionName: null,
+      itemTs: null,
+      itemUserId: null,
+      channelName: null,
+    };
+  }
+
+  // channel_rename — payload `{ channel: { id, name, ... } }`.
+  if (kind === "channel_rename") {
+    const channelObj = typeof inner.channel === "object" && inner.channel ? inner.channel : null;
+    const channelId = channelObj && typeof channelObj.id === "string" ? channelObj.id : null;
+    const channelName = channelObj && typeof channelObj.name === "string" ? channelObj.name : null;
+    return {
+      kind,
+      deliveryId: env.event_id,
+      workspaceId: env.team_id,
+      channelId,
+      channelType: pickChannelType(inner, channelId),
+      threadTs: null,
+      eventTs: pickString(inner, "event_ts"),
+      scopeKey: null,
+      userId: pickString(inner, "user"),
+      text: null,
+      isBotMessage: false,
+      eventType: inner.type,
+      isTopLevel: false,
+      reactionName: null,
+      itemTs: null,
+      itemUserId: null,
+      channelName,
+    };
+  }
+
+  // reaction_added / reaction_removed — `{ user, reaction, item: { channel, ts }, item_user }`.
+  // The provider gates dispatch on `itemUserId === installation.botUserId`
+  // (only feedback on bot's own messages matters).
+  if (kind === "reaction_added" || kind === "reaction_removed") {
+    const item = inner.item ?? {};
+    const channelId = typeof item.channel === "string" ? item.channel : null;
+    return {
+      kind,
+      deliveryId: env.event_id,
+      workspaceId: env.team_id,
+      channelId,
+      channelType: pickChannelType(inner, channelId),
+      threadTs: null,
+      eventTs: pickString(inner, "event_ts"),
+      scopeKey: null,
+      userId: pickString(inner, "user"),
+      text: null,
+      isBotMessage: false,
+      eventType: inner.type,
+      isTopLevel: false,
+      reactionName: typeof inner.reaction === "string" ? inner.reaction : null,
+      itemTs: typeof item.ts === "string" ? item.ts : null,
+      itemUserId: typeof inner.item_user === "string" ? inner.item_user : null,
+      channelName: null,
     };
   }
 
   // app_mention / message — standard channel events.
-  const channelId = typeof inner.channel === "string" ? inner.channel : null;
+  const channelId = pickChannelId(inner);
   const channelType = pickChannelType(inner, channelId);
   const ts = pickString(inner, "ts");
   const threadTs = pickThreadTs(inner);
@@ -196,6 +355,15 @@ export function parseWebhook(raw: RawSlackEnvelope): NormalizedSlackEvent | null
   // when the bot replies it'll be `thread_ts: ts` and start a thread.
   const effectiveThread = threadTs ?? ts;
   const scopeKey = channelId && effectiveThread ? `${channelId}:${effectiveThread}` : null;
+  // True top-level: thread_ts is absent (or equals ts), and not an edit/delete
+  // subtype. Edits and deletes carry ts/thread_ts but shouldn't re-arm scans.
+  const subtype = pickString(inner, "subtype");
+  const isEditOrDelete =
+    subtype === "message_changed" || subtype === "message_deleted";
+  const isTopLevel =
+    !isEditOrDelete &&
+    (kind === "message" || kind === "app_mention") &&
+    threadTs === null;
 
   return {
     kind,
@@ -210,6 +378,11 @@ export function parseWebhook(raw: RawSlackEnvelope): NormalizedSlackEvent | null
     text: pickString(inner, "text"),
     isBotMessage: detectBotMessage(inner),
     eventType: inner.type,
+    isTopLevel,
+    reactionName: null,
+    itemTs: null,
+    itemUserId: null,
+    channelName: null,
   };
 }
 
@@ -220,6 +393,13 @@ function mapEventKind(type: string | undefined): SlackEventKind | null {
     case "assistant_thread_started":
     case "tokens_revoked":
     case "app_uninstalled":
+    case "member_joined_channel":
+    case "member_left_channel":
+    case "channel_archive":
+    case "channel_unarchive":
+    case "channel_rename":
+    case "reaction_added":
+    case "reaction_removed":
       return type;
     default:
       return null;
@@ -228,6 +408,23 @@ function mapEventKind(type: string | undefined): SlackEventKind | null {
 
 function pickThreadTs(inner: RawEventInner): string | null {
   return typeof inner.thread_ts === "string" ? inner.thread_ts : null;
+}
+
+/**
+ * Read inner.channel as a string id. Most events carry it as a flat string;
+ * channel_rename nests it as `{ id, name, ... }`. Returns null for shapes
+ * we don't recognize.
+ */
+function pickChannelId(inner: RawEventInner): string | null {
+  if (typeof inner.channel === "string") return inner.channel;
+  if (
+    inner.channel &&
+    typeof inner.channel === "object" &&
+    typeof inner.channel.id === "string"
+  ) {
+    return inner.channel.id;
+  }
+  return null;
 }
 
 /**

--- a/test/unit/slack-provider-a1.test.ts
+++ b/test/unit/slack-provider-a1.test.ts
@@ -147,7 +147,7 @@ describe("SlackProvider — A1 (full identity) install flow", () => {
     const pub = await c.publications.get(complete.publicationId);
     expect(pub).toBeTruthy();
     expect(pub?.mode).toBe("full");
-    expect(pub?.sessionGranularity).toBe("per_thread");
+    expect(pub?.sessionGranularity).toBe("per_channel");
 
     const installs = await c.installations.listByUser("usr_a", "slack");
     expect(installs).toHaveLength(1);

--- a/test/unit/slack-provider-per-channel.test.ts
+++ b/test/unit/slack-provider-per-channel.test.ts
@@ -1,0 +1,409 @@
+// Per_channel granularity tests for SlackProvider. Covers:
+//   - lifecycle dispatch: member_joined/left, channel_archive/unarchive/rename
+//   - debounce throttle on top-level scan-arm events
+//   - reactions on bot-authored messages
+//   - direct_invocation routing to channel-scoped session
+//
+// These exercise the `per_channel` paths that classifyDispatch + dispatchEvent
+// added on top of the legacy `per_thread` flow. Reuses signing-secret + clock
+// scaffolding from slack-test-helpers.
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { SlackProvider } from "../../packages/slack/src/provider";
+import {
+  appMentionPayload,
+  buildFakeSlackContainer,
+  channelLifecyclePayload,
+  channelRenamePayload,
+  makeSlackProvider,
+  memberJoinedChannelPayload,
+  memberLeftChannelPayload,
+  messagePayload,
+  reactionPayload,
+  seedDedicatedSlackPublication,
+  type FakeSlackBundle,
+} from "./slack-test-helpers";
+
+const APP_SIGNING_SECRET = "ssec";
+const CHANNEL = "C0CHAN";
+const CHANNEL_SCOPE = `channel:${CHANNEL}`;
+const BOT_USER_ID = "U07BOT";
+
+describe("SlackProvider — per_channel granularity", () => {
+  let c: FakeSlackBundle;
+  let provider: SlackProvider;
+  let appId: string;
+  let pubId: string;
+
+  beforeEach(async () => {
+    c = buildFakeSlackContainer();
+    c.hmac.verify = async (secret: string, baseString: string, hex: string) =>
+      hex === `valid${secret}${baseString}`.toLowerCase().replace(/[^a-f0-9]/g, "");
+    provider = makeSlackProvider(c);
+    const seeded = await seedDedicatedSlackPublication(c, {
+      signingSecret: APP_SIGNING_SECRET,
+      sessionGranularity: "per_channel",
+    });
+    appId = seeded.appId;
+    pubId = seeded.pubId;
+    c.clock.set(1_700_000_000_000);
+  });
+
+  function validSig(rawBody: string, ts: string): string {
+    const baseString = `v0:${ts}:${rawBody}`;
+    const hex = `valid${APP_SIGNING_SECRET}${baseString}`
+      .toLowerCase()
+      .replace(/[^a-f0-9]/g, "");
+    return `v0=${hex}`;
+  }
+
+  async function deliver(rawBody: string) {
+    const ts = "1700000000";
+    return await provider.handleWebhook({
+      providerId: "slack",
+      installationId: appId,
+      deliveryId: null,
+      headers: {
+        "x-slack-signature": validSig(rawBody, ts),
+        "x-slack-request-timestamp": ts,
+      },
+      rawBody,
+    });
+  }
+
+  // ─── member_joined_channel ────────────────────────────────────────────
+
+  describe("member_joined_channel", () => {
+    it("creates a channel-session and emits joined_channel signal when bot itself joins", async () => {
+      const out = await deliver(
+        memberJoinedChannelPayload({ channel: CHANNEL, eventId: "Ev_J1", user: BOT_USER_ID }),
+      );
+      expect(out.handled).toBe(true);
+      await out.deferredWork!();
+      expect(c.sessions.created).toHaveLength(1);
+      const created = c.sessions.created[0];
+      expect(created.metadata?.slack).toMatchObject({ channelId: CHANNEL });
+      const text = (created.initialEvent.content[0] as { text: string }).text;
+      expect(text).toContain(`<oma_signal kind="joined_channel">`);
+      const scope = await c.sessionScopes.getByScope(pubId, CHANNEL_SCOPE);
+      expect(scope?.status).toBe("active");
+    });
+
+    it("drops member_joined_channel for non-bot users", async () => {
+      const out = await deliver(
+        memberJoinedChannelPayload({ channel: CHANNEL, eventId: "Ev_J2", user: "U0USER" }),
+      );
+      expect(out).toMatchObject({ handled: false, reason: "non_bot_member_joined" });
+      expect(c.sessions.created).toHaveLength(0);
+    });
+  });
+
+  // ─── member_left_channel + channel_archive (close_session) ───────────
+
+  describe("close_session lifecycle", () => {
+    beforeEach(async () => {
+      // Pre-seed an active channel-session for the close-path tests.
+      await c.sessionScopes.insert({
+        tenantId: "tnt_a",
+        publicationId: pubId,
+        scopeKey: CHANNEL_SCOPE,
+        sessionId: "sess_channel",
+        status: "active",
+        createdAt: c.clock.nowMs(),
+      });
+    });
+
+    it("member_left_channel for bot closes channel-session and emits session_closed signal", async () => {
+      const out = await deliver(
+        memberLeftChannelPayload({ channel: CHANNEL, eventId: "Ev_L1", user: BOT_USER_ID }),
+      );
+      expect(out.handled).toBe(true);
+      await out.deferredWork!();
+      const scope = await c.sessionScopes.getByScope(pubId, CHANNEL_SCOPE);
+      expect(scope?.status).toBe("completed");
+      expect(c.sessions.resumed).toHaveLength(1);
+      const text = (c.sessions.resumed[0].event.content[0] as { text: string }).text;
+      expect(text).toContain(`<oma_signal kind="session_closed">`);
+    });
+
+    it("drops member_left_channel for non-bot users", async () => {
+      const out = await deliver(
+        memberLeftChannelPayload({ channel: CHANNEL, eventId: "Ev_L2", user: "U0USER" }),
+      );
+      expect(out).toMatchObject({ handled: false, reason: "non_bot_member_left" });
+      expect(c.sessions.resumed).toHaveLength(0);
+    });
+
+    it("channel_archive closes the active channel-session", async () => {
+      const out = await deliver(
+        channelLifecyclePayload({ type: "channel_archive", channel: CHANNEL, eventId: "Ev_A1" }),
+      );
+      expect(out.handled).toBe(true);
+      await out.deferredWork!();
+      const scope = await c.sessionScopes.getByScope(pubId, CHANNEL_SCOPE);
+      expect(scope?.status).toBe("completed");
+    });
+
+    it("channel_archive drops if no active session for the channel", async () => {
+      // No active session for C0OTHER.
+      const out = await deliver(
+        channelLifecyclePayload({ type: "channel_archive", channel: "C0OTHER", eventId: "Ev_A2" }),
+      );
+      expect(out).toMatchObject({ handled: false, reason: "no_active_channel_session" });
+    });
+  });
+
+  // ─── channel_unarchive (reopen_session) ──────────────────────────────
+
+  describe("channel_unarchive", () => {
+    it("reopens a previously-completed channel-session", async () => {
+      await c.sessionScopes.insert({
+        tenantId: "tnt_a",
+        publicationId: pubId,
+        scopeKey: CHANNEL_SCOPE,
+        sessionId: "sess_channel",
+        status: "completed",
+        createdAt: c.clock.nowMs(),
+      });
+      const out = await deliver(
+        channelLifecyclePayload({ type: "channel_unarchive", channel: CHANNEL, eventId: "Ev_U1" }),
+      );
+      expect(out.handled).toBe(true);
+      await out.deferredWork!();
+      const scope = await c.sessionScopes.getByScope(pubId, CHANNEL_SCOPE);
+      expect(scope?.status).toBe("active");
+      expect(c.sessions.resumed).toHaveLength(1);
+      const text = (c.sessions.resumed[0].event.content[0] as { text: string }).text;
+      expect(text).toContain(`<oma_signal kind="joined_channel">`);
+      expect(text).toContain("added back to");
+    });
+
+    it("drops channel_unarchive when no prior session exists", async () => {
+      const out = await deliver(
+        channelLifecyclePayload({ type: "channel_unarchive", channel: CHANNEL, eventId: "Ev_U2" }),
+      );
+      expect(out).toMatchObject({ handled: false, reason: "no_prior_channel_session" });
+    });
+  });
+
+  // ─── channel_rename (metadata_only) ──────────────────────────────────
+
+  describe("channel_rename", () => {
+    it("updates cached channel_name without waking the agent", async () => {
+      await c.sessionScopes.insert({
+        tenantId: "tnt_a",
+        publicationId: pubId,
+        scopeKey: CHANNEL_SCOPE,
+        sessionId: "sess_channel",
+        status: "active",
+        createdAt: c.clock.nowMs(),
+      });
+      const out = await deliver(
+        channelRenamePayload({ channelId: CHANNEL, newName: "engineering-v2", eventId: "Ev_REN" }),
+      );
+      expect(out).toMatchObject({ handled: true, reason: "metadata_only" });
+      expect(out.deferredWork).toBeUndefined();
+      expect(c.sessions.resumed).toHaveLength(0);
+      expect(c.sessions.created).toHaveLength(0);
+      const scope = await c.sessionScopes.getByScope(pubId, CHANNEL_SCOPE);
+      expect(scope?.channelName).toBe("engineering-v2");
+    });
+
+    it("drops channel_rename when no channel session exists", async () => {
+      const out = await deliver(
+        channelRenamePayload({ channelId: CHANNEL, newName: "renamed", eventId: "Ev_REN2" }),
+      );
+      expect(out).toMatchObject({ handled: false, reason: "no_channel_session" });
+    });
+  });
+
+  // ─── scan_arm (top-level message debounce) ───────────────────────────
+
+  describe("scan_arm debounce", () => {
+    beforeEach(async () => {
+      await c.sessionScopes.insert({
+        tenantId: "tnt_a",
+        publicationId: pubId,
+        scopeKey: CHANNEL_SCOPE,
+        sessionId: "sess_channel",
+        status: "active",
+        createdAt: c.clock.nowMs(),
+      });
+    });
+
+    it("first top-level message arms scan and resumes with channel_scan_armed signal", async () => {
+      const out = await deliver(
+        messagePayload({
+          channel: CHANNEL,
+          ts: "1700000010.000100",
+          eventId: "Ev_M1",
+          text: "anyone seen this stack trace?",
+        }),
+      );
+      expect(out.handled).toBe(true);
+      await out.deferredWork!();
+      expect(c.sessions.resumed).toHaveLength(1);
+      const text = (c.sessions.resumed[0].event.content[0] as { text: string }).text;
+      expect(text).toContain(`<oma_signal kind="channel_scan_armed">`);
+      expect(text).toContain("scheduleWakeup");
+      const scope = await c.sessionScopes.getByScope(pubId, CHANNEL_SCOPE);
+      expect(scope?.pendingScanUntil).not.toBeNull();
+    });
+
+    it("second top-level message inside debounce window throttles silently", async () => {
+      // First arm.
+      const first = await deliver(
+        messagePayload({ channel: CHANNEL, ts: "1700000010.000100", eventId: "Ev_M1" }),
+      );
+      await first.deferredWork!();
+      // Second within window — should not resume again.
+      const out = await deliver(
+        messagePayload({ channel: CHANNEL, ts: "1700000015.000100", eventId: "Ev_M2" }),
+      );
+      expect(out.handled).toBe(true);
+      await out.deferredWork!();
+      // Only the first message woke the agent.
+      expect(c.sessions.resumed).toHaveLength(1);
+      // The second's webhook event row carries the throttle reason.
+      // (Handled via attachError — surfaces as a soft drop reason in logs.)
+    });
+
+    it("re-arms after pending_scan_until lapses", async () => {
+      const first = await deliver(
+        messagePayload({ channel: CHANNEL, ts: "1700000010.000100", eventId: "Ev_M1" }),
+      );
+      await first.deferredWork!();
+      // Advance past the 90s debounce window.
+      c.clock.set(1_700_000_000_000 + 91_000);
+      const second = await deliver(
+        messagePayload({ channel: CHANNEL, ts: "1700000091.000100", eventId: "Ev_M2" }),
+      );
+      await second.deferredWork!();
+      expect(c.sessions.resumed).toHaveLength(2);
+    });
+  });
+
+  // ─── reaction_added on bot's own message ─────────────────────────────
+
+  describe("reactions on bot-authored messages", () => {
+    beforeEach(async () => {
+      await c.sessionScopes.insert({
+        tenantId: "tnt_a",
+        publicationId: pubId,
+        scopeKey: CHANNEL_SCOPE,
+        sessionId: "sess_channel",
+        status: "active",
+        createdAt: c.clock.nowMs(),
+      });
+    });
+
+    it("dispatches reaction_added on bot's message with reaction_on_bot_message signal", async () => {
+      const out = await deliver(
+        reactionPayload({
+          type: "reaction_added",
+          channel: CHANNEL,
+          itemTs: "1700000005.000100",
+          itemUser: BOT_USER_ID,
+          reaction: "white_check_mark",
+          eventId: "Ev_RX1",
+        }),
+      );
+      expect(out.handled).toBe(true);
+      await out.deferredWork!();
+      expect(c.sessions.resumed).toHaveLength(1);
+      const text = (c.sessions.resumed[0].event.content[0] as { text: string }).text;
+      expect(text).toContain(`<oma_signal kind="reaction_on_bot_message">`);
+      expect(text).toContain("white_check_mark");
+    });
+
+    it("dispatches reactions on non-bot messages too when per_channel session is active", async () => {
+      // Under per_channel, any reaction in a channel the bot inhabits is
+      // perceived — `treat agent like human`. Item_user comparison is
+      // unreliable because mcp.slack.com posts via user xoxp- token, so
+      // bot-authored messages report item_user as the installer not the bot.
+      const out = await deliver(
+        reactionPayload({
+          type: "reaction_added",
+          channel: CHANNEL,
+          itemTs: "1700000005.000100",
+          itemUser: "U0OTHER",
+          eventId: "Ev_RX2",
+        }),
+      );
+      expect(out.handled).toBe(true);
+      await out.deferredWork!();
+      expect(c.sessions.resumed).toHaveLength(1);
+      const text = (c.sessions.resumed[0].event.content[0] as { text: string }).text;
+      expect(text).toContain(`<oma_signal kind="reaction_on_bot_message">`);
+    });
+
+    it("drops reaction when no active per_channel session exists for the channel", async () => {
+      // Reaction in a channel where bot has no session (we don't observe
+      // channels we're not inhabiting).
+      const out = await deliver(
+        reactionPayload({
+          type: "reaction_added",
+          channel: "C0OTHER",
+          itemTs: "1700000005.000100",
+          itemUser: "U0OTHER",
+          eventId: "Ev_RX3",
+        }),
+      );
+      expect(out.handled).toBe(false);
+      expect(out.reason).toBe("reaction_not_on_bot_message");
+      expect(c.sessions.resumed).toHaveLength(0);
+    });
+  });
+
+  // ─── direct_invocation routing under per_channel ────────────────────
+
+  describe("direct invocation under per_channel", () => {
+    it("@mention in a per_channel publication routes to the channel-session (lazy create)", async () => {
+      // No pre-seeded scope — provider should lazy-create the channel-session
+      // when it sees a direct invocation in a channel it didn't bootstrap via
+      // member_joined_channel.
+      const out = await deliver(
+        appMentionPayload({
+          channel: CHANNEL,
+          ts: "1700000020.000100",
+          eventId: "Ev_M3",
+          text: `<@${BOT_USER_ID}> what's this channel for?`,
+        }),
+      );
+      expect(out.handled).toBe(true);
+      await out.deferredWork!();
+      expect(c.sessions.created).toHaveLength(1);
+      const scope = await c.sessionScopes.getByScope(pubId, CHANNEL_SCOPE);
+      expect(scope?.status).toBe("active");
+      // Lazy-created sessions get the joined_channel onboarding signal first,
+      // then a follow-up resume with the actual direct_invocation event.
+      expect(c.sessions.resumed).toHaveLength(1);
+      const followup = (c.sessions.resumed[0].event.content[0] as { text: string }).text;
+      expect(followup).toContain(`<oma_signal kind="direct_invocation"`);
+    });
+
+    it("@mention in an existing channel-session resumes (not creates)", async () => {
+      await c.sessionScopes.insert({
+        tenantId: "tnt_a",
+        publicationId: pubId,
+        scopeKey: CHANNEL_SCOPE,
+        sessionId: "sess_channel",
+        status: "active",
+        createdAt: c.clock.nowMs(),
+      });
+      const out = await deliver(
+        appMentionPayload({
+          channel: CHANNEL,
+          ts: "1700000020.000100",
+          eventId: "Ev_M4",
+          text: `<@${BOT_USER_ID}> hi`,
+        }),
+      );
+      expect(out.handled).toBe(true);
+      await out.deferredWork!();
+      expect(c.sessions.created).toHaveLength(0);
+      expect(c.sessions.resumed).toHaveLength(1);
+      expect(c.sessions.resumed[0].sessionId).toBe("sess_channel");
+    });
+  });
+});

--- a/test/unit/slack-provider-webhook.test.ts
+++ b/test/unit/slack-provider-webhook.test.ts
@@ -295,6 +295,113 @@ describe("SlackProvider — handleWebhook", () => {
     expect(out.reason).toBe("app_uninstalled");
   });
 
+  it("tokens_revoked closes all active channel sessions for the publication and clears their pending_scan_until, leaving other publications' sessions untouched", async () => {
+    // Two active per_channel sessions on the revoked publication, one with
+    // an armed scan watermark.
+    await c.sessionScopes.insert({
+      tenantId: "tnt_a",
+      publicationId: pubId,
+      scopeKey: "channel:C0CHAN_A",
+      sessionId: "sess-a",
+      status: "active",
+      createdAt: 1_700_000_000_000,
+      pendingScanUntil: 1_700_000_090_000,
+      lastScanAt: null,
+      channelName: "general",
+    });
+    await c.sessionScopes.insert({
+      tenantId: "tnt_a",
+      publicationId: pubId,
+      scopeKey: "channel:C0CHAN_B",
+      sessionId: "sess-b",
+      status: "active",
+      createdAt: 1_700_000_000_000,
+      pendingScanUntil: null,
+      lastScanAt: null,
+      channelName: "random",
+    });
+    // An unrelated publication's session — must NOT be touched.
+    await c.sessionScopes.insert({
+      tenantId: "tnt_other",
+      publicationId: "pub_other",
+      scopeKey: "channel:C0OTHER",
+      sessionId: "sess-other",
+      status: "active",
+      createdAt: 1_700_000_000_000,
+      pendingScanUntil: 1_700_000_090_000,
+      lastScanAt: null,
+      channelName: null,
+    });
+
+    const body = JSON.stringify({
+      type: "event_callback",
+      event_id: "Ev_REVOKE_CLEANUP",
+      event_time: 1_700_000_000,
+      team_id: "T07TEAM",
+      api_app_id: "A07APP",
+      event: {
+        type: "tokens_revoked",
+        tokens: { oauth: ["U07USER"], bot: ["U07BOT"] },
+      },
+    });
+    const ts = "1700000000";
+    const out = await provider.handleWebhook({
+      providerId: "slack",
+      installationId: appId,
+      deliveryId: null,
+      headers: { "x-slack-signature": validSig(body, ts), "x-slack-request-timestamp": ts },
+      rawBody: body,
+    });
+    expect(out.handled).toBe(true);
+
+    const a = await c.sessionScopes.getByScope(pubId, "channel:C0CHAN_A");
+    expect(a?.status).toBe("completed");
+    expect(a?.pendingScanUntil).toBeNull();
+    const b = await c.sessionScopes.getByScope(pubId, "channel:C0CHAN_B");
+    expect(b?.status).toBe("completed");
+    expect(b?.pendingScanUntil).toBeNull();
+
+    const other = await c.sessionScopes.getByScope("pub_other", "channel:C0OTHER");
+    expect(other?.status).toBe("active");
+    expect(other?.pendingScanUntil).toBe(1_700_000_090_000);
+  });
+
+  it("app_uninstalled closes all active channel sessions for the publication", async () => {
+    await c.sessionScopes.insert({
+      tenantId: "tnt_a",
+      publicationId: pubId,
+      scopeKey: "channel:C0CHAN_X",
+      sessionId: "sess-x",
+      status: "active",
+      createdAt: 1_700_000_000_000,
+      pendingScanUntil: 1_700_000_090_000,
+      lastScanAt: null,
+      channelName: null,
+    });
+
+    const body = JSON.stringify({
+      type: "event_callback",
+      event_id: "Ev_UNINSTALL_CLEANUP",
+      event_time: 1_700_000_000,
+      team_id: "T07TEAM",
+      api_app_id: "A07APP",
+      event: { type: "app_uninstalled" },
+    });
+    const ts = "1700000000";
+    const out = await provider.handleWebhook({
+      providerId: "slack",
+      installationId: appId,
+      deliveryId: null,
+      headers: { "x-slack-signature": validSig(body, ts), "x-slack-request-timestamp": ts },
+      rawBody: body,
+    });
+    expect(out.handled).toBe(true);
+
+    const x = await c.sessionScopes.getByScope(pubId, "channel:C0CHAN_X");
+    expect(x?.status).toBe("completed");
+    expect(x?.pendingScanUntil).toBeNull();
+  });
+
   it("drops the redundant `message` Slack delivers alongside `app_mention`", async () => {
     // Slack always sends BOTH message.channels and app_mention for an @-bot
     // post in a channel. They reference the same Slack message ts. The

--- a/test/unit/slack-test-helpers.ts
+++ b/test/unit/slack-test-helpers.ts
@@ -7,7 +7,10 @@
 // scenario.
 
 import { SlackProvider, type SlackContainer } from "../../packages/slack/src/provider";
-import type { SlackInstallationRepo } from "../../packages/slack/src/ports";
+import type {
+  SlackInstallationRepo,
+  SlackSessionScopeRepo,
+} from "../../packages/slack/src/ports";
 import {
   buildFakeContainer,
   InMemoryInstallationRepo,
@@ -18,6 +21,7 @@ import {
   DEFAULT_SLACK_BOT_SCOPES,
   DEFAULT_SLACK_USER_SCOPES,
 } from "../../packages/slack/src/config";
+import type { SessionGranularity } from "../../packages/integrations-core/src/domain";
 
 /**
  * Slack-flavored InMemoryInstallationRepo: extends the base with the two
@@ -48,24 +52,115 @@ export class FakeSlackInstallationRepo
   }
 }
 
-export interface FakeSlackBundle extends Omit<FakeContainer, "installations"> {
+/**
+ * Slack-flavored in-memory SessionScopeRepo with per_channel methods
+ * (armPendingScan / clearPendingScan / updateChannelName) on top of the base
+ * SessionScopeRepo contract. Doesn't extend InMemorySessionScopeRepo because
+ * the base stores plain SessionScope rows that lose the per_channel fields
+ * across updateStatus; cleaner to own the Map directly.
+ */
+export class FakeSlackSessionScopeRepo implements SlackSessionScopeRepo {
+  private rows = new Map<
+    string,
+    import("../../packages/integrations-core/src/domain").SessionScope
+  >();
+
+  private key(publicationId: string, scopeKey: string): string {
+    return `${publicationId}:${scopeKey}`;
+  }
+
+  async getByScope(
+    publicationId: string,
+    scopeKey: string,
+  ): Promise<import("../../packages/integrations-core/src/domain").SessionScope | null> {
+    return this.rows.get(this.key(publicationId, scopeKey)) ?? null;
+  }
+
+  async insert(
+    row: import("../../packages/integrations-core/src/domain").SessionScope,
+  ): Promise<boolean> {
+    const k = this.key(row.publicationId, row.scopeKey);
+    if (this.rows.has(k)) return false;
+    this.rows.set(k, row);
+    return true;
+  }
+
+  async updateStatus(
+    publicationId: string,
+    scopeKey: string,
+    status: import("../../packages/integrations-core/src/domain").SessionScopeStatus,
+  ): Promise<void> {
+    const k = this.key(publicationId, scopeKey);
+    const row = this.rows.get(k);
+    if (row) this.rows.set(k, { ...row, status });
+  }
+
+  async listActive(
+    publicationId: string,
+  ): Promise<readonly import("../../packages/integrations-core/src/domain").SessionScope[]> {
+    return [...this.rows.values()].filter(
+      (r) => r.publicationId === publicationId && r.status === "active",
+    );
+  }
+
+  async armPendingScan(
+    publicationId: string,
+    scopeKey: string,
+    until: number,
+    now: number,
+  ): Promise<{ armed: boolean; currentUntil: number | null }> {
+    const k = this.key(publicationId, scopeKey);
+    const row = this.rows.get(k);
+    if (!row) return { armed: false, currentUntil: null };
+    const current = row.pendingScanUntil ?? null;
+    if (current === null || current <= now) {
+      this.rows.set(k, { ...row, pendingScanUntil: until });
+      return { armed: true, currentUntil: null };
+    }
+    return { armed: false, currentUntil: current };
+  }
+
+  async clearPendingScan(publicationId: string, scopeKey: string): Promise<void> {
+    const k = this.key(publicationId, scopeKey);
+    const row = this.rows.get(k);
+    if (row) this.rows.set(k, { ...row, pendingScanUntil: null });
+  }
+
+  async updateChannelName(
+    publicationId: string,
+    scopeKey: string,
+    channelName: string,
+  ): Promise<void> {
+    const k = this.key(publicationId, scopeKey);
+    const row = this.rows.get(k);
+    if (row) this.rows.set(k, { ...row, channelName });
+  }
+}
+
+export interface FakeSlackBundle extends Omit<FakeContainer, "installations" | "sessionScopes"> {
   installations: FakeSlackInstallationRepo;
+  sessionScopes: FakeSlackSessionScopeRepo;
 }
 
 export function buildFakeSlackContainer(): FakeSlackBundle {
   const base = buildFakeContainer();
-  return { ...base, installations: new FakeSlackInstallationRepo(base.clock) };
+  return {
+    ...base,
+    installations: new FakeSlackInstallationRepo(base.clock),
+    sessionScopes: new FakeSlackSessionScopeRepo(),
+  };
 }
 
 export function makeSlackProvider(
   c: FakeSlackBundle,
-  overrides?: Partial<{ gatewayOrigin: string }>,
+  overrides?: Partial<{ gatewayOrigin: string; defaultSessionGranularity: SessionGranularity }>,
 ): SlackProvider {
   return new SlackProvider(c as SlackContainer, {
     gatewayOrigin: overrides?.gatewayOrigin ?? "https://gw",
     botScopes: DEFAULT_SLACK_BOT_SCOPES,
     userScopes: DEFAULT_SLACK_USER_SCOPES,
     defaultCapabilities: ALL_SLACK_CAPABILITIES,
+    defaultSessionGranularity: overrides?.defaultSessionGranularity,
   });
 }
 
@@ -106,7 +201,7 @@ export function tokenResponseBody(opts?: {
  */
 export async function seedDedicatedSlackPublication(
   c: FakeSlackBundle,
-  opts: { signingSecret: string },
+  opts: { signingSecret: string; sessionGranularity?: SessionGranularity },
 ): Promise<{ instId: string; pubId: string; appId: string }> {
   const app = await c.apps.insert({
     publicationId: null,
@@ -137,7 +232,7 @@ export async function seedDedicatedSlackPublication(
     status: "live",
     persona: { name: "Triage", avatarUrl: null },
     capabilities: new Set(),
-    sessionGranularity: "per_thread",
+    sessionGranularity: opts.sessionGranularity ?? "per_thread",
   });
   await c.apps.setPublicationId(app.id, pub.id);
   return { instId: inst.id, pubId: pub.id, appId: app.id };
@@ -207,6 +302,121 @@ export function messagePayload(opts: {
       user: opts.user ?? "U0USER",
       text: opts.text ?? "hello",
       event_ts: opts.ts,
+    },
+  });
+}
+
+/** member_joined_channel envelope. user defaults to bot id. */
+export function memberJoinedChannelPayload(opts: {
+  channel: string;
+  eventId: string;
+  user?: string;
+}): string {
+  return JSON.stringify({
+    type: "event_callback",
+    event_id: opts.eventId,
+    event_time: 1_700_000_000,
+    team_id: "T07TEAM",
+    api_app_id: "A07APP",
+    event: {
+      type: "member_joined_channel",
+      channel: opts.channel,
+      user: opts.user ?? "U07BOT",
+      event_ts: "1700000000.000100",
+    },
+  });
+}
+
+/** member_left_channel envelope. */
+export function memberLeftChannelPayload(opts: {
+  channel: string;
+  eventId: string;
+  user?: string;
+}): string {
+  return JSON.stringify({
+    type: "event_callback",
+    event_id: opts.eventId,
+    event_time: 1_700_000_000,
+    team_id: "T07TEAM",
+    api_app_id: "A07APP",
+    event: {
+      type: "member_left_channel",
+      channel: opts.channel,
+      user: opts.user ?? "U07BOT",
+      event_ts: "1700000000.000200",
+    },
+  });
+}
+
+/** channel_archive / channel_unarchive envelope. */
+export function channelLifecyclePayload(opts: {
+  type: "channel_archive" | "channel_unarchive";
+  channel: string;
+  eventId: string;
+  user?: string;
+}): string {
+  return JSON.stringify({
+    type: "event_callback",
+    event_id: opts.eventId,
+    event_time: 1_700_000_000,
+    team_id: "T07TEAM",
+    api_app_id: "A07APP",
+    event: {
+      type: opts.type,
+      channel: opts.channel,
+      user: opts.user ?? "U07ADMIN",
+      event_ts: "1700000000.000300",
+    },
+  });
+}
+
+/** channel_rename envelope — channel field is `{ id, name }`. */
+export function channelRenamePayload(opts: {
+  channelId: string;
+  newName: string;
+  eventId: string;
+}): string {
+  return JSON.stringify({
+    type: "event_callback",
+    event_id: opts.eventId,
+    event_time: 1_700_000_000,
+    team_id: "T07TEAM",
+    api_app_id: "A07APP",
+    event: {
+      type: "channel_rename",
+      channel: { id: opts.channelId, name: opts.newName, created: 1_700_000_000 },
+      event_ts: "1700000000.000400",
+    },
+  });
+}
+
+/** reaction_added / reaction_removed envelope. */
+export function reactionPayload(opts: {
+  type: "reaction_added" | "reaction_removed";
+  channel: string;
+  itemTs: string;
+  itemUser?: string;
+  reaction?: string;
+  eventId: string;
+  user?: string;
+}): string {
+  return JSON.stringify({
+    type: "event_callback",
+    event_id: opts.eventId,
+    event_time: 1_700_000_000,
+    team_id: "T07TEAM",
+    api_app_id: "A07APP",
+    event: {
+      type: opts.type,
+      user: opts.user ?? "U0USER",
+      reaction: opts.reaction ?? "thumbsup",
+      item: {
+        type: "message",
+        channel: opts.channel,
+        ts: opts.itemTs,
+      },
+      item_user: opts.itemUser ?? "U07BOT",
+      event_ts: "1700000000.000500",
     },
   });
 }

--- a/test/unit/slack-test-helpers.ts
+++ b/test/unit/slack-test-helpers.ts
@@ -135,6 +135,14 @@ export class FakeSlackSessionScopeRepo implements SlackSessionScopeRepo {
     const row = this.rows.get(k);
     if (row) this.rows.set(k, { ...row, channelName });
   }
+
+  async closeAllForPublication(publicationId: string): Promise<void> {
+    for (const [k, row] of this.rows.entries()) {
+      if (row.publicationId === publicationId && row.status === "active") {
+        this.rows.set(k, { ...row, status: "completed", pendingScanUntil: null });
+      }
+    }
+  }
 }
 
 export interface FakeSlackBundle extends Omit<FakeContainer, "installations" | "sessionScopes"> {

--- a/test/unit/slack-webhook-parse.test.ts
+++ b/test/unit/slack-webhook-parse.test.ts
@@ -208,4 +208,184 @@ describe("Slack webhook parse", () => {
       expect(event).toBeNull();
     });
   });
+
+  describe("isTopLevel — per_channel scan-arm gate", () => {
+    it("flags top-level message (no thread_ts) as isTopLevel", () => {
+      const event = parseWebhook({
+        type: "event_callback",
+        event_id: "Ev_TOP",
+        event_time: 1_700_000_000,
+        team_id: "T",
+        api_app_id: "A",
+        event: {
+          type: "message",
+          channel: "C0CHAN",
+          ts: "1700000000.000100",
+          channel_type: "channel",
+          user: "U0USER",
+          text: "hi",
+        },
+      });
+      expect(event?.isTopLevel).toBe(true);
+    });
+
+    it("flags thread reply (thread_ts != ts) as NOT isTopLevel", () => {
+      const event = parseWebhook({
+        type: "event_callback",
+        event_id: "Ev_REPLY",
+        event_time: 1_700_000_000,
+        team_id: "T",
+        api_app_id: "A",
+        event: {
+          type: "message",
+          channel: "C0CHAN",
+          ts: "1700000005.000100",
+          thread_ts: "1700000000.000100",
+          channel_type: "channel",
+          user: "U0USER",
+          text: "follow-up",
+        },
+      });
+      expect(event?.isTopLevel).toBe(false);
+    });
+
+    it("flags message_changed subtype as NOT isTopLevel (don't re-arm on edits)", () => {
+      const event = parseWebhook({
+        type: "event_callback",
+        event_id: "Ev_EDIT",
+        event_time: 1_700_000_000,
+        team_id: "T",
+        api_app_id: "A",
+        event: {
+          type: "message",
+          subtype: "message_changed",
+          channel: "C0CHAN",
+          ts: "1700000010.000100",
+          channel_type: "channel",
+          user: "U0USER",
+          text: "edited",
+        },
+      });
+      expect(event?.isTopLevel).toBe(false);
+    });
+  });
+
+  describe("member_joined_channel / member_left_channel", () => {
+    it("parses member_joined_channel with user + channel", () => {
+      const event = parseWebhook({
+        type: "event_callback",
+        event_id: "Ev_JOIN",
+        event_time: 1_700_000_000,
+        team_id: "T07TEAM",
+        api_app_id: "A07APP",
+        event: {
+          type: "member_joined_channel",
+          channel: "C0CHAN",
+          user: "U07BOT",
+          event_ts: "1700000000.000123",
+        },
+      });
+      expect(event?.kind).toBe("member_joined_channel");
+      expect(event?.channelId).toBe("C0CHAN");
+      expect(event?.userId).toBe("U07BOT");
+      expect(event?.scopeKey).toBeNull();
+      expect(event?.isTopLevel).toBe(false);
+    });
+
+    it("parses member_left_channel symmetrically", () => {
+      const event = parseWebhook({
+        type: "event_callback",
+        event_id: "Ev_LEFT",
+        event_time: 1_700_000_000,
+        team_id: "T07TEAM",
+        api_app_id: "A07APP",
+        event: {
+          type: "member_left_channel",
+          channel: "C0CHAN",
+          user: "U07BOT",
+        },
+      });
+      expect(event?.kind).toBe("member_left_channel");
+      expect(event?.channelId).toBe("C0CHAN");
+      expect(event?.userId).toBe("U07BOT");
+    });
+  });
+
+  describe("channel lifecycle (archive / unarchive / rename)", () => {
+    it("parses channel_archive", () => {
+      const event = parseWebhook({
+        type: "event_callback",
+        event_id: "Ev_ARCH",
+        event_time: 1_700_000_000,
+        team_id: "T",
+        api_app_id: "A",
+        event: { type: "channel_archive", channel: "C0CHAN", user: "U07ADMIN" },
+      });
+      expect(event?.kind).toBe("channel_archive");
+      expect(event?.channelId).toBe("C0CHAN");
+      expect(event?.userId).toBe("U07ADMIN");
+    });
+
+    it("parses channel_rename with nested channel.{id,name}", () => {
+      const event = parseWebhook({
+        type: "event_callback",
+        event_id: "Ev_REN",
+        event_time: 1_700_000_000,
+        team_id: "T",
+        api_app_id: "A",
+        event: {
+          type: "channel_rename",
+          channel: { id: "C0CHAN", name: "engineering-v2", created: 1 },
+        },
+      });
+      expect(event?.kind).toBe("channel_rename");
+      expect(event?.channelId).toBe("C0CHAN");
+      expect(event?.channelName).toBe("engineering-v2");
+    });
+  });
+
+  describe("reaction_added / reaction_removed", () => {
+    it("parses reaction_added with item_user, reaction name, item.ts/channel", () => {
+      const event = parseWebhook({
+        type: "event_callback",
+        event_id: "Ev_RX",
+        event_time: 1_700_000_000,
+        team_id: "T",
+        api_app_id: "A",
+        event: {
+          type: "reaction_added",
+          user: "U0USER",
+          reaction: "white_check_mark",
+          item: { type: "message", channel: "C0CHAN", ts: "1700000000.000999" },
+          item_user: "U07BOT",
+          event_ts: "1700000005.000111",
+        },
+      });
+      expect(event?.kind).toBe("reaction_added");
+      expect(event?.channelId).toBe("C0CHAN");
+      expect(event?.userId).toBe("U0USER");
+      expect(event?.itemUserId).toBe("U07BOT");
+      expect(event?.itemTs).toBe("1700000000.000999");
+      expect(event?.reactionName).toBe("white_check_mark");
+    });
+
+    it("parses reaction_removed symmetrically", () => {
+      const event = parseWebhook({
+        type: "event_callback",
+        event_id: "Ev_RXRM",
+        event_time: 1_700_000_000,
+        team_id: "T",
+        api_app_id: "A",
+        event: {
+          type: "reaction_removed",
+          user: "U0USER",
+          reaction: "thumbsdown",
+          item: { type: "message", channel: "C0CHAN", ts: "1700000000.000888" },
+          item_user: "U07BOT",
+        },
+      });
+      expect(event?.kind).toBe("reaction_removed");
+      expect(event?.reactionName).toBe("thumbsdown");
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Adds `per_channel` session granularity to Slack publications. Bot becomes a "channel-scoped colleague" with one long-lived session per channel — proactive within channels it's a member of, debounce-armed on top-level activity, signal-aware lifecycle. Channel membership is the gate.

End-to-end verified on staging against a real Slack workspace (Triage Bot in `aa` workspace, channel #a-bc-d).

## Architecture

- **Trigger model**: membership = the gate. Bot acts proactively only in channels it's been added to. Top-level messages debounce-armed via `pending_scan_until` watermark; reactions / direct mentions / lifecycle events route to the channel-session.
- **Single model**: no cheap classifier — the same agent handles cheap "scan-arm received → schedule wakeup → end turn" turns and full engagement turns. Determinism comes from the D1 column, not the prompt.
- **Signal framing**: signals wrapped in `<oma_signal>` XML so the agent treats them as runtime telemetry, not user content. `channel_scan_armed` is mandatory-silent (scheduleWakeup + end turn); `direct_invocation` explicitly tells the agent to ignore prior signal framing in its reply.
- **Lifecycle parity**: `member_joined_channel` (joiner == bot) creates session; `member_left_channel` / `channel_archive` close it (with final `session_closed` signal so agent can cancel scheduled wakeups); `channel_unarchive` reopens; `channel_rename` updates cached `channel_name` without waking the agent.
- **Reactions**: in per_channel mode, dispatched if there's an active session in the channel (not gated on `item_user == bot_user_id` — that comparison is unreliable because mcp.slack.com posts via the user xoxp- token, so Slack reports `item_user` as the installer, not the bot user).

## Schema

`apps/main/migrations/0012_slack_per_channel.sql` — adds three nullable columns (`pending_scan_until`, `last_scan_at`, `channel_name`) to `slack_thread_sessions`. Existing per_thread rows unaffected. Already applied to staging D1.

## Manifest

Adds 7 new events (member_joined/left_channel, channel_archive/unarchive/rename, reaction_added/removed) + 2 new scopes (channels:read, groups:read). Existing installs need re-OAuth to receive channel-membership events; reaction events work without re-OAuth (reactions:read was already granted).

## Test plan

- [x] Unit: 59 tests across `slack-provider-per-channel.test.ts` (new), `slack-webhook-parse.test.ts`, `slack-provider-webhook.test.ts`, `slack-provider-a1.test.ts`. Covers parse for all 7 new event kinds, classifyDispatch rules (lifecycle / scan_arm / reaction / direct_invocation), debounce throttle, race conditions, lazy bootstrap.
- [x] E2E on staging: real Slack webhook → integrations worker → D1 → agent behavior. Verified scan_arm + throttle, member_joined dispatch, reactions in channel, direct_invocation routing to channel-session, scheduleWakeup-driven scan, agent stays silent with new prompt framing.
- [x] Typecheck passes (`pnpm typecheck`).

## Open issues (not in this PR)

- Slack didn't reliably deliver `member_left_channel` for bot self-kick on staging even after re-OAuth — needs separate investigation. Architecture path is unit-tested and works when the event is delivered.
- `tokens_revoked` / `app_uninstalled` handlers are still no-op (preexisting tech debt, plan called out as follow-up).
- Per_channel sessions can grow unbounded over time. Compaction works but Slack channels are chattier than Linear issues — may need rotation policy after observing real-world traffic.
- Bot's first reply to direct_invocation in a brand-new lazy-bootstrapped session can lag (it does conversations.info + history first). Not a bug, but UX could be polished with a "I'm still getting up to speed" interim message.

## Deploy notes

Already deployed to staging (`managed-agents-integrations-staging` version `35521cb4-4214-4453-993c-76af90ebcb22`). Triage Bot publication in workspace `aa` flipped to `per_channel` for testing; existing per_thread publications continue unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)