### PR TITLE
feat(console): trajectory viz — eval reward, session outcome/reward chips, viewer modal

### DIFF
--- a/apps/console/src/lib/trajectory.ts
+++ b/apps/console/src/lib/trajectory.ts
@@ -1,0 +1,86 @@
+// Console-side Trajectory v1 types (subset).
+//
+// The canonical types live in `packages/eval-core/src/trajectory/types.ts`.
+// We keep a minimal mirror here so the console doesn't pull in the eval-core
+// workspace package (and its transitive deps) just to read four fields off a
+// JSON response. If the spec ever lands stable types in @open-managed-agents/
+// api-types, swap this import.
+//
+// See docs/trajectory-v1-spec.md for the authoritative shape.
+
+export type TrajectoryOutcome =
+  | "success"
+  | "failure"
+  | "timeout"
+  | "interrupted"
+  | "running";
+
+export interface RewardResult {
+  raw_rewards: Record<string, number>;
+  final_reward: number;
+  verifier_id?: string;
+  computed_at?: string;
+}
+
+export interface TrajectorySummary {
+  num_events: number;
+  num_turns: number;
+  num_tool_calls: number;
+  num_tool_errors: number;
+  num_threads: number;
+  duration_ms: number;
+  token_usage: {
+    input_tokens: number;
+    output_tokens: number;
+    cache_read_input_tokens: number;
+    cache_creation_input_tokens?: number;
+  };
+}
+
+/** Minimal Trajectory envelope as the console consumes it. The wire payload
+ *  carries more (events, agent_config, environment_config, completions); we
+ *  type those as `unknown` so we don't have to mirror the full schema. */
+export interface Trajectory {
+  schema_version: "oma.trajectory.v1";
+  trajectory_id: string;
+  session_id: string;
+  group_id?: string;
+  task_id?: string;
+
+  agent_config: unknown;
+  environment_config: unknown;
+  model: { id: string; provider: string; base_url?: string };
+
+  started_at: string;
+  ended_at?: string;
+  outcome: TrajectoryOutcome;
+
+  events: unknown[];
+
+  reward?: RewardResult;
+  completions?: unknown[];
+  group_stats?: unknown;
+
+  summary: TrajectorySummary;
+}
+
+/** Render the headline for a reward: "PASS" / "FAIL" / "0.42". */
+export function rewardHeadline(reward: RewardResult): string {
+  const v = reward.final_reward;
+  if (!Number.isFinite(v)) return "—";
+  if (v >= 0.99) return "PASS";
+  if (v <= 0) return "FAIL";
+  return v.toFixed(2);
+}
+
+/** Map TrajectoryOutcome → StatusPill `status` token (Badge.tsx) so the
+ *  pill picks up the right color tone. */
+export function outcomeToStatusTone(outcome: TrajectoryOutcome): string {
+  switch (outcome) {
+    case "success":     return "completed";
+    case "failure":     return "errored";
+    case "timeout":     return "errored";
+    case "interrupted": return "terminated";
+    case "running":     return "running";
+  }
+}

--- a/apps/console/src/pages/EvalRunDetail.tsx
+++ b/apps/console/src/pages/EvalRunDetail.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router";
 import { useApi } from "../lib/api";
+import type { Trajectory } from "../lib/trajectory";
+import { rewardHeadline } from "../lib/trajectory";
 
 interface EvalTrial {
   trial_index: number;
@@ -76,6 +78,15 @@ export function EvalRunDetail() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  /** Cache of trajectory fetches keyed by session_id. Populated lazily when
+   *  the user expands a task row — we don't pull every trial's trajectory
+   *  on initial page load (could be hundreds of trials per run). The
+   *  sentinel "loading" / "error" states keep the UI honest while inflight
+   *  / after a failure (404 = trajectory not built yet, 5xx = sandbox flaky)
+   *  so we don't retry on every render. */
+  const [trajectories, setTrajectories] = useState<
+    Map<string, Trajectory | "loading" | "error">
+  >(new Map());
 
   useEffect(() => {
     if (!id) return;
@@ -110,6 +121,40 @@ export function EvalRunDetail() {
       else next.add(taskId);
       return next;
     });
+    // Lazy-fetch trajectories for any trial in this task that has a
+    // session_id and hasn't been requested yet. The fetch result lands in
+    // `trajectories` keyed by session_id; render reads from that map.
+    const task = run?.tasks.find(t => t.id === taskId);
+    if (!task) return;
+    for (const tr of task.trials) {
+      if (!tr.session_id) continue;
+      // Avoid re-fetching anything already in flight, completed, or failed.
+      if (trajectories.has(tr.session_id)) continue;
+      void fetchTrajectory(tr.session_id);
+    }
+  }
+
+  async function fetchTrajectory(sessionId: string) {
+    setTrajectories(prev => {
+      if (prev.has(sessionId)) return prev;
+      const next = new Map(prev);
+      next.set(sessionId, "loading");
+      return next;
+    });
+    try {
+      const traj = await api<Trajectory>(`/v1/sessions/${sessionId}/trajectory`);
+      setTrajectories(prev => {
+        const next = new Map(prev);
+        next.set(sessionId, traj);
+        return next;
+      });
+    } catch {
+      setTrajectories(prev => {
+        const next = new Map(prev);
+        next.set(sessionId, "error");
+        return next;
+      });
+    }
   }
 
   if (loading) {
@@ -264,13 +309,10 @@ export function EvalRunDetail() {
                                 </span>
                               </td>
                               <td className="py-1 pr-3">
-                                {tr.reward != null ? (
-                                  <span className={tr.reward >= 1 ? "text-success font-semibold" : "text-fg-subtle"}>
-                                    {tr.reward}
-                                  </span>
-                                ) : (
-                                  <span className="text-fg-subtle">—</span>
-                                )}
+                                <TrialReward
+                                  fallback={tr.reward}
+                                  trajectory={tr.session_id ? trajectories.get(tr.session_id) : undefined}
+                                />
                               </td>
                               <td className="py-1 pr-3 font-mono text-fg-muted">{tr.exit_code ?? "—"}</td>
                               <td className="py-1 pr-3 text-fg-muted">{durationStr(tr.started_at, tr.ended_at)}</td>
@@ -291,6 +333,29 @@ export function EvalRunDetail() {
                           ))}
                         </tbody>
                       </table>
+
+                      {t.trials.some(tr => tr.session_id && trajectories.get(tr.session_id) && trajectories.get(tr.session_id) !== "loading" && trajectories.get(tr.session_id) !== "error") && (
+                        <details>
+                          <summary className="cursor-pointer text-xs text-fg-subtle hover:text-fg">
+                            reward breakdown
+                          </summary>
+                          <div className="mt-1 space-y-2">
+                            {t.trials.map(tr => {
+                              if (!tr.session_id) return null;
+                              const traj = trajectories.get(tr.session_id);
+                              if (!traj || traj === "loading" || traj === "error") return null;
+                              if (!traj.reward) return null;
+                              return (
+                                <RewardBreakdown
+                                  key={tr.trial_index}
+                                  trialIndex={tr.trial_index}
+                                  reward={traj.reward}
+                                />
+                              );
+                            })}
+                          </div>
+                        </details>
+                      )}
 
                       {t.trials.some(tr => tr.error) && (
                         <div className="text-xs text-danger space-y-0.5">
@@ -348,6 +413,104 @@ export function EvalRunDetail() {
           </tbody>
         </table>
       </div>
+    </div>
+  );
+}
+
+/** Reward cell on a trial row.
+ *
+ *  Prefers `Trajectory.reward.final_reward` (the unified Verifier output)
+ *  when the lazy-fetched trajectory is available — that's the v1 story.
+ *  Falls back to the legacy `EvalTrialResult.reward` (from when the eval
+ *  runner stamped a single number directly on the trial) so trials whose
+ *  trajectory isn't built yet still render something useful.
+ *
+ *  Sentinel handling:
+ *   - "loading" → small dim placeholder (no extra chrome)
+ *   - "error"   → fallback + "trajectory unavailable" tooltip
+ *   - undefined → fallback only (parent task wasn't expanded yet) */
+function TrialReward({
+  fallback,
+  trajectory,
+}: {
+  fallback: number | undefined;
+  trajectory: Trajectory | "loading" | "error" | undefined;
+}) {
+  if (trajectory && trajectory !== "loading" && trajectory !== "error" && trajectory.reward) {
+    const r = trajectory.reward;
+    const headline = rewardHeadline(r);
+    const isPass = r.final_reward >= 0.99;
+    const isFail = r.final_reward <= 0;
+    const cls = isPass
+      ? "text-success font-semibold"
+      : isFail
+      ? "text-danger font-semibold"
+      : "text-fg";
+    return (
+      <div className="leading-tight">
+        <div className={cls}>{headline}</div>
+        {r.verifier_id && (
+          <div className="text-[10px] text-fg-subtle font-mono">graded by {r.verifier_id}</div>
+        )}
+      </div>
+    );
+  }
+  if (trajectory === "loading") {
+    return <span className="text-fg-subtle text-[10px]">loading…</span>;
+  }
+  if (fallback != null) {
+    const tooltip = trajectory === "error" ? "trajectory unavailable; using legacy reward" : undefined;
+    return (
+      <span
+        className={fallback >= 1 ? "text-success font-semibold" : "text-fg-subtle"}
+        title={tooltip}
+      >
+        {fallback}
+      </span>
+    );
+  }
+  if (trajectory === "error") {
+    return <span className="text-fg-subtle text-[10px]" title="trajectory fetch failed">trajectory unavailable</span>;
+  }
+  return <span className="text-fg-subtle">—</span>;
+}
+
+/** Per-trial raw_rewards table. Renders one row per criterion in
+ *  `RewardResult.raw_rewards`. Hidden in a <details> in the parent so
+ *  large multi-criterion verifiers don't blow out the row height. */
+function RewardBreakdown({
+  trialIndex,
+  reward,
+}: {
+  trialIndex: number;
+  reward: { raw_rewards: Record<string, number>; final_reward: number; verifier_id?: string };
+}) {
+  const entries = Object.entries(reward.raw_rewards);
+  return (
+    <div className="border border-border rounded p-2 bg-bg">
+      <div className="text-[11px] text-fg-subtle mb-1 flex items-baseline gap-2">
+        <span>trial {trialIndex}</span>
+        {reward.verifier_id && (
+          <span className="font-mono">{reward.verifier_id}</span>
+        )}
+        <span className="ml-auto text-fg">
+          final = <span className="font-semibold">{reward.final_reward.toFixed(2)}</span>
+        </span>
+      </div>
+      {entries.length === 0 ? (
+        <div className="text-[11px] text-fg-subtle italic">no raw_rewards recorded</div>
+      ) : (
+        <table className="w-full text-[11px]">
+          <tbody>
+            {entries.map(([k, v]) => (
+              <tr key={k} className="border-t border-border/40">
+                <td className="py-0.5 pr-2 font-mono text-fg-muted">{k}</td>
+                <td className="py-0.5 text-right text-fg">{Number.isFinite(v) ? v.toFixed(2) : String(v)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
     </div>
   );
 }

--- a/apps/console/src/pages/SessionDetail.tsx
+++ b/apps/console/src/pages/SessionDetail.tsx
@@ -4,9 +4,13 @@ import { useApi } from "../lib/api";
 import { Markdown } from "../components/Markdown";
 import { formatDuration, formatRelative, shortenId } from "../lib/format";
 import { Badge, StatusPill } from "../components/Badge";
+import { Modal } from "../components/Modal";
+import { Button } from "../components/Button";
 import { AgentIcon, ClockIcon, DurationIcon, EnvIcon, VaultIcon } from "../components/icons";
 import { TimelineView } from "../components/timeline/TimelineView";
 import type { Event } from "../lib/events";
+import type { Trajectory, TrajectoryOutcome } from "../lib/trajectory";
+import { rewardHeadline, outcomeToStatusTone } from "../lib/trajectory";
 
 type View = "chat" | "timeline";
 
@@ -57,6 +61,14 @@ export function SessionDetail() {
     eventKind?: string;
   } | null>(null);
   const [status, setStatus] = useState("idle");
+  /** Lazy-fetched Trajectory v1 envelope. Drives the outcome + reward
+   *  chips in the header strip and the Trajectory viewer modal. We don't
+   *  block initial render on this — chips render as `—` until it lands.
+   *  Sentinels mirror EvalRunDetail: "loading" while in flight, "error"
+   *  if the fetch failed (404 = trajectory not built yet, 5xx = sandbox
+   *  flaky); both keep the trigger from re-firing every render. */
+  const [trajectory, setTrajectory] = useState<Trajectory | "loading" | "error" | undefined>(undefined);
+  const [showTrajectory, setShowTrajectory] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);
   const seenKeys = useRef(new Set<string>());
   const abortRef = useRef<AbortController | null>(null);
@@ -298,6 +310,18 @@ export function SessionDetail() {
     abortRef.current = abort;
     streamEvents(id, addEvent, abort.signal);
 
+    // Lazy-fetch the Trajectory envelope so the header chips have the
+    // outcome + reward to show. Decoupled from session/events fetches —
+    // trajectory builds on-demand off the events log, so a 5xx here is
+    // independent of session metadata loading. We do this once per
+    // session id and let the user reopen the page to refresh. Live
+    // sessions intentionally don't poll: trajectory.outcome === "running"
+    // is fine, the StatusPill already shows the live status.
+    setTrajectory("loading");
+    api<Trajectory>(`/v1/sessions/${id}/trajectory`)
+      .then((t) => setTrajectory(t))
+      .catch(() => setTrajectory("error"));
+
     return () => { abort.abort(); };
   }, [id]);
 
@@ -333,6 +357,15 @@ export function SessionDetail() {
         </div>
         <div className="flex items-center gap-2 flex-wrap">
           <StatusPill status={status as "idle" | "running" | "terminated" | "error" | string} />
+          {/* Trajectory outcome chip — only when the trajectory has actually
+              finished. While the session is still running we let StatusPill
+              carry the "Running…" signal alone (per Phase 3 spec) instead of
+              double-pilling. */}
+          <TrajectoryOutcomeChip trajectory={trajectory} />
+          {/* Reward chip — final_reward + verifier_id tooltip. Hidden when
+              the verifier hasn't run (no trajectory.reward) so we don't
+              imply "no reward = score 0". */}
+          <TrajectoryRewardChip trajectory={trajectory} />
           {/* Always render env + agent + vault badges so an operator can
               see what makes up this session at a glance. Name falls back
               to a short ID slice if the snapshot didn't carry one — better
@@ -375,6 +408,24 @@ export function SessionDetail() {
         {view === "timeline" && (
           <span className="ml-auto text-xs text-fg-subtle font-mono">{events.length} events</span>
         )}
+        {/* Trajectory viewer trigger — pushed to the right edge of the tab
+            row. Disabled until the lazy fetch resolves so the click never
+            opens an empty modal. Errors keep the button enabled (the modal
+            shows the error). */}
+        <button
+          onClick={() => setShowTrajectory(true)}
+          disabled={trajectory === undefined || trajectory === "loading"}
+          className={`${view === "timeline" ? "ml-3" : "ml-auto"} text-xs text-fg-muted hover:text-fg disabled:opacity-40 disabled:cursor-not-allowed border border-border hover:border-border-strong rounded px-2 py-1 transition-colors my-1.5`}
+          title={
+            trajectory === "loading"
+              ? "Loading trajectory…"
+              : trajectory === "error"
+              ? "Trajectory unavailable — click to inspect error"
+              : "View raw Trajectory v1 envelope"
+          }
+        >
+          Trajectory
+        </button>
       </div>
 
       {/* Linear context (when triggered by a Linear webhook) */}
@@ -496,7 +547,127 @@ export function SessionDetail() {
           />
         )}
       </div>
+      <TrajectoryViewerModal
+        open={showTrajectory}
+        onClose={() => setShowTrajectory(false)}
+        sessionId={id ?? ""}
+        trajectory={trajectory}
+      />
     </div>
+  );
+}
+
+/** Outcome chip rendered in the session header strip. Hidden while
+ *  the trajectory is loading / errored / still running so we never
+ *  paint an inaccurate state. The "running" outcome is intentionally
+ *  squelched here — StatusPill already renders the live status. */
+function TrajectoryOutcomeChip({
+  trajectory,
+}: {
+  trajectory: Trajectory | "loading" | "error" | undefined;
+}) {
+  if (!trajectory || trajectory === "loading" || trajectory === "error") return null;
+  if (trajectory.outcome === "running") return null;
+  const tone = outcomeToStatusTone(trajectory.outcome);
+  return (
+    <StatusPill
+      status={tone}
+      label={`Outcome: ${trajectory.outcome}`}
+    />
+  );
+}
+
+/** Reward chip rendered in the session header strip. Pure read-out of
+ *  the verifier output; tooltip shows verifier_id for debugging. */
+function TrajectoryRewardChip({
+  trajectory,
+}: {
+  trajectory: Trajectory | "loading" | "error" | undefined;
+}) {
+  if (!trajectory || trajectory === "loading" || trajectory === "error") return null;
+  const r = trajectory.reward;
+  if (!r) return null;
+  const headline = rewardHeadline(r);
+  const isPass = r.final_reward >= 0.99;
+  const isFail = r.final_reward <= 0;
+  // Reuse StatusPill tone tokens so the visual language stays consistent
+  // with the outcome chip next to it (success = same green, failure = red).
+  const tone = isPass ? "completed" : isFail ? "errored" : "neutral";
+  const titleParts = [
+    `Reward: ${r.final_reward.toFixed(4)}`,
+    r.verifier_id ? `verifier: ${r.verifier_id}` : null,
+    r.computed_at ? `computed: ${new Date(r.computed_at).toLocaleString()}` : null,
+  ].filter(Boolean) as string[];
+  return (
+    <span title={titleParts.join(" · ")}>
+      <StatusPill status={tone} label={`Reward: ${headline}`} />
+    </span>
+  );
+}
+
+/** Trajectory viewer modal — Phase 3 minimum-viable: pretty-printed
+ *  JSON with a Download button. Anthropic Messages / Inspect AI / OTel
+ *  projections are Phase 4. The download uses an in-memory blob URL
+ *  so we don't have to round-trip to a server endpoint. */
+function TrajectoryViewerModal({
+  open,
+  onClose,
+  sessionId,
+  trajectory,
+}: {
+  open: boolean;
+  onClose: () => void;
+  sessionId: string;
+  trajectory: Trajectory | "loading" | "error" | undefined;
+}) {
+  const ready = trajectory && trajectory !== "loading" && trajectory !== "error";
+  const json = ready ? JSON.stringify(trajectory, null, 2) : "";
+
+  function download() {
+    if (!ready) return;
+    const blob = new Blob([json], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `trajectory-${sessionId}.json`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  }
+
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      title="Trajectory"
+      subtitle={ready ? `${trajectory.trajectory_id} · session ${sessionId}` : `session ${sessionId}`}
+      maxWidth="max-w-4xl"
+      footer={
+        <>
+          <Button variant="ghost" onClick={onClose}>Close</Button>
+          <Button onClick={download} disabled={!ready}>Download JSON</Button>
+        </>
+      }
+    >
+      {trajectory === "loading" && (
+        <div className="text-sm text-fg-subtle">Loading trajectory…</div>
+      )}
+      {trajectory === "error" && (
+        <div className="text-sm text-danger">
+          Trajectory unavailable. The session may not have any events yet, or the
+          sandbox worker is unreachable. Retry by reloading the page.
+        </div>
+      )}
+      {trajectory === undefined && (
+        <div className="text-sm text-fg-subtle">No trajectory loaded yet.</div>
+      )}
+      {ready && (
+        <pre className="font-mono text-[11px] bg-bg-surface border border-border rounded px-3 py-2 overflow-auto max-h-[60vh] text-fg whitespace-pre">
+          {json}
+        </pre>
+      )}
+    </Modal>
   );
 }
 


### PR DESCRIPTION
> Stacked on #35.

## Summary

Phase 3 of the Trajectory v1 unification track. Surfaces the v1 envelope in the Console UI so the data we now persist is actually visible and reviewable.

## What lands

**apps/console/src/pages/EvalRunDetail.tsx:**
- Lazy-fetches per-trial trajectory via GET /v1/sessions/:id/trajectory when a row is expanded
- Shows final_reward, verifier_id, and raw_rewards breakdown inline
- State machine for the per-trial fetch (Map<sessionId, Trajectory|"loading"|"error">) so failures don't block other rows

**apps/console/src/pages/SessionDetail.tsx:**
- Outcome chip + reward chip in the header
- "View Trajectory" opens a modal: pretty-printed JSON + Download button
- Three small components: TrajectoryOutcomeChip, TrajectoryRewardChip, TrajectoryViewerModal

## Test plan

- [ ] Open an eval run — expand a trial row → trajectory loads, reward visible
- [ ] Open a session detail — outcome + reward chips render when present, hide when absent
- [ ] Click "View Trajectory" → modal renders, Download produces a valid .json
- [ ] vite build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)