### PR TITLE
feat(verifier): Verifier interface + 5 builtins; eval-runner & rl-rollout converge on it

### DIFF
--- a/apps/agent/src/harness/outcome-evaluator.ts
+++ b/apps/agent/src/harness/outcome-evaluator.ts
@@ -1,5 +1,6 @@
 import { generateText } from "ai";
 import type { LanguageModel } from "ai";
+import type { Score } from "@open-managed-agents/shared";
 import { extractTextFromContent, parseJudgeJson } from "@open-managed-agents/shared";
 
 export interface EvaluationResult {
@@ -98,3 +99,36 @@ function parseRubricVerdict(text: string): EvaluationResult | null {
 
 // Re-export the shared helpers for tests / other consumers
 export { extractTextFromContent, parseJudgeJson };
+
+/**
+ * Phase 2 of trajectory v1 unification: project an `EvaluationResult`
+ * (the supervisor loop's verdict shape) onto the canonical `Score`
+ * shape used by the Verifier framework. Verdict-driven control flow in
+ * session-do.ts continues to consume `EvaluationResult` directly; this
+ * helper lets call sites that need to *persist* the verdict as
+ * `Trajectory.reward.raw_rewards` produce a Verifier-shaped output
+ * without a second LLM call.
+ *
+ * Why not refactor the supervisor loop to call `verifierForSpec(...).judge`
+ * (the RewardModelVerifier) instead? Two reasons, both Phase 2 scope:
+ *   1. The supervisor loop already has a model handle (the agent's
+ *      configured aux model), prompts the LLM with its own format, and
+ *      drives "needs_revision" injection back into history. Routing it
+ *      through an HTTP reward model endpoint would require either
+ *      stubbing the endpoint to call back into this same model handle
+ *      (silly) or wiring an in-process Verifier shape that can take a
+ *      LanguageModel directly (out of scope — see Phase 4 backlog).
+ *   2. The verdict ↔ score translation is lossy in only one direction
+ *      (we lose the `feedback` string in raw_rewards). Persisting the
+ *      verdict via this helper preserves the feedback in `Score.reason`,
+ *      which Console can render verbatim.
+ */
+export function evaluationResultToScore(r: EvaluationResult): Score {
+  const pass = r.result === "satisfied";
+  return {
+    pass,
+    value: pass ? 1 : 0,
+    reason: r.feedback || (pass ? "satisfied" : "needs_revision"),
+    metadata: { criteria: { satisfied: pass ? 1 : 0 } },
+  };
+}

--- a/apps/main/src/eval-runner.ts
+++ b/apps/main/src/eval-runner.ts
@@ -12,15 +12,15 @@
 // writeSetupFiles below), then (3) send the spec's first user message and
 // wait for idle, repeating for each subsequent message.
 
-import type { Env, AgentConfig, EnvironmentConfig, StoredEvent } from "@open-managed-agents/shared";
-import { buildTrajectory } from "@open-managed-agents/shared";
+import type { Env, AgentConfig, EnvironmentConfig, StoredEvent, Trajectory, RewardResult, VerifierContext } from "@open-managed-agents/shared";
+import { buildTrajectory, verifierForSpec, NoRunVerifier } from "@open-managed-agents/shared";
 import { logWarn } from "@open-managed-agents/shared";
 import type { SessionRecord, FullStatus } from "@open-managed-agents/shared";
 import { buildCfServices, getCfServicesForTenant, type Services } from "@open-managed-agents/services";
 import type { EvalRunRow, EvalRunStatus } from "@open-managed-agents/evals-store";
 import { toEnvironmentConfig } from "@open-managed-agents/environments-store";
 import { kvKey } from "./kv-helpers";
-import type { EvalRunRecord, EvalTaskResult, EvalTaskSpec } from "./routes/evals";
+import type { EvalRunRecord, EvalTaskResult, EvalTaskSpec, EvalTrialResult } from "./routes/evals";
 
 // ---------- Sandbox helpers (mirrors routes/sessions.ts) ----------
 
@@ -330,13 +330,148 @@ async function getSessionStatus(env: Env, run: EvalRunRecord, sessionId: string)
   }
 }
 
+/**
+ * Build a VerifierContext that lets a Verifier reach back into the agent
+ * sandbox via /exec. Used by `script` + (future) `composite` Verifiers.
+ * Stays a function (not closure-captured at module scope) so each call
+ * resolves the binding fresh — environments can re-enter ready/not-ready
+ * state during a long run.
+ */
+function buildVerifierContext(env: Env, run: EvalRunRecord, sessionId: string): VerifierContext {
+  return {
+    sessionId,
+    runExec: async (cmd, opts) => {
+      const binding = await getSandboxBinding(env, run.environment_id, run.tenant_id);
+      if (!binding) throw new Error("environment binding lost");
+      const res = await fwd(binding, `/sessions/${sessionId}/exec`, "POST", JSON.stringify({
+        command: cmd,
+        timeout_ms: opts?.timeoutMs ?? 600_000,
+      }));
+      if (!res.ok) {
+        const body = await res.text().catch(() => "");
+        return { exit_code: -1, output: `HTTP ${res.status}: ${body.slice(0, 200)}` };
+      }
+      const data = (await res.json()) as { exit_code?: number; output?: string };
+      return { exit_code: data.exit_code ?? -1, output: data.output ?? "" };
+    },
+  };
+}
+
+/**
+ * Run the trial's RewardSpec against the built trajectory and return a
+ * RewardResult ready to drop into `Trajectory.reward`. When no spec is
+ * declared on the task, fall back to the Phase 1 placeholder (idle =
+ * pass) so existing eval runs keep producing the same reward semantics.
+ */
+async function runVerifier(
+  env: Env,
+  run: EvalRunRecord,
+  task: EvalTaskResult,
+  trial: EvalTrialResult,
+  sessionId: string,
+  trajectory: Trajectory,
+): Promise<RewardResult> {
+  const computedAt = new Date().toISOString();
+  const reward = task.spec.reward;
+
+  // No spec → Phase 1 fallback. "Trial reached idle without timeout/error"
+  // is the implicit verifier; eval-runner gates this entry point on that
+  // being true, so always 1. Marked with a stable verifier_id so consumers
+  // can distinguish unconfigured-task rewards from real verifier output.
+  if (!reward) {
+    return {
+      raw_rewards: { outcome: 1 },
+      final_reward: 1,
+      verifier_id: "eval-runner.trial-status.v1",
+      computed_at: computedAt,
+    };
+  }
+
+  const ctx = buildVerifierContext(env, run, sessionId);
+  let verifier;
+  try {
+    verifier = verifierForSpec(reward, ctx);
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    logWarn(
+      { op: "eval.verifier.spec_invalid", run_id: run.id, task_id: task.spec.id, err: msg },
+      "verifier spec rejected; recording 0 reward",
+    );
+    return {
+      raw_rewards: { spec_invalid: 0 },
+      final_reward: 0,
+      verifier_id: "verifier-spec-invalid.v1",
+      computed_at: computedAt,
+    };
+  }
+
+  let score;
+  try {
+    score = await verifier.check(trajectory);
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    logWarn(
+      { op: "eval.verifier.check_threw", run_id: run.id, task_id: task.spec.id, verifier_id: verifier.id, err: msg },
+      "verifier check threw; recording 0 reward",
+    );
+    return {
+      raw_rewards: { verifier_error: 0 },
+      final_reward: 0,
+      verifier_id: verifier.id,
+      computed_at: computedAt,
+    };
+  }
+
+  // Translate Score → RewardResult. `criteria` (if provided by the
+  // verifier) is the breakdown; otherwise we reify a single-key map so
+  // downstream code (Console reward bar, RL reward stats) sees a stable
+  // shape regardless of which Verifier produced it.
+  const criteria = (score.metadata as { criteria?: Record<string, number> } | undefined)?.criteria;
+  const rawRewards = criteria && Object.keys(criteria).length > 0
+    ? criteria
+    : { value: score.value };
+  // Avoid mutating verifier-owned structures (CompositeVerifier reuses
+  // `criteria` across its own metadata and downstream propagation).
+  const persisted: Record<string, number> = {};
+  for (const [k, v] of Object.entries(rawRewards)) {
+    if (typeof v === "number" && Number.isFinite(v)) persisted[k] = v;
+  }
+
+  return {
+    raw_rewards: persisted,
+    final_reward: score.value,
+    verifier_id: verifier.id,
+    computed_at: computedAt,
+  };
+}
+
+/**
+ * Synthesize a RewardResult for a failure trial — there's no useful
+ * execution to grade, so we tag the trajectory with NoRunVerifier so
+ * Console / RL stats can distinguish "scored 0" from "never scored".
+ */
+async function synthesizeNoRunReward(reasonHint: string): Promise<RewardResult> {
+  // NoRunVerifier ignores its trajectory arg; we still call it so the
+  // reward field is built via the same Verifier abstraction as everything
+  // else (one code path = one shape).
+  const verifier = new NoRunVerifier(reasonHint);
+  const score = await verifier.check({} as Trajectory);
+  return {
+    raw_rewards: { failure: 0 },
+    final_reward: score.value,
+    verifier_id: verifier.id,
+    computed_at: new Date().toISOString(),
+  };
+}
+
 async function buildAndStoreTrajectory(
   env: Env,
   run: EvalRunRecord,
   task: EvalTaskResult,
-  trial: import("./routes/evals").EvalTrialResult,
+  trial: EvalTrialResult,
   sessionId: string,
-  finalReward: number,
+  reward: RewardResult,
+  outcomeOverride?: Trajectory["outcome"],
 ): Promise<{ trajectory_id: string; final_reward: number }> {
   const t = run.tenant_id;
   const services = await getServices(env, t);
@@ -381,42 +516,64 @@ async function buildAndStoreTrajectory(
     },
   });
 
-  // --- Trajectory v1 Phase 1 enrichment ---
+  // --- Trajectory v1 envelope enrichment ---
   // Wire eval-runner-owned fields into the envelope BEFORE storage so the
   // persisted trajectory carries reward / task_id / group_id / a corrected
-  // outcome on its own. Phase 3 (Console UI) will read these directly;
-  // Phase 2 will swap the static reward for a Verifier abstraction.
+  // outcome on its own. Phase 3 (Console UI) will read these directly.
 
   // task_id / group_id — eval-runner is the only caller that knows them.
-  // Non-eval session trajectories (built via /v1/sessions/:id/trajectory)
-  // correctly leave both undefined.
   trajectory.task_id = task.spec.id;
   trajectory.group_id = run.id;
 
-  // outcome timeout override — `deriveOutcome` can't see eval-runner's
-  // wall-clock budget. We do. If the trial bailed via the per-trial
-  // timeout_ms guard (the `trial timeout: ...` error string is set by
-  // advanceTrial) the trajectory's outcome should be `timeout`, not
-  // whatever deriveOutcome produced (likely `running` — the session
-  // never reached status_idle / status_terminated / session.error).
-  if (trial.error && /timeout/i.test(trial.error)) {
+  // outcome override — `deriveOutcome` can't see eval-runner's wall-clock
+  // budget or setup-error short-circuits. Caller passes the right outcome
+  // when known (timeout / failure on bootstrap-error trials). Otherwise
+  // we infer from the trial's error string for the "trial timeout" path.
+  if (outcomeOverride) {
+    trajectory.outcome = outcomeOverride;
+  } else if (trial.error && /timeout/i.test(trial.error)) {
     trajectory.outcome = "timeout";
   }
 
-  // reward — Phase 1 placeholder verifier. Caller provides the scalar
-  // (today: 0/1 from did-the-trial-finalize-successfully). Phase 2 will
-  // replace this with the unified Verifier abstraction (see
-  // docs/handoff-verifier-framework.md).
-  trajectory.reward = {
-    raw_rewards: { outcome: finalReward },
-    final_reward: finalReward,
-    verifier_id: "eval-runner.trial-status.v1",
-    computed_at: new Date().toISOString(),
-  };
+  trajectory.reward = reward;
 
   // Store trajectory under a stable key; for now use trajectory_id as the only key
   await env.CONFIG_KV.put(kvKey(t, "trajectory", trajectory.trajectory_id), JSON.stringify(trajectory));
-  return { trajectory_id: trajectory.trajectory_id, final_reward: finalReward };
+  return { trajectory_id: trajectory.trajectory_id, final_reward: reward.final_reward };
+}
+
+/**
+ * Best-effort no-run trajectory persistence for failure trials. Used
+ * when a trial dies before producing useful execution (setup error,
+ * postUserMessage failure, per-trial wall-clock timeout). Synthesizes a
+ * reward with NoRunVerifier so the Console / RL stats can still query
+ * the failure timeline through the canonical Trajectory envelope.
+ *
+ * Failure to build the trajectory is logged and swallowed — we still
+ * want the trial.status=failed transition to land even if the events
+ * endpoint is currently 500-ing.
+ */
+async function persistFailureTrajectory(
+  env: Env,
+  run: EvalRunRecord,
+  task: EvalTaskResult,
+  trial: EvalTrialResult,
+  sessionId: string,
+  outcome: Trajectory["outcome"],
+  reasonHint: string,
+): Promise<void> {
+  try {
+    const reward = await synthesizeNoRunReward(reasonHint);
+    const result = await buildAndStoreTrajectory(env, run, task, trial, sessionId, reward, outcome);
+    trial.trajectory_id = result.trajectory_id;
+    trial.reward = result.final_reward;
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    logWarn(
+      { op: "eval.failure_trajectory.skip", run_id: run.id, task_id: task.spec.id, session_id: sessionId, err: msg },
+      "could not build failure-trial trajectory; trial.failed without trajectory_id",
+    );
+  }
 }
 
 // ---------- Single-tick advance (per-trial) ----------
@@ -425,15 +582,16 @@ async function advanceTrial(
   env: Env,
   run: EvalRunRecord,
   task: EvalTaskResult,
-  trial: import("./routes/evals").EvalTrialResult,
+  trial: EvalTrialResult,
 ): Promise<boolean> {
   // Returns true if any progress was made (caller should save).
   if (trial.status === "completed" || trial.status === "failed") return false;
 
   // Bootstrap: create session + write setup_files (if any) + send first message
   if (trial.status === "pending") {
+    let sessionId: string | undefined;
     try {
-      const sessionId = await createTaskSession(env, run, task);
+      sessionId = await createTaskSession(env, run, task);
       trial.session_id = sessionId;
       trial.status = "running";
       trial.started_at = new Date().toISOString();
@@ -454,6 +612,15 @@ async function advanceTrial(
       trial.status = "failed";
       trial.error = err instanceof Error ? err.message : String(err);
       trial.ended_at = new Date().toISOString();
+      // Phase 2 failure-trial gap fix: when a session was successfully
+      // created but the trial died before producing useful execution
+      // (setup_files, setup_script, or first postUserMessage failed),
+      // build a no-run trajectory so the failure is queryable through
+      // the canonical Trajectory envelope. If `createTaskSession` itself
+      // threw there's no sessionId — nothing to build, leave it bare.
+      if (sessionId) {
+        await persistFailureTrajectory(env, run, task, trial, sessionId, "failure", trial.error);
+      }
       return true;
     }
   }
@@ -477,6 +644,11 @@ async function advanceTrial(
       trial.status = "failed";
       trial.error = `trial timeout: ${Math.round(elapsed / 1000)}s exceeded budget ${Math.round(timeoutMs / 1000)}s (m_idx=${trial.current_message_index ?? 0})`;
       trial.ended_at = new Date().toISOString();
+      // Phase 2 failure-trial gap fix: stale-session timeout is the most
+      // diagnostically valuable failure shape (model hung mid-tool,
+      // sandbox crashed, status endpoint broken). The trajectory will
+      // contain the partial event stream up to the freeze point.
+      await persistFailureTrajectory(env, run, task, trial, trial.session_id, "timeout", trial.error);
       return true;
     }
   }
@@ -495,28 +667,54 @@ async function advanceTrial(
       trial.status = "failed";
       trial.error = err instanceof Error ? err.message : String(err);
       trial.ended_at = new Date().toISOString();
+      // Phase 2 failure-trial gap fix: postUserMessage failure mid-run
+      // — the agent already produced N-1 turns of trajectory worth
+      // archiving even if turn N can't be sent.
+      await persistFailureTrajectory(env, run, task, trial, trial.session_id, "failure", trial.error);
       return true;
     }
   }
 
-  // All messages sent and session idle → build trajectory and finalize.
-  // Reaching this point means every spec.messages[] turn ran to idle without
-  // exceeding timeout_ms or hitting an error path; per Phase 1's
-  // trial-status-as-reward (the placeholder until the Verifier abstraction
-  // lands in Phase 2), that's a 1.0. Trajectory storage failure below is
-  // infrastructure, not verification — rolls back to running for retry,
-  // gives up at 3 attempts and demotes to failed (with the trajectory then
-  // never persisted, so no reward to write).
+  // All messages sent and session idle → build trajectory + run verifier.
+  // Reaching this point means every spec.messages[] turn ran to idle
+  // without exceeding timeout_ms or hitting an error path; the verifier
+  // (or the Phase 1 placeholder fallback when no spec is declared)
+  // grades the resulting trajectory and supplies the reward. Trajectory
+  // storage failure below is infrastructure, not verification — rolls
+  // back to running for retry, gives up at 3 attempts and demotes to
+  // failed (with the trajectory then never persisted, so no reward to
+  // write).
   try {
-    const finalReward = 1;
-    const result = await buildAndStoreTrajectory(env, run, task, trial, trial.session_id, finalReward);
-    trial.trajectory_id = result.trajectory_id;
+    // Build the trajectory once and run the verifier against it. The
+    // verifier may itself reach back into the sandbox via /exec (script
+    // RewardSpec); the canonical Trajectory is what gets graded.
+    // Synthesize a placeholder reward first so buildAndStoreTrajectory
+    // has something to wire in; immediately replace with the verified
+    // reward and re-store so persisted state matches what the verifier
+    // produced. Two writes is fine — eval finalize is bounded once per
+    // trial, the second store atomically overwrites the first.
+    const placeholder = await synthesizeNoRunReward("pre-verify placeholder");
+    const built = await buildAndStoreTrajectory(env, run, task, trial, trial.session_id, placeholder);
+    // Re-fetch the trajectory we just wrote (the verifier needs the
+    // enriched envelope: events + summary + outcome). Cheap: it's local KV.
+    const t = run.tenant_id;
+    const stored = await env.CONFIG_KV.get(kvKey(t, "trajectory", built.trajectory_id), "text");
+    if (!stored) throw new Error(`trajectory ${built.trajectory_id} disappeared after store`);
+    const trajectory = JSON.parse(stored) as Trajectory;
+    const reward = await runVerifier(env, run, task, trial, trial.session_id, trajectory);
+    trajectory.reward = reward;
+    await env.CONFIG_KV.put(
+      kvKey(t, "trajectory", built.trajectory_id),
+      JSON.stringify(trajectory),
+    );
+
+    trial.trajectory_id = built.trajectory_id;
     trial.status = "completed";
     trial.ended_at = new Date().toISOString();
     // Mirror Trajectory.reward.final_reward onto the trial for Console
     // back-compat. Phase 3 will switch the UI to read trajectory.reward
     // directly and this can drop.
-    trial.reward = result.final_reward;
+    trial.reward = reward.final_reward;
     return true;
   } catch (err: unknown) {
     // Bounded retry: events fetch can transiently 500 under storage

--- a/apps/main/src/routes/evals.ts
+++ b/apps/main/src/routes/evals.ts
@@ -1,5 +1,5 @@
 import { Hono } from "hono";
-import type { Env } from "@open-managed-agents/shared";
+import type { Env, RewardSpec } from "@open-managed-agents/shared";
 import type { EvalRunStatus } from "@open-managed-agents/evals-store";
 import type { Services } from "@open-managed-agents/services";
 import { kvKey } from "../kv-helpers";
@@ -27,6 +27,22 @@ export interface EvalTaskSpec {
   // Default 1. When > 1, server spawns N sessions per task and stores N
   // trajectory_ids; pass@k / pass^k computed by downstream scorer layer.
   trials?: number;
+  /**
+   * Phase 2: declarative reward / verification spec. Optional.
+   *   - undefined  → eval-runner falls back to "trial reached idle = pass"
+   *                 (the Phase 1 placeholder; reward.verifier_id =
+   *                 "eval-runner.trial-status.v1")
+   *   - { type: "script", verify_script } → ScriptVerifier runs the script
+   *                 in the sandbox via /exec and grades by exit code
+   *   - { type: "verifiable", scorer, opts } → wraps a named Scorer from
+   *                 packages/eval-core/src/scorers/scorers.ts
+   *   - { type: "composite", components: [...] } → weighted aggregate
+   *   - { type: "reward_model", endpoint } → external HTTP grader
+   *
+   * JSON wire shape matches RLTask.reward so the same task definitions
+   * work for both eval and RL. See packages/eval-core/src/verifier/types.ts.
+   */
+  reward?: RewardSpec;
 }
 
 export type { EvalRunStatus };

--- a/packages/eval-core/src/index.ts
+++ b/packages/eval-core/src/index.ts
@@ -13,3 +13,4 @@ export * from "./trajectory/types";
 export * from "./trajectory/build";
 export * from "./trajectory/projections/anthropic-messages";
 export * from "./scorers";
+export * from "./verifier";

--- a/packages/eval-core/src/verifier/builtins/composite.ts
+++ b/packages/eval-core/src/verifier/builtins/composite.ts
@@ -1,0 +1,71 @@
+// Composite Verifier — wraps N sub-Verifiers and aggregates their
+// `score.value` by weighted average. Each sub-score becomes a key in
+// the composite's `criteria`.
+//
+// Use case: a task that wants both "tests pass" (script) and "code is
+// idiomatic" (reward_model judge) signals combined into a single
+// reward scalar. The sub-Verifiers run in parallel — one slow LLM
+// judge doesn't stall the script verifier.
+
+import type { Trajectory } from "../../trajectory/types.js";
+import type { Score } from "../../scorers/types.js";
+import type { Verifier, VerifierContext, CompositeRewardSpec } from "../types.js";
+import { verifierForSpec } from "../registry.js";
+
+export class CompositeVerifier implements Verifier {
+  readonly id = "composite.v1";
+
+  constructor(
+    private readonly spec: CompositeRewardSpec,
+    private readonly ctx: VerifierContext,
+  ) {}
+
+  async check(traj: Trajectory): Promise<Score> {
+    const components = this.spec.components;
+    if (!components || components.length === 0) {
+      return {
+        pass: false,
+        value: 0,
+        reason: "composite verifier has no components",
+        metadata: { criteria: {} },
+      };
+    }
+
+    // Parallel execution — composite latency is max(child), not sum.
+    const settled = await Promise.allSettled(
+      components.map(async (c) => ({
+        name: c.name,
+        weight: c.weight,
+        score: await verifierForSpec(c.verifier, this.ctx).check(traj),
+      })),
+    );
+
+    const criteria: Record<string, number> = {};
+    const reasons: string[] = [];
+    let weightedSum = 0;
+    let totalWeight = 0;
+    let allPass = true;
+
+    for (const s of settled) {
+      if (s.status === "rejected") {
+        allPass = false;
+        reasons.push(`unknown_child_failed: ${String(s.reason).slice(0, 100)}`);
+        continue;
+      }
+      const { name, weight, score } = s.value;
+      criteria[name] = score.value;
+      weightedSum += score.value * weight;
+      totalWeight += weight;
+      reasons.push(`${name}=${score.value.toFixed(3)} (${score.reason.slice(0, 80)})`);
+      if (!score.pass) allPass = false;
+    }
+
+    const value = totalWeight > 0 ? weightedSum / totalWeight : 0;
+    return {
+      pass: allPass,
+      value,
+      reason: `composite: ${reasons.join("; ")}`,
+      metadata: { criteria },
+    };
+  }
+}

--- a/packages/eval-core/src/verifier/builtins/no_run.ts
+++ b/packages/eval-core/src/verifier/builtins/no_run.ts
@@ -1,0 +1,31 @@
+// No-Run Verifier — synthetic Verifier emitted for trials that died
+// before the agent ever produced a useful execution (setup error,
+// postUserMessage failure, per-trial wall-clock timeout). There's
+// nothing meaningful to score, so we record `value=0, pass=false`
+// with a stable verifier_id so consumers can distinguish "scored as
+// failure" from "no scoring attempted".
+//
+// Phase 2 use: eval-runner uses this for the failure-trial trajectory
+// gap fix (Phase 1 left it on purpose: failure trials had no
+// trajectory built; Phase 2 builds the trajectory and tags it
+// no-run.v1 so the failure timeline is still queryable).
+
+import type { Trajectory } from "../../trajectory/types.js";
+import type { Score } from "../../scorers/types.js";
+import type { Verifier } from "../types.js";
+
+export class NoRunVerifier implements Verifier {
+  readonly id = "no-run.v1";
+
+  constructor(private readonly reasonHint?: string) {}
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async check(_traj: Trajectory): Promise<Score> {
+    return {
+      pass: false,
+      value: 0,
+      reason: this.reasonHint ? `no-run: ${this.reasonHint}` : "no-run",
+      metadata: { criteria: { failure: 0 } },
+    };
+  }
+}

--- a/packages/eval-core/src/verifier/builtins/reward_model.ts
+++ b/packages/eval-core/src/verifier/builtins/reward_model.ts
@@ -1,0 +1,93 @@
+// Reward-Model Verifier — POSTs the trajectory + rubric to an external
+// HTTP endpoint and parses the response as a Score.
+//
+// Standard wire format the endpoint must produce:
+//   {
+//     "value": number,        // 0..1
+//     "pass": boolean,
+//     "reasoning"?: string,
+//     "criteria"?: Record<string, number>
+//   }
+//
+// Failure modes (network error, non-2xx, malformed body, timeout) are
+// converted to a deterministic 0-score so the trial doesn't hang. The
+// underlying error is surfaced in `reasoning` so the trajectory still
+// records why scoring failed.
+//
+// `judge(traj, rubric)` overrides whatever rubric was configured at
+// construction time — eval-core consumers should wire it from the
+// task's runtime rubric (e.g. `state.outcome.rubric` for the supervisor
+// loop).
+
+import type { Trajectory } from "../../trajectory/types.js";
+import type { Score } from "../../scorers/types.js";
+import type { Verifier, VerifierContext, RewardModelRewardSpec } from "../types.js";
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+interface RewardModelResponse {
+  value?: number;
+  pass?: boolean;
+  reasoning?: string;
+  criteria?: Record<string, number>;
+}
+
+export class RewardModelVerifier implements Verifier {
+  readonly id = "reward_model.v1";
+
+  constructor(
+    private readonly spec: RewardModelRewardSpec,
+    private readonly _ctx: VerifierContext,
+  ) {}
+
+  async check(traj: Trajectory): Promise<Score> {
+    return this.callRewardModel(traj, this.spec.prompt_template);
+  }
+
+  async judge(traj: Trajectory, rubric: string): Promise<Score> {
+    return this.callRewardModel(traj, rubric);
+  }
+
+  private async callRewardModel(traj: Trajectory, rubric?: string): Promise<Score> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), DEFAULT_TIMEOUT_MS);
+    try {
+      const res = await fetch(this.spec.endpoint, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ trajectory: traj, rubric: rubric ?? "" }),
+        signal: controller.signal,
+      });
+      if (!res.ok) {
+        const body = await res.text().catch(() => "");
+        return zero(`reward_model HTTP ${res.status}: ${body.slice(0, 200)}`);
+      }
+      const parsed = (await res.json().catch(() => null)) as RewardModelResponse | null;
+      if (!parsed || typeof parsed.value !== "number") {
+        return zero(`reward_model malformed response (no numeric value)`);
+      }
+      const value = clamp01(parsed.value);
+      const pass = typeof parsed.pass === "boolean" ? parsed.pass : value >= 0.5;
+      return {
+        pass,
+        value,
+        reason: parsed.reasoning || `reward_model value=${value.toFixed(3)}`,
+        metadata: { criteria: parsed.criteria ?? { value } },
+      };
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return zero(`reward_model error: ${msg.slice(0, 200)}`);
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+}
+
+function clamp01(n: number): number {
+  if (!Number.isFinite(n)) return 0;
+  return Math.max(0, Math.min(1, n));
+}
+
+function zero(reason: string): Score {
+  return { pass: false, value: 0, reason, metadata: { criteria: { value: 0 } } };
+}

--- a/packages/eval-core/src/verifier/builtins/script.ts
+++ b/packages/eval-core/src/verifier/builtins/script.ts
@@ -1,0 +1,57 @@
+// Script Verifier — runs a bash script in the agent's sandbox via /exec
+// and translates the exit code to a Score.
+//
+// This is the single most common Verifier shape in production today
+// (every terminal-bench task uses it: pytest the agent's output, exit 0
+// = pass). Replaces the inline /exec logic that previously lived inline
+// in eval-runner / rl-rollout / TB run-cloud — same wire format, single
+// implementation.
+
+import type { Trajectory } from "../../trajectory/types.js";
+import type { Score } from "../../scorers/types.js";
+import type { Verifier, VerifierContext, ScriptRewardSpec } from "../types.js";
+
+const DEFAULT_TIMEOUT_MS = 10 * 60 * 1000; // 10 min — matches existing TB call-sites
+
+export class ScriptVerifier implements Verifier {
+  readonly id = "script.v1";
+
+  constructor(
+    private readonly spec: ScriptRewardSpec,
+    private readonly ctx: VerifierContext,
+  ) {}
+
+  async check(_traj: Trajectory): Promise<Score> {
+    const timeout = this.spec.timeout_ms ?? DEFAULT_TIMEOUT_MS;
+    let exitCode = -1;
+    let output = "";
+    try {
+      const res = await this.ctx.runExec(this.spec.verify_script, { timeoutMs: timeout });
+      exitCode = res.exit_code;
+      output = res.output ?? "";
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return {
+        pass: false,
+        value: 0,
+        reason: `script verifier failed before running: ${msg.slice(0, 200)}`,
+        metadata: { exit_code: -1, output: "", error: msg },
+      };
+    }
+
+    const pass = exitCode === 0;
+    return {
+      pass,
+      value: pass ? 1 : 0,
+      reason: pass
+        ? `verify_script exited 0`
+        : `verify_script exited ${exitCode}`,
+      metadata: {
+        exit_code: exitCode,
+        // Truncate output — long pytest dumps would balloon the trajectory
+        // envelope on KV. Keep tail (where the failure summary usually is).
+        output: output.length > 4000 ? output.slice(-4000) : output,
+      },
+    };
+  }
+}

--- a/packages/eval-core/src/verifier/builtins/verifiable.ts
+++ b/packages/eval-core/src/verifier/builtins/verifiable.ts
@@ -1,0 +1,97 @@
+// Verifiable Verifier — wraps one of the named, pure-function Scorers
+// from packages/eval-core/src/scorers/scorers.ts as a Verifier.
+//
+// This is the bridge that activates the scorer library: existing
+// `bashExit` / `fileWritten` / `idleNoError` / `regex` / etc. become
+// referenceable from a JSON RewardSpec via:
+//
+//   { "type": "verifiable", "scorer": "bashExit", "opts": { "expectedCode": 0 } }
+//
+// SCORER_REGISTRY is the only piece that knows about each scorer's
+// constructor signature — keeps scorers.ts unchanged (they remain
+// pure higher-order functions) and gives JSON callers a typed entry
+// point. Adding a new scorer = appending to SCORER_REGISTRY.
+
+import type { Trajectory } from "../../trajectory/types.js";
+import type { Score, Scorer } from "../../scorers/types.js";
+import type { Verifier, VerifierContext, VerifiableRewardSpec } from "../types.js";
+import {
+  agentMessageContains,
+  bashExit,
+  bashOutputMarker,
+  bashSuccess,
+  fileWritten,
+  gaiaMatch,
+  idleNoError,
+  includes,
+  regex,
+  threadCreated,
+  toolNotUsed,
+  toolUsed,
+} from "../../scorers/scorers.js";
+
+type ScorerFactory = (opts: Record<string, unknown>) => Scorer;
+
+/**
+ * Mapping table: scorer name (used in JSON RewardSpec.scorer) →
+ * factory that adapts `opts` into the existing scorer signature.
+ *
+ * Entries here cover the 11 production scorers shipped today. New
+ * additions: keep the entry minimal (just unwrap `opts.<arg>`); the
+ * scorer factory in scorers.ts stays the source of truth.
+ */
+export const SCORER_REGISTRY: Record<string, ScorerFactory> = {
+  includes: (opts) =>
+    includes(String(opts.target ?? ""), { caseInsensitive: opts.caseInsensitive !== false }),
+
+  regex: (opts) => {
+    const pattern = opts.pattern;
+    const flags = typeof opts.flags === "string" ? opts.flags : "";
+    if (pattern instanceof RegExp) return regex(pattern);
+    return regex(new RegExp(String(pattern ?? ""), flags));
+  },
+
+  toolUsed: (opts) => toolUsed(String(opts.name ?? "")),
+  toolNotUsed: (opts) => toolNotUsed(String(opts.name ?? "")),
+
+  bashExit: (opts) => {
+    const expectedCode = typeof opts.expectedCode === "number" ? opts.expectedCode : 0;
+    return bashExit(expectedCode);
+  },
+  bashSuccess: () => bashSuccess(),
+  bashOutputMarker: (opts) => bashOutputMarker(String(opts.marker ?? "")),
+
+  fileWritten: (opts) => fileWritten(String(opts.filePath ?? opts.path ?? "")),
+
+  idleNoError: () => idleNoError(),
+
+  agentMessageContains: (opts) =>
+    agentMessageContains(String(opts.target ?? ""), {
+      caseInsensitive: opts.caseInsensitive !== false,
+    }),
+
+  threadCreated: (opts) =>
+    threadCreated(typeof opts.minCount === "number" ? opts.minCount : 1),
+
+  gaiaMatch: (opts) => gaiaMatch(String(opts.expected ?? "")),
+};
+
+export class VerifiableVerifier implements Verifier {
+  readonly id: string;
+  private readonly scorer: Scorer;
+
+  constructor(spec: VerifiableRewardSpec, _ctx: VerifierContext) {
+    const factory = SCORER_REGISTRY[spec.scorer];
+    if (!factory) {
+      throw new Error(
+        `verifiable: unknown scorer "${spec.scorer}" — known: ${Object.keys(SCORER_REGISTRY).join(", ")}`,
+      );
+    }
+    this.id = `verifiable.${spec.scorer}.v1`;
+    this.scorer = factory(spec.opts ?? {});
+  }
+
+  async check(traj: Trajectory): Promise<Score> {
+    return Promise.resolve(this.scorer(traj));
+  }
+}

--- a/packages/eval-core/src/verifier/index.ts
+++ b/packages/eval-core/src/verifier/index.ts
@@ -1,0 +1,9 @@
+// Verifier subsystem barrel — see types.ts for design notes.
+
+export * from "./types";
+export * from "./registry";
+export { ScriptVerifier } from "./builtins/script";
+export { CompositeVerifier } from "./builtins/composite";
+export { VerifiableVerifier, SCORER_REGISTRY } from "./builtins/verifiable";
+export { RewardModelVerifier } from "./builtins/reward_model";
+export { NoRunVerifier } from "./builtins/no_run";

--- a/packages/eval-core/src/verifier/registry.ts
+++ b/packages/eval-core/src/verifier/registry.ts
@@ -1,0 +1,30 @@
+// verifierForSpec: maps a RewardSpec to a concrete Verifier instance.
+//
+// One factory function so all consumers (eval-runner, rl-rollout, the
+// supervisor outcome loop, future Console "Re-grade" button) reach the
+// same implementations from a single dispatch point. Adding a new
+// RewardSpec branch lands here only.
+
+import type { Verifier, VerifierContext, RewardSpec } from "./types.js";
+import { ScriptVerifier } from "./builtins/script.js";
+import { CompositeVerifier } from "./builtins/composite.js";
+import { VerifiableVerifier } from "./builtins/verifiable.js";
+import { RewardModelVerifier } from "./builtins/reward_model.js";
+
+export function verifierForSpec(spec: RewardSpec, ctx: VerifierContext): Verifier {
+  switch (spec.type) {
+    case "script":
+      return new ScriptVerifier(spec, ctx);
+    case "composite":
+      return new CompositeVerifier(spec, ctx);
+    case "verifiable":
+      return new VerifiableVerifier(spec, ctx);
+    case "reward_model":
+      return new RewardModelVerifier(spec, ctx);
+    default: {
+      // exhaustiveness check — every RewardSpec branch must be handled
+      const _exhaustive: never = spec;
+      throw new Error(`unknown RewardSpec type: ${JSON.stringify(_exhaustive)}`);
+    }
+  }
+}

--- a/packages/eval-core/src/verifier/types.ts
+++ b/packages/eval-core/src/verifier/types.ts
@@ -1,0 +1,116 @@
+// OMA Verifier framework — Phase 2 of the Trajectory v1 unification plan.
+//
+// Replaces the three parallel verification paths that grew up independently:
+//   - eval-runner: ad-hoc /exec verify_script + exit_code
+//   - outcome-evaluator: standalone LLM judge
+//   - rl/verifier: turn-based heuristic checks
+//
+// Now: one Verifier interface, three consumers (eval / outcome / RL), one
+// canonical RewardSpec wire format. Trajectory.reward.verifier_id records
+// which Verifier produced a given reward, so a session can be re-graded
+// with a different one without re-executing.
+//
+// Design rule (per docs/handoff-verifier-framework.md):
+//   Task + Agent execution + Verifier → Score
+//     Outcome: score → needs_revision/satisfied (supervisor loop)
+//     Eval:    score → pass/fail (quality report)
+//     RL:      score → reward signal (training)
+
+import type { Trajectory } from "../trajectory/types.js";
+import type { Score } from "../scorers/types.js";
+
+/** Sandbox + session handle the script Verifier needs to run a verify
+ *  command. Ignored by Verifiers that don't touch the sandbox. */
+export interface VerifierContext {
+  /** Session whose sandbox the verifier should use. */
+  sessionId: string;
+  /**
+   * Run a shell command in the session's sandbox via /exec. Returns the
+   * exit code and combined stdout+stderr. Wall-clock timeout is the
+   * caller's responsibility — implementations should pass through
+   * `timeoutMs` when supplied.
+   */
+  runExec(cmd: string, opts?: { timeoutMs?: number }): Promise<{ exit_code: number; output: string }>;
+}
+
+/**
+ * One verifier — produces a Score from a Trajectory.
+ *
+ * Two modes:
+ *   - check(traj): deterministic inspection (script exit, file existence,
+ *     tool-use pattern match, …). Always available.
+ *   - judge(traj, rubric): LLM-based qualitative assessment. Optional;
+ *     consumers must fall back to check() when undefined.
+ */
+export interface Verifier {
+  /** Stable id used as `RewardResult.verifier_id` and for logging. */
+  readonly id: string;
+  /** Deterministic check — pure inspection of the trajectory. */
+  check(traj: Trajectory): Promise<Score>;
+  /**
+   * Optional LLM-judge variant when the task ships a rubric. Verifiers
+   * that don't have a judge mode should leave this undefined; consumers
+   * fall back to `check`.
+   */
+  judge?(traj: Trajectory, rubric: string): Promise<Score>;
+}
+
+/**
+ * Reward spec shapes that ship today. Verifier registry maps each to
+ * a concrete implementation. Keeps the existing JSON wire format
+ * (`type: "verifiable" | "script" | "reward_model" | "composite"`)
+ * intact so old task JSONs keep working.
+ *
+ * `weights` is consumer-defined metadata — composite uses per-component
+ * weight (see ScriptRewardSpec); leaf shapes carry it for forward-compat
+ * with future aggregators (e.g. multi-criterion scorers).
+ */
+export type RewardSpec =
+  | ScriptRewardSpec
+  | RewardModelRewardSpec
+  | CompositeRewardSpec
+  | VerifiableRewardSpec;
+
+export interface ScriptRewardSpec {
+  type: "script";
+  /** Bash script to run in the agent's sandbox. exit 0 = pass. */
+  verify_script: string;
+  /** Optional: per-component weights (currently informational). */
+  weights?: Record<string, number>;
+  /** Optional per-script wall-clock timeout in ms. Default at the runner. */
+  timeout_ms?: number;
+}
+
+export interface RewardModelRewardSpec {
+  type: "reward_model";
+  /** External HTTP endpoint the trajectory + rubric are POSTed to. */
+  endpoint: string;
+  /** Optional rubric / prompt template the endpoint will use. */
+  prompt_template?: string;
+  weights?: Record<string, number>;
+}
+
+export interface CompositeRewardSpec {
+  type: "composite";
+  components: Array<{
+    /** Sub-Verifier RewardSpec. */
+    verifier: RewardSpec;
+    /** Weight applied to this sub-Verifier's `score.value` during aggregation. */
+    weight: number;
+    /** Human-readable name used as the criteria key. */
+    name: string;
+  }>;
+}
+
+export interface VerifiableRewardSpec {
+  type: "verifiable";
+  /**
+   * Name of a registered Scorer (eval-core/src/scorers/scorers.ts —
+   * `bashExit`, `fileWritten`, `idleNoError`, `regex`, …). Resolved by
+   * the verifiable builtin's mapping table.
+   */
+  scorer: string;
+  /** Constructor opts forwarded to the named scorer factory. */
+  opts?: Record<string, unknown>;
+  weights?: Record<string, number>;
+}

--- a/packages/eval-core/tests/verifier.test.ts
+++ b/packages/eval-core/tests/verifier.test.ts
@@ -1,0 +1,234 @@
+// Phase 2 acceptance test for the Verifier framework.
+//
+// Goal: prove that verifierForSpec correctly resolves each RewardSpec
+// branch and that the verifiable builtin's SCORER_REGISTRY actually
+// reaches the named scorer factory in scorers.ts. Anything more
+// elaborate (live /exec, real reward_model HTTP) is integration.
+
+// @ts-nocheck
+import { describe, it, expect } from "vitest";
+import {
+  verifierForSpec,
+  SCORER_REGISTRY,
+  ScriptVerifier,
+  CompositeVerifier,
+  VerifiableVerifier,
+  RewardModelVerifier,
+  NoRunVerifier,
+} from "@open-managed-agents/eval-core";
+import type { Trajectory } from "@open-managed-agents/eval-core";
+
+function ev(seq: number, type: string, data: object = {}) {
+  return { seq, type, data: JSON.stringify({ type, ...data }), ts: "2026-04-17T10:00:00Z" };
+}
+
+function makeTrajectory(events: any[]): Trajectory {
+  return {
+    schema_version: "oma.trajectory.v1",
+    trajectory_id: "tr-1",
+    session_id: "sess-1",
+    agent_config: {} as any,
+    environment_config: {} as any,
+    model: { id: "test-model", provider: "" },
+    started_at: "2026-04-17T10:00:00Z",
+    outcome: "success",
+    events,
+    summary: {} as any,
+  };
+}
+
+const dummyCtx = {
+  sessionId: "sess-1",
+  runExec: async () => ({ exit_code: 0, output: "" }),
+};
+
+describe("verifierForSpec dispatch", () => {
+  it("resolves type:'script' to ScriptVerifier", () => {
+    const v = verifierForSpec({ type: "script", verify_script: "true" }, dummyCtx);
+    expect(v).toBeInstanceOf(ScriptVerifier);
+    expect(v.id).toBe("script.v1");
+  });
+
+  it("resolves type:'composite' to CompositeVerifier", () => {
+    const v = verifierForSpec(
+      {
+        type: "composite",
+        components: [
+          { name: "a", weight: 1, verifier: { type: "script", verify_script: "true" } },
+        ],
+      },
+      dummyCtx,
+    );
+    expect(v).toBeInstanceOf(CompositeVerifier);
+    expect(v.id).toBe("composite.v1");
+  });
+
+  it("resolves type:'verifiable' to VerifiableVerifier with the named scorer", () => {
+    const v = verifierForSpec(
+      { type: "verifiable", scorer: "bashExit", opts: { expectedCode: 0 } },
+      dummyCtx,
+    );
+    expect(v).toBeInstanceOf(VerifiableVerifier);
+    expect(v.id).toBe("verifiable.bashExit.v1");
+  });
+
+  it("resolves type:'reward_model' to RewardModelVerifier", () => {
+    const v = verifierForSpec(
+      { type: "reward_model", endpoint: "https://example.test/score" },
+      dummyCtx,
+    );
+    expect(v).toBeInstanceOf(RewardModelVerifier);
+    expect(v.id).toBe("reward_model.v1");
+  });
+
+  it("rejects an unknown scorer name with the registry's known list", () => {
+    expect(() =>
+      verifierForSpec({ type: "verifiable", scorer: "doesNotExist" }, dummyCtx),
+    ).toThrow(/unknown scorer "doesNotExist"/);
+  });
+});
+
+describe("VerifiableVerifier (the bashExit registry path)", () => {
+  it("returns pass when the last bash tool call exited 0", async () => {
+    const traj = makeTrajectory([
+      ev(1, "user.message", { content: [{ type: "text", text: "ls" }] }),
+      ev(2, "agent.tool_use", { id: "tu1", name: "bash", input: { command: "ls" } }),
+      ev(3, "agent.tool_result", { tool_use_id: "tu1", content: "file1\nfile2\nexit=0" }),
+      ev(4, "session.status_idle"),
+    ]);
+    const v = verifierForSpec(
+      { type: "verifiable", scorer: "bashExit", opts: { expectedCode: 0 } },
+      dummyCtx,
+    );
+    const score = await v.check(traj);
+    expect(score.pass).toBe(true);
+    expect(score.value).toBe(1);
+  });
+
+  it("returns fail when the last bash tool call exited non-zero", async () => {
+    const traj = makeTrajectory([
+      ev(1, "user.message", { content: [{ type: "text", text: "false" }] }),
+      ev(2, "agent.tool_use", { id: "tu1", name: "bash", input: { command: "false" } }),
+      ev(3, "agent.tool_result", { tool_use_id: "tu1", content: "exit=1" }),
+      ev(4, "session.status_idle"),
+    ]);
+    const v = verifierForSpec(
+      { type: "verifiable", scorer: "bashExit", opts: { expectedCode: 0 } },
+      dummyCtx,
+    );
+    const score = await v.check(traj);
+    expect(score.pass).toBe(false);
+    expect(score.value).toBe(0);
+  });
+
+  it("registry exposes all 11 production scorers", () => {
+    // Lock the registry surface so adding a scorer to scorers.ts and
+    // forgetting to wire it through the JSON RewardSpec layer fails fast.
+    expect(Object.keys(SCORER_REGISTRY).sort()).toEqual([
+      "agentMessageContains",
+      "bashExit",
+      "bashOutputMarker",
+      "bashSuccess",
+      "fileWritten",
+      "gaiaMatch",
+      "idleNoError",
+      "includes",
+      "regex",
+      "threadCreated",
+      "toolNotUsed",
+      "toolUsed",
+    ]);
+  });
+});
+
+describe("ScriptVerifier", () => {
+  it("returns pass when ctx.runExec exits 0", async () => {
+    const ctx = {
+      sessionId: "sess-1",
+      runExec: async () => ({ exit_code: 0, output: "all tests passed" }),
+    };
+    const v = verifierForSpec({ type: "script", verify_script: "pytest" }, ctx);
+    const score = await v.check({} as any);
+    expect(score.pass).toBe(true);
+    expect(score.value).toBe(1);
+    expect((score.metadata as any).exit_code).toBe(0);
+  });
+
+  it("returns fail when ctx.runExec exits non-zero, surfaces output tail", async () => {
+    const longOutput = "a".repeat(5000) + "FAIL line";
+    const ctx = {
+      sessionId: "sess-1",
+      runExec: async () => ({ exit_code: 1, output: longOutput }),
+    };
+    const v = verifierForSpec({ type: "script", verify_script: "pytest" }, ctx);
+    const score = await v.check({} as any);
+    expect(score.pass).toBe(false);
+    expect(score.value).toBe(0);
+    expect((score.metadata as any).exit_code).toBe(1);
+    // Truncated to 4000 chars (tail kept where pytest summary lives)
+    expect((score.metadata as any).output.length).toBe(4000);
+    expect((score.metadata as any).output.endsWith("FAIL line")).toBe(true);
+  });
+
+  it("returns fail with reason on runExec throw", async () => {
+    const ctx = {
+      sessionId: "sess-1",
+      runExec: async () => {
+        throw new Error("network unreachable");
+      },
+    };
+    const v = verifierForSpec({ type: "script", verify_script: "pytest" }, ctx);
+    const score = await v.check({} as any);
+    expect(score.pass).toBe(false);
+    expect(score.value).toBe(0);
+    expect(score.reason).toMatch(/network unreachable/);
+  });
+});
+
+describe("CompositeVerifier", () => {
+  it("aggregates child scores by weighted average", async () => {
+    let callCount = 0;
+    const ctx = {
+      sessionId: "sess-1",
+      // Two script children — first passes (1.0), second fails (0.0)
+      runExec: async () => {
+        callCount++;
+        return { exit_code: callCount === 1 ? 0 : 1, output: "" };
+      },
+    };
+    const v = verifierForSpec(
+      {
+        type: "composite",
+        components: [
+          { name: "tests", weight: 3, verifier: { type: "script", verify_script: "pytest" } },
+          { name: "lint", weight: 1, verifier: { type: "script", verify_script: "ruff check" } },
+        ],
+      },
+      ctx,
+    );
+    const score = await v.check({} as any);
+    // Weighted average = (3*1 + 1*0) / 4 = 0.75
+    expect(score.value).toBeCloseTo(0.75, 5);
+    // pass=false because at least one child failed
+    expect(score.pass).toBe(false);
+    expect((score.metadata as any).criteria).toEqual({ tests: 1, lint: 0 });
+  });
+
+  it("returns 0 with empty components array", async () => {
+    const v = verifierForSpec({ type: "composite", components: [] }, dummyCtx);
+    const score = await v.check({} as any);
+    expect(score.value).toBe(0);
+    expect(score.pass).toBe(false);
+  });
+});
+
+describe("NoRunVerifier", () => {
+  it("always returns 0 with stable verifier_id", async () => {
+    const v = new NoRunVerifier("setup_files write failed");
+    const score = await v.check({} as any);
+    expect(v.id).toBe("no-run.v1");
+    expect(score.pass).toBe(false);
+    expect(score.value).toBe(0);
+    expect(score.reason).toMatch(/no-run: setup_files write failed/);
+  });
+});

--- a/rl/rollout.ts
+++ b/rl/rollout.ts
@@ -1,12 +1,13 @@
 import type { RLTask, RLTaskSet, RolloutConfig, RolloutResult, Trajectory, TokenUsage } from "./types.js";
 import { eventsToTrajectory } from "./trajectory.js";
 import { computeReward, batchRewardStats } from "./reward.js";
-import { runScriptVerifier } from "./verifier.js";
+import { verifierForSpec, type VerifierContext } from "../packages/eval-core/src/index.js";
 import {
   createAgent,
   createSession,
   deleteAgent,
   deleteSession,
+  execInSandbox,
   sendAndWait,
   setupFiles,
   getOrCreateEnvironment,
@@ -17,6 +18,22 @@ const DEFAULT_TOOLS = [
 ];
 
 const DEFAULT_SYSTEM = "You are a helpful assistant. Complete tasks precisely and efficiently.";
+
+/**
+ * Build a VerifierContext for the given session that runs verify_scripts
+ * directly in the sandbox via /exec. Replaces the prior runScriptVerifier
+ * approach (which sent a follow-up message asking the model to run the
+ * script and emit `EXIT_CODE=N`) — that flow consumed model tokens, was
+ * non-deterministic (model could refuse / paraphrase), and had no
+ * timeout discipline. The Verifier framework's ScriptVerifier uses this
+ * ctx.runExec to talk to the sandbox directly.
+ */
+function buildVerifierContext(sessionId: string): VerifierContext {
+  return {
+    sessionId,
+    runExec: (cmd, opts) => execInSandbox(sessionId, cmd, opts?.timeoutMs ?? 600_000),
+  };
+}
 
 class SessionPool {
   private available: Array<{ sessionId: string; agentId: string }> = [];
@@ -93,13 +110,21 @@ async function executeTask(
 
     if (task.reward.type === "script" && task.reward.verify_script) {
       try {
-        const vr = await runScriptVerifier(
-          sendAndWait,
-          handle.sessionId,
-          task.reward.verify_script,
-          600_000,
+        // Phase 2 unification: route through ScriptVerifier (single
+        // verify_script implementation across eval-runner + RL rollout).
+        // Pass an empty Trajectory placeholder — ScriptVerifier doesn't
+        // inspect it, only runs the script and grades by exit code.
+        const ctx = buildVerifierContext(handle.sessionId);
+        const verifier = verifierForSpec(
+          { type: "script", verify_script: task.reward.verify_script },
+          ctx,
         );
-        trajectory.metadata.verifier_result = vr;
+        const score = await verifier.check({} as never);
+        const meta = score.metadata as { exit_code?: number; output?: string } | undefined;
+        trajectory.metadata.verifier_result = {
+          exit_code: typeof meta?.exit_code === "number" ? meta.exit_code : score.pass ? 0 : -1,
+          output: typeof meta?.output === "string" ? meta.output : "",
+        };
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         trajectory.metadata.verifier_result = { exit_code: -1, output: `verifier_error: ${msg}` };

--- a/rl/verifier.ts
+++ b/rl/verifier.ts
@@ -69,6 +69,13 @@ function checkSandboxExec(_trajectory: Trajectory, _check: VerifyCheck): number 
 // --- Script verifier (run a verify_script in the sandbox via a follow-up turn) ---
 
 /**
+ * @deprecated Phase 2 (trajectory-v1) replaced this with the canonical
+ * `ScriptVerifier` from `@open-managed-agents/eval-core`, which executes
+ * `verify_script` directly in the sandbox via the `/exec` endpoint
+ * (deterministic, no model token cost, hard timeout). Kept exported only
+ * to avoid breaking external imports during the deprecation window;
+ * remove once no consumer imports it (Phase 4 cleanup).
+ *
  * Run a verify_script in the agent's sandbox by sending a follow-up message,
  * then parse the agent's reply for `EXIT_CODE=<n>`. Used for `RewardSpec.type
  * === "script"` tasks (e.g. terminal-bench pytest tests).

--- a/test/eval/client.ts
+++ b/test/eval/client.ts
@@ -375,6 +375,40 @@ export interface CleanupHandle {
   sessionIds: string[];
 }
 
+/**
+ * Run a raw shell command in this session's sandbox via /v1/sessions/:id/exec.
+ * Bypasses the agent — used by RL rollout's verify_script flow so the model
+ * doesn't have to re-execute deterministic infra.
+ *
+ * Mirrors the eval-runner-side helper in apps/main/src/eval-runner.ts —
+ * keeps a single sandbox-exec call shape across both runners.
+ */
+export async function execInSandbox(
+  sessionId: string,
+  command: string,
+  timeoutMs: number = 600_000,
+): Promise<{ exit_code: number; output: string }> {
+  const url = `${API_URL}/v1/sessions/${sessionId}/exec`;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs + 5_000); // extra slack
+  try {
+    const res = await fetch(url, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ command, timeout_ms: timeoutMs }),
+      signal: controller.signal,
+    });
+    if (!res.ok) {
+      const body = await res.text().catch(() => "");
+      return { exit_code: -1, output: `HTTP ${res.status}: ${body.slice(0, 200)}` };
+    }
+    const data = (await res.json()) as { exit_code?: number; output?: string };
+    return { exit_code: data.exit_code ?? -1, output: data.output ?? "" };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
 export async function cleanup(handle: CleanupHandle): Promise<void> {
   for (const sid of handle.sessionIds) {
     await deleteSession(sid);


### PR DESCRIPTION
> Stacked on #34 — review after that merges, or treat as a single squash unit.

## Summary

Phase 2 of the Trajectory v1 unification track. Introduces a single `Verifier` substrate that **outcome evaluation**, **eval reward**, and **RL rollout reward** all consume. Replaces three near-duplicate scoring code paths with one.

## What lands

**`packages/eval-core` — `Verifier` interface and 5 built-ins:**
- `Verifier.check(traj) → Score` — rule-based (script, registry scorer, composite, no-run)
- `Verifier.judge(traj, rubric) → Score` — model-based (LlmJudgeVerifier in Phase 4)
- Built-ins: `script`, `verifiable` (11-scorer registry), `composite`, `reward_model`, `no_run`
- `RewardSpec` discriminated union tagging which built-in to use

**`apps/main/src/eval-runner.ts` — eval reward via Verifier:**
- `runVerifier()` translates `Score → RewardResult`
- `synthesizeNoRunReward()` keeps failure trials inside the framework instead of returning a synthetic blob

**`apps/main` outcome-evaluator → Score projection:**
- AMA-style `EvaluationResult` adapts to the Score shape so the supervisor (Phase 4) can drive the same loop

**`rl/rollout.ts`:**
- Routes `verify_script` through the canonical `ScriptVerifier`, killing the parallel implementation in `rl/verifier.ts`

**Acceptance suite:**
- `packages/eval-core/tests/verifier.test.ts` — 14 tests covering registry dispatch + each built-in

## Why one substrate matters

Outcome verdicts, eval rewards, and RL rewards were three implementations of "reduce a trajectory to a number". Three implementations meant three places to update when, e.g., we added a scorer, three places where shapes drifted, three places where failure-path coverage was inconsistent.

## Test plan

- [ ] pnpm vitest run packages/eval-core — verifier suite green
- [ ] Run an eval with a script reward — Trajectory.reward populated via Verifier path
- [ ] Run RL rollout — verify_script routes through ScriptVerifier
- [ ] Force a no-run failure trial — Trajectory persisted with no_run synthesized reward

🤖 Generated with [Claude Code](https://claude.com/claude-code)