### PR TITLE
feat(skills): zip upload + zip-bomb defense

### DIFF
--- a/apps/console/src/lib/api.ts
+++ b/apps/console/src/lib/api.ts
@@ -45,13 +45,17 @@ export function useApi() {
     init?: RequestInit
   ): Promise<T> {
     const activeTenant = getActiveTenantId();
+    // Don't auto-set JSON content-type for FormData — the browser must add
+    // multipart boundaries itself, and a manually set content-type without
+    // the boundary breaks parsing on the server.
+    const isFormData = init?.body instanceof FormData;
     let res: Response;
     try {
       res = await fetch(`${BASE}${path}`, {
         ...init,
         credentials: "include",
         headers: {
-          ...(init?.body ? { "content-type": "application/json" } : {}),
+          ...(init?.body && !isFormData ? { "content-type": "application/json" } : {}),
           // Pin the workspace for this request. Backend validates membership;
           // a stale value (deleted tenant, removed membership) yields 403 and
           // the sidebar's catch-and-retry path clears + reloads.

--- a/apps/console/src/pages/SkillsList.tsx
+++ b/apps/console/src/pages/SkillsList.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useApi } from "../lib/api";
 import { Modal } from "../components/Modal";
 import { Button } from "../components/Button";
@@ -18,6 +18,7 @@ interface Skill {
 interface SkillFile {
   filename: string;
   content: string;
+  encoding?: "utf8" | "base64";
 }
 
 interface VersionSummary {
@@ -33,21 +34,26 @@ interface VersionDetail {
 
 /* ---------- constants ---------- */
 
-const SKILL_TEMPLATE = `---
-name: my-skill
-description: Brief description of what this skill does and when to use it.
----
+// Mirrors the default UPLOAD_MAX_BYTES on the server (apps/main/src/quotas.ts).
+// Self-hosters who raised the server limit will lose this client-side
+// pre-rejection but the server will still enforce; that's an acceptable
+// degradation for an unusual config.
+const MAX_UPLOAD_BYTES = 25 * 1024 * 1024;
 
-# My Custom Skill
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  return `${(n / (1024 * 1024)).toFixed(1)} MB`;
+}
 
-## Instructions
-
-[Step-by-step guidance for Claude to follow]
-
-## Examples
-
-[Concrete examples of using this skill]
-`;
+function isZipFile(file: File): boolean {
+  const name = file.name.toLowerCase();
+  return (
+    name.endsWith(".zip") ||
+    file.type === "application/zip" ||
+    file.type === "application/x-zip-compressed"
+  );
+}
 
 /* ---------- component ---------- */
 
@@ -61,9 +67,11 @@ export function SkillsList() {
   /* create dialog */
   const [showCreate, setShowCreate] = useState(false);
   const [createTitle, setCreateTitle] = useState("");
-  const [createSkillMd, setCreateSkillMd] = useState(SKILL_TEMPLATE);
-  const [createFiles, setCreateFiles] = useState<SkillFile[]>([]);
+  const [createZip, setCreateZip] = useState<File | null>(null);
+  const [createUploading, setCreateUploading] = useState(false);
+  const [createDragOver, setCreateDragOver] = useState(false);
   const [createError, setCreateError] = useState("");
+  const createInputRef = useRef<HTMLInputElement>(null);
 
   /* detail dialog */
   const [detail, setDetail] = useState<Skill | null>(null);
@@ -73,9 +81,11 @@ export function SkillsList() {
 
   /* new version sub-form inside detail */
   const [showNewVersion, setShowNewVersion] = useState(false);
-  const [nvSkillMd, setNvSkillMd] = useState("");
-  const [nvFiles, setNvFiles] = useState<SkillFile[]>([]);
+  const [nvZip, setNvZip] = useState<File | null>(null);
+  const [nvUploading, setNvUploading] = useState(false);
+  const [nvDragOver, setNvDragOver] = useState(false);
   const [nvError, setNvError] = useState("");
+  const nvInputRef = useRef<HTMLInputElement>(null);
 
   /* clawhub install */
   const [showClawHub, setShowClawHub] = useState(false);
@@ -103,27 +113,49 @@ export function SkillsList() {
 
   const resetCreate = () => {
     setCreateTitle("");
-    setCreateSkillMd(SKILL_TEMPLATE);
-    setCreateFiles([]);
+    setCreateZip(null);
     setCreateError("");
+    setCreateDragOver(false);
+    if (createInputRef.current) createInputRef.current.value = "";
+  };
+
+  // Validate file synchronously and set state. Returns true on success
+  // so callers can know whether to clear the surrounding drop-zone state.
+  const acceptCreateZip = (file: File): boolean => {
+    if (!isZipFile(file)) {
+      setCreateError(`"${file.name}" is not a .zip file`);
+      return false;
+    }
+    if (file.size > MAX_UPLOAD_BYTES) {
+      setCreateError(
+        `Zip is ${formatBytes(file.size)}, exceeds the ${formatBytes(MAX_UPLOAD_BYTES)} upload limit`,
+      );
+      return false;
+    }
+    setCreateError("");
+    setCreateZip(file);
+    return true;
   };
 
   const doCreate = async () => {
+    if (!createZip) return;
     setCreateError("");
-    const files: SkillFile[] = [
-      { filename: "SKILL.md", content: createSkillMd },
-      ...createFiles,
-    ];
+    setCreateUploading(true);
     try {
-      await api("/v1/skills", {
-        method: "POST",
-        body: JSON.stringify({ display_title: createTitle, files }),
-      });
+      const fd = new FormData();
+      fd.append("file", createZip);
+      // Empty string here would override the server-side fallback to the
+      // SKILL.md frontmatter name; only send when the user actually typed
+      // something.
+      if (createTitle.trim()) fd.append("display_title", createTitle.trim());
+      await api("/v1/skills/upload", { method: "POST", body: fd });
       setShowCreate(false);
       resetCreate();
       load();
     } catch (e: any) {
-      setCreateError(e.message);
+      setCreateError(e?.message || "Upload failed");
+    } finally {
+      setCreateUploading(false);
     }
   };
 
@@ -134,6 +166,7 @@ export function SkillsList() {
     setDetailLoading(true);
     setShowNewVersion(false);
     setNvError("");
+    setNvZip(null);
     try {
       const [versionDetail, versionsRes] = await Promise.all([
         api<VersionDetail>(
@@ -155,38 +188,57 @@ export function SkillsList() {
     setDetailFiles([]);
     setDetailVersions([]);
     setShowNewVersion(false);
+    setNvZip(null);
+    setNvError("");
   };
 
   /* ---- new version ---- */
 
   const startNewVersion = () => {
-    /* pre-populate from current files */
-    const skillMdFile = detailFiles.find((f) => f.filename === "SKILL.md");
-    setNvSkillMd(skillMdFile?.content || SKILL_TEMPLATE);
-    setNvFiles(detailFiles.filter((f) => f.filename !== "SKILL.md"));
     setNvError("");
+    setNvZip(null);
+    setNvDragOver(false);
+    if (nvInputRef.current) nvInputRef.current.value = "";
     setShowNewVersion(true);
   };
 
-  const doNewVersion = async () => {
-    if (!detail) return;
+  const acceptNvZip = (file: File): boolean => {
+    if (!isZipFile(file)) {
+      setNvError(`"${file.name}" is not a .zip file`);
+      return false;
+    }
+    if (file.size > MAX_UPLOAD_BYTES) {
+      setNvError(
+        `Zip is ${formatBytes(file.size)}, exceeds the ${formatBytes(MAX_UPLOAD_BYTES)} upload limit`,
+      );
+      return false;
+    }
     setNvError("");
-    const files: SkillFile[] = [
-      { filename: "SKILL.md", content: nvSkillMd },
-      ...nvFiles,
-    ];
+    setNvZip(file);
+    return true;
+  };
+
+  const doNewVersion = async () => {
+    if (!detail || !nvZip) return;
+    setNvError("");
+    setNvUploading(true);
     try {
-      await api(`/v1/skills/${detail.id}/versions`, {
+      const fd = new FormData();
+      fd.append("file", nvZip);
+      await api(`/v1/skills/${detail.id}/versions/upload`, {
         method: "POST",
-        body: JSON.stringify({ files }),
+        body: fd,
       });
       setShowNewVersion(false);
+      setNvZip(null);
       /* refresh both the list and this detail */
       load();
       const refreshed = await api<Skill>(`/v1/skills/${detail.id}`);
       openDetail(refreshed);
     } catch (e: any) {
-      setNvError(e.message);
+      setNvError(e?.message || "Upload failed");
+    } finally {
+      setNvUploading(false);
     }
   };
 
@@ -338,8 +390,7 @@ export function SkillsList() {
             <div className="text-center py-12 text-fg-subtle border border-dashed border-border rounded-lg">
               <p className="text-sm mb-1">No custom skills yet</p>
               <p className="text-xs">
-                Create a skill with a SKILL.md file to give your agents domain
-                expertise.
+                Upload a skill folder as a .zip with SKILL.md at the root.
               </p>
             </div>
           ) : (
@@ -390,16 +441,18 @@ export function SkillsList() {
       <Modal
         open={showCreate}
         onClose={() => {
+          if (createUploading) return;
           setShowCreate(false);
           resetCreate();
         }}
-        title="New Custom Skill"
-        subtitle="Create a SKILL.md with YAML frontmatter and optional resource files."
-        maxWidth="max-w-2xl"
+        title="Upload Custom Skill"
+        subtitle="Upload an Anthropic-style skill folder packaged as a .zip."
+        maxWidth="max-w-xl"
         footer={
           <>
             <Button
               variant="ghost"
+              disabled={createUploading}
               onClick={() => {
                 setShowCreate(false);
                 resetCreate();
@@ -409,9 +462,11 @@ export function SkillsList() {
             </Button>
             <Button
               onClick={doCreate}
-              disabled={!createTitle || !createSkillMd.trim()}
+              disabled={!createZip || createUploading}
+              loading={createUploading}
+              loadingLabel="Uploading..."
             >
-              Create Skill
+              Upload
             </Button>
           </>
         }
@@ -423,95 +478,42 @@ export function SkillsList() {
             </div>
           )}
 
-          {/* Display Title */}
+          {/* Drop zone */}
+          <DropZone
+            file={createZip}
+            dragOver={createDragOver}
+            onDragOver={(over) => setCreateDragOver(over)}
+            onFile={(f) => acceptCreateZip(f)}
+            onClear={() => {
+              setCreateZip(null);
+              if (createInputRef.current) createInputRef.current.value = "";
+            }}
+            inputRef={createInputRef}
+            disabled={createUploading}
+          />
+
+          {/* Display Title (optional override) */}
           <div>
             <label className="text-sm text-fg-muted block mb-1">
-              Display Title
+              Display Title{" "}
+              <span className="text-fg-subtle">
+                (optional — falls back to SKILL.md <code>name</code>)
+              </span>
             </label>
             <input
               value={createTitle}
               onChange={(e) => setCreateTitle(e.target.value)}
               className={inputCls}
-              placeholder="My Custom Skill"
+              placeholder="Leave blank to use the skill's own name"
+              disabled={createUploading}
             />
           </div>
 
-          {/* SKILL.md */}
-          <div>
-            <label className="text-sm text-fg-muted block mb-1">
-              SKILL.md{" "}
-              <span className="text-fg-subtle">
-                (YAML frontmatter with name and description)
-              </span>
-            </label>
-            <textarea
-              value={createSkillMd}
-              onChange={(e) => setCreateSkillMd(e.target.value)}
-              rows={14}
-              className={`${inputCls} resize-none font-mono text-xs leading-relaxed`}
-            />
-          </div>
-
-          {/* Additional files */}
-          <div>
-            <div className="flex items-center justify-between mb-2">
-              <label className="text-sm text-fg-muted">
-                Additional Files{" "}
-                <span className="text-fg-subtle">
-                  ({createFiles.length})
-                </span>
-              </label>
-              <button
-                onClick={() =>
-                  setCreateFiles([
-                    ...createFiles,
-                    { filename: "", content: "" },
-                  ])
-                }
-                className="text-xs text-fg-muted hover:text-fg transition-colors"
-              >
-                + Add file
-              </button>
-            </div>
-            {createFiles.map((f, i) => (
-              <div
-                key={i}
-                className="border border-border rounded-lg p-3 mb-2"
-              >
-                <div className="flex items-center gap-2 mb-2">
-                  <input
-                    value={f.filename}
-                    onChange={(e) => {
-                      const updated = [...createFiles];
-                      updated[i] = { ...updated[i], filename: e.target.value };
-                      setCreateFiles(updated);
-                    }}
-                    className={`${inputCls} flex-1`}
-                    placeholder="filename.txt"
-                  />
-                  <button
-                    onClick={() =>
-                      setCreateFiles(createFiles.filter((_, j) => j !== i))
-                    }
-                    className="px-2 py-2 text-fg-subtle hover:text-danger transition-colors text-lg leading-none"
-                  >
-                    ×
-                  </button>
-                </div>
-                <textarea
-                  value={f.content}
-                  onChange={(e) => {
-                    const updated = [...createFiles];
-                    updated[i] = { ...updated[i], content: e.target.value };
-                    setCreateFiles(updated);
-                  }}
-                  rows={4}
-                  className={`${inputCls} resize-none font-mono text-xs leading-relaxed`}
-                  placeholder="File content..."
-                />
-              </div>
-            ))}
-          </div>
+          <p className="text-xs text-fg-subtle">
+            The zip must contain <code>SKILL.md</code> at the root, or one
+            top-level folder containing it (the common case when you
+            <code> zip -r my-skill.zip my-skill</code>).
+          </p>
         </div>
       </Modal>
 
@@ -611,12 +613,23 @@ export function SkillsList() {
                       key={i}
                       className="border border-border rounded-lg overflow-hidden"
                     >
-                      <div className="bg-bg-surface px-3 py-1.5 border-b border-border text-xs font-mono text-fg-muted">
-                        {f.filename}
+                      <div className="bg-bg-surface px-3 py-1.5 border-b border-border text-xs font-mono text-fg-muted flex items-center justify-between">
+                        <span className="truncate">{f.filename}</span>
+                        {f.encoding === "base64" && (
+                          <span className="ml-2 text-[10px] uppercase tracking-wider text-fg-subtle">
+                            binary
+                          </span>
+                        )}
                       </div>
-                      <pre className="px-3 py-2 text-xs font-mono text-fg-muted whitespace-pre-wrap max-h-60 overflow-y-auto leading-relaxed">
-                        {f.content}
-                      </pre>
+                      {f.encoding === "base64" ? (
+                        <p className="px-3 py-2 text-xs italic text-fg-subtle">
+                          Binary file — not previewed.
+                        </p>
+                      ) : (
+                        <pre className="px-3 py-2 text-xs font-mono text-fg-muted whitespace-pre-wrap max-h-60 overflow-y-auto leading-relaxed">
+                          {f.content}
+                        </pre>
+                      )}
                     </div>
                   ))}
                 </div>
@@ -627,98 +640,42 @@ export function SkillsList() {
             {showNewVersion && (
               <div className="border border-border-strong rounded-lg p-4 bg-bg-surface/50 space-y-3">
                 <h3 className="text-sm font-medium text-fg">
-                  Create New Version
+                  Upload New Version
                 </h3>
                 {nvError && (
                   <div className="text-sm text-danger bg-danger-subtle border border-danger/30 rounded-lg px-3 py-2">
                     {nvError}
                   </div>
                 )}
-                <div>
-                  <label className="text-xs text-fg-muted block mb-1">
-                    SKILL.md
-                  </label>
-                  <textarea
-                    value={nvSkillMd}
-                    onChange={(e) => setNvSkillMd(e.target.value)}
-                    rows={10}
-                    className={`${inputCls} resize-none font-mono text-xs leading-relaxed`}
-                  />
-                </div>
-                <div>
-                  <div className="flex items-center justify-between mb-2">
-                    <label className="text-xs text-fg-muted">
-                      Additional Files ({nvFiles.length})
-                    </label>
-                    <button
-                      onClick={() =>
-                        setNvFiles([
-                          ...nvFiles,
-                          { filename: "", content: "" },
-                        ])
-                      }
-                      className="text-xs text-fg-muted hover:text-fg transition-colors"
-                    >
-                      + Add file
-                    </button>
-                  </div>
-                  {nvFiles.map((f, i) => (
-                    <div
-                      key={i}
-                      className="border border-border rounded-lg p-3 mb-2 bg-bg"
-                    >
-                      <div className="flex items-center gap-2 mb-2">
-                        <input
-                          value={f.filename}
-                          onChange={(e) => {
-                            const updated = [...nvFiles];
-                            updated[i] = {
-                              ...updated[i],
-                              filename: e.target.value,
-                            };
-                            setNvFiles(updated);
-                          }}
-                          className={`${inputCls} flex-1`}
-                          placeholder="filename.txt"
-                        />
-                        <button
-                          onClick={() =>
-                            setNvFiles(
-                              nvFiles.filter((_, j) => j !== i)
-                            )
-                          }
-                          className="px-2 py-2 text-fg-subtle hover:text-danger transition-colors text-lg leading-none"
-                        >
-                          ×
-                        </button>
-                      </div>
-                      <textarea
-                        value={f.content}
-                        onChange={(e) => {
-                          const updated = [...nvFiles];
-                          updated[i] = {
-                            ...updated[i],
-                            content: e.target.value,
-                          };
-                          setNvFiles(updated);
-                        }}
-                        rows={4}
-                        className={`${inputCls} resize-none font-mono text-xs leading-relaxed`}
-                        placeholder="File content..."
-                      />
-                    </div>
-                  ))}
-                </div>
+                <DropZone
+                  file={nvZip}
+                  dragOver={nvDragOver}
+                  onDragOver={(over) => setNvDragOver(over)}
+                  onFile={(f) => acceptNvZip(f)}
+                  onClear={() => {
+                    setNvZip(null);
+                    if (nvInputRef.current) nvInputRef.current.value = "";
+                  }}
+                  inputRef={nvInputRef}
+                  disabled={nvUploading}
+                />
                 <div className="flex justify-end gap-2">
                   <Button
                     variant="ghost"
-                    onClick={() => setShowNewVersion(false)}
+                    disabled={nvUploading}
+                    onClick={() => {
+                      setShowNewVersion(false);
+                      setNvZip(null);
+                      setNvError("");
+                    }}
                   >
                     Cancel
                   </Button>
                   <Button
                     onClick={doNewVersion}
-                    disabled={!nvSkillMd.trim()}
+                    disabled={!nvZip || nvUploading}
+                    loading={nvUploading}
+                    loadingLabel="Uploading..."
                   >
                     Publish Version
                   </Button>
@@ -829,6 +786,101 @@ export function SkillsList() {
           )}
         </div>
       </Modal>
+    </div>
+  );
+}
+
+/* ---------- DropZone ---------- */
+
+interface DropZoneProps {
+  file: File | null;
+  dragOver: boolean;
+  onDragOver: (over: boolean) => void;
+  onFile: (file: File) => boolean;
+  onClear: () => void;
+  inputRef: React.RefObject<HTMLInputElement | null>;
+  disabled?: boolean;
+}
+
+function DropZone({
+  file,
+  dragOver,
+  onDragOver,
+  onFile,
+  onClear,
+  inputRef,
+  disabled,
+}: DropZoneProps) {
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    onDragOver(false);
+    if (disabled) return;
+    const f = e.dataTransfer.files?.[0];
+    if (f) onFile(f);
+  };
+
+  return (
+    <div
+      onDragOver={(e) => {
+        e.preventDefault();
+        if (!disabled) onDragOver(true);
+      }}
+      onDragLeave={(e) => {
+        e.preventDefault();
+        onDragOver(false);
+      }}
+      onDrop={handleDrop}
+      className={[
+        "border-2 border-dashed rounded-lg px-4 py-6 text-center transition-colors",
+        dragOver
+          ? "border-brand bg-brand/5"
+          : "border-border bg-bg-surface/30",
+        disabled ? "opacity-60 pointer-events-none" : "",
+      ].join(" ")}
+    >
+      <input
+        ref={inputRef}
+        type="file"
+        accept=".zip,application/zip,application/x-zip-compressed"
+        className="hidden"
+        onChange={(e) => {
+          const f = e.target.files?.[0];
+          if (f) onFile(f);
+        }}
+      />
+      {file ? (
+        <div className="flex items-center justify-between gap-3">
+          <div className="min-w-0 text-left">
+            <div className="text-sm font-medium text-fg truncate">{file.name}</div>
+            <div className="text-xs text-fg-subtle">{formatBytes(file.size)}</div>
+          </div>
+          <div className="flex gap-2 shrink-0">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => inputRef.current?.click()}
+            >
+              Replace
+            </Button>
+            <Button variant="ghost" size="sm" onClick={onClear}>
+              Remove
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          <div className="text-sm text-fg-muted">
+            Drag &amp; drop a <code>.zip</code>, or
+          </div>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => inputRef.current?.click()}
+          >
+            Choose file
+          </Button>
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/main/package.json
+++ b/apps/main/package.json
@@ -25,6 +25,7 @@
     "@open-managed-agents/shared": "workspace:*",
     "@open-managed-agents/tenant-db": "workspace:*",
     "@open-managed-agents/tenant-dbs-store": "workspace:*",
+    "fflate": "^0.8.2",
     "hono": "^4.7.0"
   }
 }

--- a/apps/main/src/routes/skills.ts
+++ b/apps/main/src/routes/skills.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import type { Env } from "@open-managed-agents/shared";
 import { generateId, skillFileR2Key } from "@open-managed-agents/shared";
 import { logWarn } from "@open-managed-agents/shared";
+import { unzipSync } from "fflate";
 import { checkUploadFreq, checkUploadSize } from "../quotas";
 import { kvKey, kvPrefix, kvListAll } from "../kv-helpers";
 
@@ -225,59 +226,215 @@ function validateFiles(files: SkillFileInput[]): string | null {
 }
 
 // ---------------------------------------------------------------------------
-// POST /v1/skills — create a custom skill
+// Zip handling — accept a packaged skill folder and convert to the same
+// SkillFileInput[] shape the JSON endpoint already consumes. Strips the
+// common top-level directory (Anthropic-style `my-skill/SKILL.md`),
+// filters platform junk, and classifies each file as utf8 vs base64 by
+// strict TextDecoder.
 // ---------------------------------------------------------------------------
 
-app.post("/", async (c) => {
-  const t = c.get("tenant_id");
-  // Cheap upfront rejects — same gates as POST /v1/files. Both soft-pass
-  // when unconfigured.
-  const sizeCheck = checkUploadSize(c.env, c.req.raw);
-  if (sizeCheck) return sizeCheck;
-  const freqCheck = await checkUploadFreq(c.env, t);
-  if (freqCheck) return freqCheck;
+const IGNORED_BASENAMES = new Set([".DS_Store", "Thumbs.db"]);
+const IGNORED_PREFIXES = ["__MACOSX/", ".git/", ".idea/", ".vscode/"];
 
-  const bucket = ensureBucket(c);
-  if (!bucket) return c.json({ error: "FILES_BUCKET binding not configured" }, 500);
+function zipEntryIgnored(path: string): boolean {
+  if (IGNORED_PREFIXES.some((p) => path.startsWith(p) || path.includes(`/${p}`))) return true;
+  const base = path.split("/").pop() || "";
+  if (IGNORED_BASENAMES.has(base)) return true;
+  if (base.startsWith("._")) return true;
+  return false;
+}
 
-  const body = await c.req.json<{
-    display_title?: string;
-    name?: string;
-    description?: string;
-    files: SkillFileInput[];
-  }>();
+function commonRootPrefix(paths: string[]): string {
+  if (paths.length === 0) return "";
+  const firstSlash = paths[0].indexOf("/");
+  if (firstSlash < 0) return "";
+  const candidate = paths[0].slice(0, firstSlash + 1);
+  return paths.every((p) => p.startsWith(candidate)) ? candidate : "";
+}
 
-  if (!body.files || !Array.isArray(body.files) || body.files.length === 0) {
-    return c.json({ error: "files array is required and must not be empty" }, 400);
+function formatBytesHuman(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  return `${(n / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function bytesToBase64Str(bytes: Uint8Array): string {
+  let bin = "";
+  const CHUNK = 8192;
+  for (let i = 0; i < bytes.length; i += CHUNK) {
+    bin += String.fromCharCode.apply(
+      null,
+      bytes.subarray(i, i + CHUNK) as unknown as number[],
+    );
+  }
+  return btoa(bin);
+}
+
+function tryDecodeUtf8(bytes: Uint8Array): string | null {
+  try {
+    return new TextDecoder("utf-8", { fatal: true, ignoreBOM: false }).decode(bytes);
+  } catch {
+    return null;
+  }
+}
+
+interface ParsedSkillZip {
+  files: SkillFileInput[];
+  name?: string;
+  description?: string;
+}
+
+/** Caps applied during unzip to defend against zip-bombs. The dialed limits
+ *  are deliberately generous — the largest legitimate Anthropic-style skill
+ *  observed in the field is ~5 MB / ~100 files, so 100 MB / 25 MB per file /
+ *  500 files leaves ~20× headroom. A maliciously crafted zip can declare
+ *  multi-GB uncompressed sizes from a kilobyte payload; we reject as soon
+ *  as the central-directory metadata exceeds these limits, before
+ *  decompression actually runs. */
+const ZIP_MAX_TOTAL_UNCOMPRESSED = 100 * 1024 * 1024;
+const ZIP_MAX_FILE_UNCOMPRESSED = 25 * 1024 * 1024;
+const ZIP_MAX_FILE_COUNT = 500;
+
+class ZipLimitError extends Error {}
+
+function parseSkillZipBytes(bytes: Uint8Array): ParsedSkillZip {
+  let entries: Record<string, Uint8Array>;
+  try {
+    let totalUncompressed = 0;
+    let count = 0;
+    entries = unzipSync(bytes, {
+      filter: (file) => {
+        // Skip directory entries and platform junk before they count
+        // against the budget — fflate would otherwise call us for every
+        // __MACOSX/* entry.
+        if (file.name.endsWith("/") || zipEntryIgnored(file.name)) return false;
+        count++;
+        if (count > ZIP_MAX_FILE_COUNT) {
+          throw new ZipLimitError(
+            `Zip has too many files (>${ZIP_MAX_FILE_COUNT}); refusing to process`,
+          );
+        }
+        if (file.originalSize > ZIP_MAX_FILE_UNCOMPRESSED) {
+          throw new ZipLimitError(
+            `File "${file.name}" is ${formatBytesHuman(file.originalSize)} uncompressed; per-file limit is ${formatBytesHuman(ZIP_MAX_FILE_UNCOMPRESSED)}`,
+          );
+        }
+        totalUncompressed += file.originalSize;
+        if (totalUncompressed > ZIP_MAX_TOTAL_UNCOMPRESSED) {
+          throw new ZipLimitError(
+            `Zip uncompressed size exceeds ${formatBytesHuman(ZIP_MAX_TOTAL_UNCOMPRESSED)} (zip-bomb defense)`,
+          );
+        }
+        return true;
+      },
+    });
+  } catch (err) {
+    if (err instanceof ZipLimitError) throw err;
+    throw new Error(
+      `Could not read zip: ${err instanceof Error ? err.message : "unknown error"}`,
+    );
   }
 
-  const validateErr = validateFiles(body.files);
-  if (validateErr) return c.json({ error: validateErr }, 400);
+  // fflate's filter already dropped directory + ignored entries; what
+  // remains is the actual skill payload.
+  const usable = Object.entries(entries);
+  if (usable.length === 0) {
+    throw new Error("Zip is empty (after filtering metadata files)");
+  }
 
-  const extracted = extractFromFiles(body.files);
-  const name = body.name || extracted.name;
-  const description = body.description || extracted.description || "";
-  const displayTitle = body.display_title || name || "";
+  const prefix = commonRootPrefix(usable.map(([p]) => p));
+  const stripped = usable.map(([path, data]) => ({
+    path: prefix ? path.slice(prefix.length) : path,
+    bytes: data,
+  }));
+
+  const skillMd = stripped.find((e) => e.path.toLowerCase() === "skill.md");
+  if (!skillMd) {
+    throw new Error(
+      "Zip must contain SKILL.md at the root (or a single top-level folder containing it)",
+    );
+  }
+  const skillMdText = tryDecodeUtf8(skillMd.bytes);
+  if (skillMdText === null) {
+    throw new Error("SKILL.md must be UTF-8 text");
+  }
+
+  const files: SkillFileInput[] = [];
+  for (const entry of stripped) {
+    if (!entry.path) continue;
+    const decoded =
+      entry.path === skillMd.path
+        ? skillMdText
+        : tryDecodeUtf8(entry.bytes);
+    if (decoded !== null) {
+      files.push({ filename: entry.path, content: decoded, encoding: "utf8" });
+    } else {
+      files.push({
+        filename: entry.path,
+        content: bytesToBase64Str(entry.bytes),
+        encoding: "base64",
+      });
+    }
+  }
+
+  const { name, description } = parseFrontmatter(skillMdText);
+  return { files, name, description };
+}
+
+
+
+// ---------------------------------------------------------------------------
+// Shared persistence — both the JSON POST and the multipart upload endpoint
+// converge here once they have a validated SkillFileInput[] in hand.
+// ---------------------------------------------------------------------------
+
+interface PersistArgs {
+  files: SkillFileInput[];
+  display_title?: string;
+  name?: string;
+  description?: string;
+}
+
+async function persistNewSkill(
+  env: Env,
+  bucket: R2Bucket,
+  tenantId: string,
+  args: PersistArgs,
+): Promise<
+  | { ok: true; skill: SkillMeta; files: Array<{ filename: string; content: string; encoding: "utf8" | "base64" }>; status: 201 }
+  | { ok: false; status: number; error: string }
+> {
+  if (!args.files || args.files.length === 0) {
+    return { ok: false, status: 400, error: "files array is required and must not be empty" };
+  }
+  const validateErr = validateFiles(args.files);
+  if (validateErr) return { ok: false, status: 400, error: validateErr };
+
+  const extracted = extractFromFiles(args.files);
+  const name = args.name || extracted.name;
+  const description = args.description || extracted.description || "";
+  const displayTitle = args.display_title || name || "";
 
   if (!name) {
-    return c.json(
-      { error: "name is required (provide it explicitly or via SKILL.md frontmatter)" },
-      400,
-    );
+    return {
+      ok: false,
+      status: 400,
+      error: "name is required (provide it explicitly or via SKILL.md frontmatter)",
+    };
   }
   if (!NAME_RE.test(name)) {
-    return c.json(
-      { error: "name must be lowercase letters, numbers, and hyphens only (max 64 chars)" },
-      400,
-    );
+    return {
+      ok: false,
+      status: 400,
+      error: "name must be lowercase letters, numbers, and hyphens only (max 64 chars)",
+    };
   }
 
   const now = new Date().toISOString();
   const id = `skill_${generateId()}`;
   const versionId = Date.now().toString();
 
-  const manifest = await writeFilesToR2(bucket, t, id, versionId, body.files);
-
+  const manifest = await writeFilesToR2(bucket, tenantId, id, versionId, args.files);
   const skill: SkillMeta = {
     id,
     display_title: displayTitle,
@@ -290,14 +447,139 @@ app.post("/", async (c) => {
   const version: SkillVersion = { version: versionId, files: manifest, created_at: now };
 
   await Promise.all([
-    c.env.CONFIG_KV.put(kvKey(t, "skill", id), JSON.stringify(skill)),
-    c.env.CONFIG_KV.put(kvKey(t, "skillver", id, versionId), JSON.stringify(version)),
+    env.CONFIG_KV.put(kvKey(tenantId, "skill", id), JSON.stringify(skill)),
+    env.CONFIG_KV.put(kvKey(tenantId, "skillver", id, versionId), JSON.stringify(version)),
   ]);
 
-  // Return the same shape the previous API returned: skill metadata + files
-  // with content (so existing CLI tooling keeps working).
-  const filesOut = await readFilesFromR2(bucket, t, id, versionId, manifest);
-  return c.json({ ...skill, files: filesOut }, 201);
+  const filesOut = await readFilesFromR2(bucket, tenantId, id, versionId, manifest);
+  return { ok: true, status: 201, skill, files: filesOut };
+}
+
+async function persistNewVersion(
+  env: Env,
+  bucket: R2Bucket,
+  tenantId: string,
+  skillId: string,
+  args: PersistArgs,
+): Promise<
+  | { ok: true; version: SkillVersion; status: 201 }
+  | { ok: false; status: number; error: string }
+> {
+  const raw = await env.CONFIG_KV.get(kvKey(tenantId, "skill", skillId));
+  if (!raw) return { ok: false, status: 404, error: "Skill not found" };
+  const skill: SkillMeta = JSON.parse(raw);
+  if (skill.source !== "custom") {
+    return { ok: false, status: 403, error: "Cannot create versions for built-in skills" };
+  }
+
+  if (!args.files || args.files.length === 0) {
+    return { ok: false, status: 400, error: "files array is required and must not be empty" };
+  }
+  const validateErr = validateFiles(args.files);
+  if (validateErr) return { ok: false, status: 400, error: validateErr };
+
+  const now = new Date().toISOString();
+  const versionId = Date.now().toString();
+
+  const manifest = await writeFilesToR2(bucket, tenantId, skillId, versionId, args.files);
+  const version: SkillVersion = { version: versionId, files: manifest, created_at: now };
+
+  skill.latest_version = versionId;
+  if (args.display_title !== undefined) skill.display_title = args.display_title;
+  if (args.description !== undefined) skill.description = args.description;
+
+  // Refresh display_title / description from frontmatter if caller didn't
+  // override — matches the JSON endpoint's existing behavior.
+  const extracted = extractFromFiles(args.files);
+  if (!args.display_title && extracted.name) skill.display_title = extracted.name;
+  if (!args.description && extracted.description) skill.description = extracted.description;
+
+  await Promise.all([
+    env.CONFIG_KV.put(kvKey(tenantId, "skill", skillId), JSON.stringify(skill)),
+    env.CONFIG_KV.put(kvKey(tenantId, "skillver", skillId, versionId), JSON.stringify(version)),
+  ]);
+
+  return { ok: true, status: 201, version };
+}
+
+// ---------------------------------------------------------------------------
+// POST /v1/skills — create a custom skill (JSON; SDK / programmatic path)
+// ---------------------------------------------------------------------------
+
+app.post("/", async (c) => {
+  const t = c.get("tenant_id");
+  const sizeCheck = checkUploadSize(c.env, c.req.raw);
+  if (sizeCheck) return sizeCheck;
+  const freqCheck = await checkUploadFreq(c.env, t);
+  if (freqCheck) return freqCheck;
+
+  const bucket = ensureBucket(c);
+  if (!bucket) return c.json({ error: "FILES_BUCKET binding not configured" }, 500);
+
+  const body = await c.req.json<PersistArgs>();
+  const result = await persistNewSkill(c.env, bucket, t, body);
+  if (!result.ok) return c.json({ error: result.error }, result.status as 400 | 500);
+  return c.json({ ...result.skill, files: result.files }, 201);
+});
+
+// ---------------------------------------------------------------------------
+// POST /v1/skills/upload — create a custom skill from a packaged .zip
+// (multipart/form-data: file=<zip>, optional display_title)
+// ---------------------------------------------------------------------------
+
+app.post("/upload", async (c) => {
+  const t = c.get("tenant_id");
+  const sizeCheck = checkUploadSize(c.env, c.req.raw);
+  if (sizeCheck) return sizeCheck;
+  const freqCheck = await checkUploadFreq(c.env, t);
+  if (freqCheck) return freqCheck;
+
+  const bucket = ensureBucket(c);
+  if (!bucket) return c.json({ error: "FILES_BUCKET binding not configured" }, 500);
+
+  const contentType = c.req.header("content-type") || "";
+  if (!contentType.includes("multipart/form-data")) {
+    return c.json({ error: "expected multipart/form-data" }, 400);
+  }
+
+  let formData: FormData;
+  try {
+    formData = await c.req.formData();
+  } catch (err) {
+    return c.json(
+      { error: `Invalid multipart body: ${err instanceof Error ? err.message : "unknown"}` },
+      400,
+    );
+  }
+  const file = formData.get("file") as File | null;
+  if (!file || typeof (file as { arrayBuffer?: unknown }).arrayBuffer !== "function") {
+    return c.json({ error: "file field is required (the skill .zip)" }, 400);
+  }
+
+  const bytes = new Uint8Array(await file.arrayBuffer());
+  let parsed: ParsedSkillZip;
+  try {
+    parsed = parseSkillZipBytes(bytes);
+  } catch (err) {
+    return c.json(
+      { error: err instanceof Error ? err.message : "Failed to read zip" },
+      400,
+    );
+  }
+
+  const displayTitle =
+    typeof formData.get("display_title") === "string"
+      ? (formData.get("display_title") as string)
+      : undefined;
+
+  const result = await persistNewSkill(c.env, bucket, t, {
+    files: parsed.files,
+    name: parsed.name,
+    description: parsed.description,
+    display_title: displayTitle,
+  });
+  if (!result.ok) return c.json({ error: result.error }, result.status as 400 | 500);
+  return c.json({ ...result.skill, files: result.files }, 201);
 });
 
 // ---------------------------------------------------------------------------
@@ -386,7 +668,7 @@ app.delete("/:id", async (c) => {
 });
 
 // ---------------------------------------------------------------------------
-// POST /v1/skills/:id/versions — create a new version
+// POST /v1/skills/:id/versions — create a new version (JSON)
 // ---------------------------------------------------------------------------
 
 app.post("/:id/versions", async (c) => {
@@ -400,46 +682,69 @@ app.post("/:id/versions", async (c) => {
   if (!bucket) return c.json({ error: "FILES_BUCKET binding not configured" }, 500);
 
   const id = c.req.param("id");
-  const raw = await c.env.CONFIG_KV.get(kvKey(t, "skill", id));
-  if (!raw) return c.json({ error: "Skill not found" }, 404);
+  const body = await c.req.json<PersistArgs>();
+  const result = await persistNewVersion(c.env, bucket, t, id, body);
+  if (!result.ok) return c.json({ error: result.error }, result.status as 400 | 403 | 404 | 500);
+  return c.json(result.version, 201);
+});
 
-  const skill: SkillMeta = JSON.parse(raw);
-  if (skill.source !== "custom") {
-    return c.json({ error: "Cannot create versions for built-in skills" }, 403);
+// ---------------------------------------------------------------------------
+// POST /v1/skills/:id/versions/upload — new version from a packaged .zip
+// ---------------------------------------------------------------------------
+
+app.post("/:id/versions/upload", async (c) => {
+  const t = c.get("tenant_id");
+  const sizeCheck = checkUploadSize(c.env, c.req.raw);
+  if (sizeCheck) return sizeCheck;
+  const freqCheck = await checkUploadFreq(c.env, t);
+  if (freqCheck) return freqCheck;
+
+  const bucket = ensureBucket(c);
+  if (!bucket) return c.json({ error: "FILES_BUCKET binding not configured" }, 500);
+
+  const contentType = c.req.header("content-type") || "";
+  if (!contentType.includes("multipart/form-data")) {
+    return c.json({ error: "expected multipart/form-data" }, 400);
   }
 
-  const body = await c.req.json<{
-    files: SkillFileInput[];
-    display_title?: string;
-    description?: string;
-  }>();
-
-  if (!body.files || !Array.isArray(body.files) || body.files.length === 0) {
-    return c.json({ error: "files array is required and must not be empty" }, 400);
+  let formData: FormData;
+  try {
+    formData = await c.req.formData();
+  } catch (err) {
+    return c.json(
+      { error: `Invalid multipart body: ${err instanceof Error ? err.message : "unknown"}` },
+      400,
+    );
   }
-  const validateErr = validateFiles(body.files);
-  if (validateErr) return c.json({ error: validateErr }, 400);
+  const file = formData.get("file") as File | null;
+  if (!file || typeof (file as { arrayBuffer?: unknown }).arrayBuffer !== "function") {
+    return c.json({ error: "file field is required (the skill .zip)" }, 400);
+  }
 
-  const now = new Date().toISOString();
-  const versionId = Date.now().toString();
+  const bytes = new Uint8Array(await file.arrayBuffer());
+  let parsed: ParsedSkillZip;
+  try {
+    parsed = parseSkillZipBytes(bytes);
+  } catch (err) {
+    return c.json(
+      { error: err instanceof Error ? err.message : "Failed to read zip" },
+      400,
+    );
+  }
 
-  const manifest = await writeFilesToR2(bucket, t, id, versionId, body.files);
-  const version: SkillVersion = { version: versionId, files: manifest, created_at: now };
+  const displayTitle =
+    typeof formData.get("display_title") === "string"
+      ? (formData.get("display_title") as string)
+      : undefined;
 
-  skill.latest_version = versionId;
-  if (body.display_title !== undefined) skill.display_title = body.display_title;
-  if (body.description !== undefined) skill.description = body.description;
-
-  const extracted = extractFromFiles(body.files);
-  if (!body.display_title && extracted.name) skill.display_title = extracted.name;
-  if (!body.description && extracted.description) skill.description = extracted.description;
-
-  await Promise.all([
-    c.env.CONFIG_KV.put(kvKey(t, "skill", id), JSON.stringify(skill)),
-    c.env.CONFIG_KV.put(kvKey(t, "skillver", id, versionId), JSON.stringify(version)),
-  ]);
-
-  return c.json(version, 201);
+  const id = c.req.param("id");
+  const result = await persistNewVersion(c.env, bucket, t, id, {
+    files: parsed.files,
+    display_title: displayTitle,
+    description: parsed.description,
+  });
+  if (!result.ok) return c.json({ error: result.error }, result.status as 400 | 403 | 404 | 500);
+  return c.json(result.version, 201);
 });
 
 // ---------------------------------------------------------------------------

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@cloudflare/workers-types": "^4.20250410.0",
     "@playwright/test": "^1.59.1",
     "@types/node": "^25.6.0",
+    "fflate": "^0.8.2",
     "jsonc-parser": "^3.3.1",
     "typescript": "^5.8.0",
     "vitest": "^4.1.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       '@types/node':
         specifier: ^25.6.0
         version: 25.6.0
+      fflate:
+        specifier: ^0.8.2
+        version: 0.8.2
       jsonc-parser:
         specifier: ^3.3.1
         version: 3.3.1
@@ -311,6 +314,9 @@ importers:
       '@open-managed-agents/vaults-store':
         specifier: workspace:*
         version: link:../../packages/vaults-store
+      fflate:
+        specifier: ^0.8.2
+        version: 0.8.2
       hono:
         specifier: ^4.7.0
         version: 4.12.12
@@ -2960,6 +2966,9 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fflate@0.8.2:
+    resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
 
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
@@ -7147,6 +7156,8 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  fflate@0.8.2: {}
 
   fill-range@7.1.1:
     dependencies:

--- a/test/integration/skills.test.ts
+++ b/test/integration/skills.test.ts
@@ -1,6 +1,7 @@
 // @ts-nocheck
 import { exports } from "cloudflare:workers";
 import { describe, it, expect } from "vitest";
+import { zipSync, strToU8 } from "fflate";
 
 const H = { "x-api-key": "test-key", "Content-Type": "application/json" };
 function api(path: string, init?: RequestInit) {
@@ -14,6 +15,20 @@ function get(path: string) {
 }
 function del(path: string) {
   return api(path, { method: "DELETE", headers: H });
+}
+
+/** Build a multipart upload Request without setting content-type ourselves —
+ *  FormData lets fetch synthesize the correct boundary. We construct a Request
+ *  the same way the dispatcher does so c.req.formData() works. */
+function postZip(path: string, zipBytes: Uint8Array, opts?: { displayTitle?: string; filename?: string }) {
+  const fd = new FormData();
+  fd.append("file", new File([zipBytes], opts?.filename ?? "skill.zip", { type: "application/zip" }));
+  if (opts?.displayTitle) fd.append("display_title", opts.displayTitle);
+  return api(path, {
+    method: "POST",
+    headers: { "x-api-key": "test-key" },
+    body: fd,
+  });
 }
 
 const SKILL_MD = `---
@@ -472,5 +487,186 @@ Summarize emails efficiently.
     expect(skill.description).toBe(
       "Summarizes long email threads into concise bullet points"
     );
+  });
+});
+
+// ============================================================
+// 4. Zip upload — POST /v1/skills/upload + /:id/versions/upload
+// ============================================================
+describe("Skills zip upload", () => {
+  // Tiny binary blob to verify base64 encoding round-trips through R2.
+  const PNG_BYTES = new Uint8Array([
+    0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+    0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52,
+  ]);
+
+  function buildSkillZip(opts?: {
+    /** When true, wrap files inside a top-level folder (Anthropic-style) so
+     *  we can verify the server strips the common prefix. */
+    nested?: boolean;
+    name?: string;
+    description?: string;
+  }) {
+    const name = opts?.name ?? "zipped-skill";
+    const desc = opts?.description ?? "Created from a zip";
+    const md = `---\nname: ${name}\ndescription: ${desc}\n---\n\n# ${name}\n`;
+    const root = opts?.nested ? `${name}/` : "";
+    return zipSync({
+      [`${root}SKILL.md`]: strToU8(md),
+      [`${root}helper.py`]: strToU8("def hello():\n    return 'hi'\n"),
+      [`${root}assets/pixel.png`]: PNG_BYTES,
+      [`${root}.DS_Store`]: strToU8("junk"),
+    });
+  }
+
+  it("creates a skill from a zip with a nested top-level folder", async () => {
+    const bytes = buildSkillZip({ nested: true, name: "from-zip-nested" });
+    const res = await postZip("/v1/skills/upload", bytes);
+    expect(res.status).toBe(201);
+    const skill = (await res.json()) as any;
+    expect(skill.name).toBe("from-zip-nested");
+    expect(skill.description).toBe("Created from a zip");
+    // Files in the response should NOT carry the top-level folder prefix.
+    const filenames = (skill.files as any[]).map((f) => f.filename);
+    expect(filenames).toContain("SKILL.md");
+    expect(filenames).toContain("helper.py");
+    expect(filenames).toContain("assets/pixel.png");
+    // .DS_Store should have been filtered out.
+    expect(filenames.find((n: string) => n.includes(".DS_Store"))).toBeUndefined();
+  });
+
+  it("creates a skill from a flat zip (no top-level folder)", async () => {
+    const bytes = buildSkillZip({ nested: false, name: "from-zip-flat" });
+    const res = await postZip("/v1/skills/upload", bytes);
+    expect(res.status).toBe(201);
+    const skill = (await res.json()) as any;
+    expect(skill.name).toBe("from-zip-flat");
+  });
+
+  it("encodes binary files as base64 in the response", async () => {
+    const bytes = buildSkillZip({ nested: true, name: "binary-skill" });
+    const res = await postZip("/v1/skills/upload", bytes);
+    expect(res.status).toBe(201);
+    const skill = (await res.json()) as any;
+    const png = (skill.files as any[]).find((f) => f.filename === "assets/pixel.png");
+    expect(png).toBeTruthy();
+    expect(png.encoding).toBe("base64");
+    // base64-decode and compare bytes.
+    const bin = atob(png.content);
+    const out = new Uint8Array(bin.length);
+    for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+    expect(Array.from(out)).toEqual(Array.from(PNG_BYTES));
+  });
+
+  it("uses display_title form field when provided", async () => {
+    const bytes = buildSkillZip({ name: "title-override" });
+    const res = await postZip("/v1/skills/upload", bytes, {
+      displayTitle: "My Override Title",
+    });
+    expect(res.status).toBe(201);
+    const skill = (await res.json()) as any;
+    expect(skill.display_title).toBe("My Override Title");
+    expect(skill.name).toBe("title-override");
+  });
+
+  it("rejects zip without SKILL.md", async () => {
+    const bytes = zipSync({
+      "README.md": strToU8("not a skill"),
+    });
+    const res = await postZip("/v1/skills/upload", bytes);
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as any;
+    expect(body.error).toMatch(/SKILL\.md/);
+  });
+
+  it("rejects upload without file field", async () => {
+    const fd = new FormData();
+    fd.append("display_title", "no file");
+    const res = await api("/v1/skills/upload", {
+      method: "POST",
+      headers: { "x-api-key": "test-key" },
+      body: fd,
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects non-multipart body", async () => {
+    const res = await api("/v1/skills/upload", {
+      method: "POST",
+      headers: H,
+      body: JSON.stringify({ foo: "bar" }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("creates a new version from a zip via /versions/upload", async () => {
+    // Seed a skill via the JSON path.
+    const createRes = await post("/v1/skills", makeSkillBody({ display_title: "Versioned" }));
+    const skill = (await createRes.json()) as any;
+    const before = skill.latest_version;
+
+    const bytes = buildSkillZip({ nested: true, name: "my-skill", description: "v2 from zip" });
+    const verRes = await postZip(`/v1/skills/${skill.id}/versions/upload`, bytes);
+    expect(verRes.status).toBe(201);
+    const ver = (await verRes.json()) as any;
+    expect(ver.version).toBeTruthy();
+    expect(ver.version).not.toBe(before);
+
+    // Description should refresh from the zip's frontmatter (matches the JSON
+    // version endpoint's existing behavior).
+    const refreshed = (await (await get(`/v1/skills/${skill.id}`)).json()) as any;
+    expect(refreshed.latest_version).toBe(ver.version);
+    expect(refreshed.description).toBe("v2 from zip");
+  });
+
+  it("rejects /versions/upload for unknown skill", async () => {
+    const bytes = buildSkillZip({ name: "unused" });
+    const res = await postZip("/v1/skills/skill_nonexistent/versions/upload", bytes);
+    expect(res.status).toBe(404);
+  });
+
+  // ----- zip-bomb defense -----
+
+  it("rejects zip when a single file's uncompressed size exceeds the per-file cap", async () => {
+    // 30MB of zeroes → ~30KB on the wire after DEFLATE → uncompressed size
+    // well past the 25MB per-file limit.
+    const huge = new Uint8Array(30 * 1024 * 1024);
+    const bytes = zipSync({
+      "SKILL.md": strToU8("---\nname: bombed\ndescription: x\n---\n"),
+      "huge.bin": huge,
+    });
+    const res = await postZip("/v1/skills/upload", bytes);
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as any;
+    expect(body.error).toMatch(/per-file limit/);
+  });
+
+  it("rejects zip when total uncompressed size exceeds the aggregate cap", async () => {
+    // Six 20MB compressible blobs = 120MB uncompressed total, which trips
+    // the 100MB aggregate cap. Each individual file stays under the
+    // per-file limit so the failure mode is unambiguous.
+    const blob = new Uint8Array(20 * 1024 * 1024);
+    const files: Record<string, Uint8Array> = {
+      "SKILL.md": strToU8("---\nname: bombed\ndescription: x\n---\n"),
+    };
+    for (let i = 0; i < 6; i++) files[`blob-${i}.bin`] = blob;
+    const bytes = zipSync(files);
+    const res = await postZip("/v1/skills/upload", bytes);
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as any;
+    expect(body.error).toMatch(/zip-bomb defense|aggregate|exceeds/i);
+  });
+
+  it("rejects zip with too many files", async () => {
+    // 501 tiny files trips the file-count cap of 500.
+    const files: Record<string, Uint8Array> = {
+      "SKILL.md": strToU8("---\nname: many\ndescription: x\n---\n"),
+    };
+    for (let i = 0; i < 501; i++) files[`f-${i}.txt`] = strToU8("x");
+    const bytes = zipSync(files);
+    const res = await postZip("/v1/skills/upload", bytes);
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as any;
+    expect(body.error).toMatch(/too many files/i);
   });
 });


### PR DESCRIPTION
## Summary

- Console New Skill / New Version dialogs now accept a packaged **.zip** instead of forcing users to hand-type each file. Server unzips with **fflate** and writes per-file to R2 — same downstream layout as the JSON endpoint, so agent-side mounting is unchanged.
- Two new multipart endpoints: `POST /v1/skills/upload` and `POST /v1/skills/:id/versions/upload`. Existing JSON `POST /v1/skills` retained for SDK / programmatic use.
- **zip-bomb defense** via fflate's `filter` callback: caps total uncompressed size, per-file size, and file count by reading central-directory metadata **before** decompression starts. Largest legitimate skill in the field is 5.5MB / 88 files; caps leave ~18× headroom.
- Console UX: drag/drop, client-side size precheck against `UPLOAD_MAX_BYTES` default, Uploading… state with disabled cancel, binary-aware version preview (no garbled base64 dump).

## Why server-side and not client-side

We considered client-side decompression (jszip + multipart-many-files) but the typical skill in OMA's workload is <1MB / <50 files, with the absolute outlier 5.5MB / 88 files. Worker decompression of a 5MB zip is ~30ms / ~12MB memory — well inside the 30s CPU / 128MB envelope. Pushing decompression to the client would add ~100KB to the bundle (even with dynamic import) and create two parallel paths (CLI vs console) with no payoff at this scale.

The one real risk — **zip-bombs** — is what the size-cap defense addresses. Workflows / sandbox containers are deferred until OMA's skill scale actually justifies them.

## Test plan

- [x] `pnpm test test/integration/skills.test.ts` → 37/37 PASS (24 pre-existing + 10 new upload + 3 new zip-bomb)
- [x] `tsc --noEmit -p apps/main` → 0 errors in changed files
- [x] `pnpm --filter managed-agents-console build` → bundle 952 KB (no growth)
- [ ] Manual smoke: upload a real Anthropic skill .zip via console
- [ ] Manual smoke: try a malicious zip-bomb fixture to verify 400 + clear error

🤖 Generated with [Claude Code](https://claude.com/claude-code)