### PR TITLE
feat(trajectory v1, phases 2-4): Verifier substrate + Console viz + outcome AMA-align

### DIFF
--- a/apps/agent/src/harness/outcome-evaluator.ts
+++ b/apps/agent/src/harness/outcome-evaluator.ts
@@ -1,5 +1,6 @@
 import { generateText } from "ai";
 import type { LanguageModel } from "ai";
+import type { Score } from "@open-managed-agents/shared";
 import { extractTextFromContent, parseJudgeJson } from "@open-managed-agents/shared";
 
 export interface EvaluationResult {
@@ -98,3 +99,36 @@ function parseRubricVerdict(text: string): EvaluationResult | null {
 
 // Re-export the shared helpers for tests / other consumers
 export { extractTextFromContent, parseJudgeJson };
+
+/**
+ * Phase 2 of trajectory v1 unification: project an `EvaluationResult`
+ * (the supervisor loop's verdict shape) onto the canonical `Score`
+ * shape used by the Verifier framework. Verdict-driven control flow in
+ * session-do.ts continues to consume `EvaluationResult` directly; this
+ * helper lets call sites that need to *persist* the verdict as
+ * `Trajectory.reward.raw_rewards` produce a Verifier-shaped output
+ * without a second LLM call.
+ *
+ * Why not refactor the supervisor loop to call `verifierForSpec(...).judge`
+ * (the RewardModelVerifier) instead? Two reasons, both Phase 2 scope:
+ *   1. The supervisor loop already has a model handle (the agent's
+ *      configured aux model), prompts the LLM with its own format, and
+ *      drives "needs_revision" injection back into history. Routing it
+ *      through an HTTP reward model endpoint would require either
+ *      stubbing the endpoint to call back into this same model handle
+ *      (silly) or wiring an in-process Verifier shape that can take a
+ *      LanguageModel directly (out of scope — see Phase 4 backlog).
+ *   2. The verdict ↔ score translation is lossy in only one direction
+ *      (we lose the `feedback` string in raw_rewards). Persisting the
+ *      verdict via this helper preserves the feedback in `Score.reason`,
+ *      which Console can render verbatim.
+ */
+export function evaluationResultToScore(r: EvaluationResult): Score {
+  const pass = r.result === "satisfied";
+  return {
+    pass,
+    value: pass ? 1 : 0,
+    reason: r.feedback || (pass ? "satisfied" : "needs_revision"),
+    metadata: { criteria: { satisfied: pass ? 1 : 0 } },
+  };
+}

--- a/apps/agent/src/runtime/outcome-supervisor.ts
+++ b/apps/agent/src/runtime/outcome-supervisor.ts
@@ -418,13 +418,38 @@ function findLastAgentMessageId(
  * stay valid for any verifier that ignores them (script / verifiable /
  * llm_judge); composite verifiers that recurse into reward_model would
  * need richer construction — handle that when the use case lands.
+ *
+ * Wraps each SessionEvent into the StoredEvent shape the eval-core
+ * scorer helpers expect (`{ seq, type, data: JSON.stringify(event), ts }`).
+ * `history.getEvents()` returns the deserialized SessionEvent stream
+ * (top-level fields), but the helpers parse `e.data` to get the
+ * structured payload — so without the wrap, `getToolUses` /
+ * `getAgentMessageTexts` / etc. all return empty.
  */
 function makeMinimalTrajectory(
   events: StoredEvent[] | SessionEvent[],
 ): Trajectory {
-  // Both StoredEvent and SessionEvent satisfy the eval-core scorer
-  // helpers' minimal expectations (`{type, data?}`). The cast is safe
-  // because verifier consumers only read these fields.
+  const wrapped: StoredEvent[] = events.map((e, i) => {
+    // If the event already carries the StoredEvent envelope (eval-runner
+    // path, which fetches via /events endpoint), pass it through.
+    if (
+      typeof (e as StoredEvent).data === "string" &&
+      typeof (e as StoredEvent).seq === "number"
+    ) {
+      return e as StoredEvent;
+    }
+    // Supervisor path: history.getEvents() returns deserialized events.
+    // Wrap into StoredEvent so the scorer helpers see the structured
+    // payload via parseData.
+    const ts =
+      (e as { processed_at?: string }).processed_at ?? new Date(0).toISOString();
+    return {
+      seq: i,
+      type: (e as { type?: string }).type ?? "unknown",
+      data: JSON.stringify(e),
+      ts,
+    };
+  });
   return {
     schema_version: "oma.trajectory.v1",
     trajectory_id: "supervisor-inline",
@@ -434,9 +459,9 @@ function makeMinimalTrajectory(
     model: { id: "supervisor-inline", provider: "" },
     started_at: new Date(0).toISOString(),
     outcome: "running",
-    events: events as StoredEvent[],
+    events: wrapped,
     summary: {
-      num_events: events.length,
+      num_events: wrapped.length,
       num_turns: 0,
       num_tool_calls: 0,
       num_tool_errors: 0,

--- a/apps/agent/src/runtime/outcome-supervisor.ts
+++ b/apps/agent/src/runtime/outcome-supervisor.ts
@@ -1,0 +1,453 @@
+// Outcome supervisor — runs the AMA-aligned grader loop for a session.
+//
+// Extracted from session-do.ts so the loop logic is unit-testable
+// without spinning up a Durable Object. The session-do delegates to
+// `runOutcomeSupervisor()` after each `harness.run(...)` completes if
+// `state.outcome` is populated.
+//
+// Design highlights:
+//   - One Verifier instance per outcome (built once at loop start).
+//     Rule-based path (`state.outcome.verifier`) goes through
+//     `verifierForSpec` so it composes with the existing Phase 2
+//     framework. LLM-judge path constructs an in-process LlmJudgeVerifier
+//     so usage tokens propagate to span.outcome_evaluation_end.usage.
+//   - Each iteration: emit `span.outcome_evaluation_start` (with
+//     `outcome_id` + 0-indexed iteration), `span.outcome_evaluation_ongoing`
+//     heartbeat, then run the verifier against a minimal Trajectory
+//     built from the current event log. Result enum maps from the Score:
+//       pass → satisfied;
+//       !pass && iteration === max-1 → max_iterations_reached;
+//       !pass otherwise → needs_revision (inject reason as user.message,
+//         re-run harness, advance iteration).
+//   - Verifier throws → result: "failed", explanation = err.message.
+//   - AbortSignal aborts (user.interrupt) → result: "interrupted", but
+//     ONLY if the start span already fired this iteration (per AMA spec).
+//   - Every terminal verdict appends to `state.outcome_evaluations[]`
+//     for the GET /v1/sessions/:id aggregate.
+
+import type {
+  AgentMessageEvent,
+  RubricSpec,
+  SessionEvent,
+  SpanOutcomeEvaluationEndEvent,
+  SpanOutcomeEvaluationOngoingEvent,
+  SpanOutcomeEvaluationStartEvent,
+  StoredEvent,
+  UserMessageEvent,
+} from "@open-managed-agents/shared";
+import { generateEventId } from "@open-managed-agents/shared";
+import {
+  createLlmJudgeVerifier,
+  verifierForSpec,
+  type JudgeFn,
+  type RewardSpec,
+  type Score,
+  type Trajectory,
+  type Verifier,
+  type VerifierContext,
+} from "@open-managed-agents/shared";
+import { resolveRubric } from "./resolve-rubric";
+
+/** AMA `span.outcome_evaluation_end.usage` shape. */
+export interface OutcomeUsage {
+  input_tokens: number;
+  output_tokens: number;
+  cache_creation_input_tokens?: number;
+  cache_read_input_tokens?: number;
+}
+
+/** Persisted aggregate row. Mirrors what session-do writes to
+ *  `state.outcome_evaluations[]`. */
+export interface OutcomeEvaluationRecord {
+  outcome_id: string;
+  result:
+    | "satisfied"
+    | "needs_revision"
+    | "max_iterations_reached"
+    | "failed"
+    | "interrupted";
+  iteration: number;
+  explanation?: string;
+  /** @deprecated alias of explanation. Both written for back-compat. */
+  feedback?: string;
+  usage?: OutcomeUsage;
+  processed_at?: string;
+}
+
+/** Active outcome state, as stored on `SessionState.outcome`. */
+export interface ActiveOutcomeState {
+  outcome_id: string;
+  description: string;
+  rubric?: string | RubricSpec;
+  /** Cached resolved rubric markdown (set lazily on first iteration). */
+  rubric_content?: string;
+  /** OMA-superset rule-based check. Wire shape mirrors RewardSpec. */
+  verifier?: { type: string; [key: string]: unknown };
+  max_iterations?: number;
+}
+
+export interface OutcomeSupervisorDeps {
+  outcome: ActiveOutcomeState;
+  /** Iteration to start at. 0-indexed (AMA-spec). */
+  initialIteration?: number;
+  /** Tenant id — used by the rubric file resolver. */
+  tenantId: string;
+  filesBucket: R2Bucket | null | undefined;
+  /** Append-and-broadcast for events that go to history + WS. */
+  appendAndBroadcast: (event: SessionEvent) => void;
+  /** Broadcast-only — used for the start span (AMA emits it but the
+   *  ongoing/end spans are the persisted history rows; we keep parity
+   *  with the previous emit shape that wrote start to WS only). */
+  broadcastOnly: (event: SessionEvent) => void;
+  /** Read all events for the current iteration's trajectory build. */
+  getEvents: () => StoredEvent[] | SessionEvent[];
+  /** Build a verifier from the OMA-superset RewardSpec branch. */
+  makeVerifierContext: () => VerifierContext;
+  /** Build the LLM-judge callback (closure over generateText). */
+  makeJudgeFn: () => JudgeFn;
+  /** Optional model identifier used for the verifier id (logs / metadata). */
+  judgeModelId?: string;
+  /** Run another harness turn after a needs_revision verdict. */
+  runHarnessTurn: (msg: UserMessageEvent) => Promise<void>;
+  /** Persist a delta back to SessionState. Caller decides what to merge. */
+  persistState: (delta: {
+    outcome?: ActiveOutcomeState | null;
+    outcome_iteration?: number;
+    outcome_evaluations?: OutcomeEvaluationRecord[];
+  }) => void;
+  /** Read the current persisted outcome_evaluations[]. */
+  readEvaluations: () => OutcomeEvaluationRecord[];
+  /** Mid-eval interrupt detection. */
+  abortSignal: AbortSignal;
+}
+
+const TERMINAL_RESULTS = new Set([
+  "satisfied",
+  "max_iterations_reached",
+  "failed",
+  "interrupted",
+]);
+
+export interface OutcomeSupervisorReport {
+  iterations: OutcomeEvaluationRecord[];
+  terminal: OutcomeEvaluationRecord;
+}
+
+/**
+ * Run the supervisor loop until a terminal verdict. Returns the final
+ * verdict + per-iteration trail. Throws only on caller-side errors
+ * (e.g. failure to persist state); supervisor-internal failures land in
+ * the verdict as `failed`.
+ */
+export async function runOutcomeSupervisor(
+  deps: OutcomeSupervisorDeps,
+): Promise<OutcomeSupervisorReport> {
+  const outcome = deps.outcome;
+  const maxIterations = clampMaxIterations(outcome.max_iterations);
+  let iteration = Math.max(0, deps.initialIteration ?? 0);
+
+  // ── Build the verifier ──
+  let verifier: Verifier | null = null;
+  let preflightFailure: string | null = null;
+  let activeOutcome: ActiveOutcomeState = outcome;
+
+  if (outcome.verifier) {
+    try {
+      verifier = verifierForSpec(
+        outcome.verifier as unknown as RewardSpec,
+        deps.makeVerifierContext(),
+      );
+    } catch (err) {
+      preflightFailure = `verifier construction failed: ${describe(err)}`;
+    }
+  } else {
+    // LLM-judge path. Resolve the rubric (cache hit if already done).
+    let rubricContent = outcome.rubric_content;
+    if (!rubricContent) {
+      const resolution = await resolveRubric(outcome.rubric, {
+        tenantId: deps.tenantId,
+        filesBucket: deps.filesBucket,
+      });
+      if (!resolution.ok) {
+        preflightFailure = resolution.error;
+      } else {
+        rubricContent = resolution.content;
+        activeOutcome = { ...outcome, rubric_content: rubricContent };
+        deps.persistState({ outcome: activeOutcome });
+      }
+    }
+    if (rubricContent && !preflightFailure) {
+      verifier = createLlmJudgeVerifier({
+        rubric: rubricContent,
+        description: outcome.description,
+        modelId: deps.judgeModelId,
+        judge: deps.makeJudgeFn(),
+        abortSignal: deps.abortSignal,
+      });
+    }
+  }
+
+  const evaluations: OutcomeEvaluationRecord[] = [];
+
+  // Pre-flight failure: emit a single failed verdict and exit.
+  if (preflightFailure || !verifier) {
+    const record = await emitVerdict(deps, activeOutcome, iteration, {
+      result: "failed",
+      explanation: preflightFailure ?? "verifier could not be constructed",
+      preStartFired: false,
+    });
+    evaluations.push(record);
+    return { iterations: evaluations, terminal: record };
+  }
+
+  // ── Main loop ──
+  let terminal: OutcomeEvaluationRecord | null = null;
+
+  while (iteration < maxIterations) {
+    // Pre-iteration interrupt check. Per AMA spec, "interrupted" is only
+    // emitted if `outcome_evaluation_start` already fired — so a clean
+    // pre-iteration abort exits silently (no end span). This matches
+    // session-do's existing user.interrupt handler which broadcasts an
+    // idle event, not an outcome end.
+    if (deps.abortSignal.aborted) break;
+
+    const startEventId = generateEventId();
+    const lastAgentMessageId = findLastAgentMessageId(deps.getEvents());
+    const startEvent: SpanOutcomeEvaluationStartEvent = {
+      type: "span.outcome_evaluation_start",
+      id: startEventId,
+      outcome_id: activeOutcome.outcome_id,
+      iteration,
+      ...(lastAgentMessageId ? { parent_event_id: lastAgentMessageId } : {}),
+    };
+    // Match prior behavior: start-span is broadcast-only (not persisted to
+    // history). Heartbeat + end span go to both.
+    deps.broadcastOnly(startEvent);
+
+    const ongoingEvent: SpanOutcomeEvaluationOngoingEvent = {
+      type: "span.outcome_evaluation_ongoing",
+      outcome_id: activeOutcome.outcome_id,
+      iteration,
+    };
+    deps.appendAndBroadcast(ongoingEvent);
+
+    const trajectory = makeMinimalTrajectory(deps.getEvents());
+
+    let endResult: OutcomeEvaluationRecord["result"];
+    let explanation: string;
+    let usage: OutcomeUsage | undefined;
+    try {
+      const score: Score = await verifier.check(trajectory);
+      explanation = score.reason || "";
+      const meta = (score.metadata ?? {}) as { usage?: OutcomeUsage };
+      if (meta.usage) usage = meta.usage;
+      if (score.pass) {
+        endResult = "satisfied";
+      } else if (iteration >= maxIterations - 1) {
+        endResult = "max_iterations_reached";
+      } else {
+        endResult = "needs_revision";
+      }
+    } catch (err) {
+      const isAbort =
+        (err instanceof Error && err.name === "AbortError") ||
+        deps.abortSignal.aborted;
+      endResult = isAbort ? "interrupted" : "failed";
+      explanation = isAbort
+        ? "outcome evaluation interrupted by user"
+        : `verifier error: ${describe(err)}`;
+    }
+
+    const record = await emitVerdict(deps, activeOutcome, iteration, {
+      result: endResult,
+      explanation,
+      usage,
+      preStartFired: true,
+      startEventId,
+      lastAgentMessageId,
+    });
+    evaluations.push(record);
+
+    if (TERMINAL_RESULTS.has(record.result)) {
+      terminal = record;
+      break;
+    }
+
+    // needs_revision — advance iteration, inject feedback, re-run harness.
+    iteration += 1;
+    deps.persistState({ outcome: activeOutcome, outcome_iteration: iteration });
+
+    const feedbackMsg: UserMessageEvent = {
+      type: "user.message",
+      content: [
+        {
+          type: "text",
+          text:
+            `[Outcome iteration ${iteration - 1}] needs revision:\n` +
+            `${explanation || "(no explanation)"}\n\n` +
+            `Please address the feedback and try again.`,
+        },
+      ],
+    };
+    deps.appendAndBroadcast(feedbackMsg);
+
+    try {
+      await deps.runHarnessTurn(feedbackMsg);
+    } catch (err) {
+      // Harness crash mid-revision. Emit a `failed` end span so callers
+      // see a terminal outcome; surface the underlying error in
+      // explanation for debuggability. Don't rethrow — session-do's outer
+      // try/catch already logged the harness error and broadcast a
+      // session.error event for the harness crash itself.
+      const failedRecord = await emitVerdict(deps, activeOutcome, iteration, {
+        result: "failed",
+        explanation: `harness crashed during revision: ${describe(err)}`,
+        preStartFired: false,
+      });
+      evaluations.push(failedRecord);
+      terminal = failedRecord;
+      break;
+    }
+  }
+
+  if (!terminal) {
+    // Loop exited without a terminal (max iterations reached without an
+    // end span — unreachable in practice but defended for safety).
+    terminal = await emitVerdict(deps, activeOutcome, iteration - 1, {
+      result: "max_iterations_reached",
+      explanation: "supervisor loop exited without a terminal verdict",
+      preStartFired: false,
+    });
+    evaluations.push(terminal);
+  }
+
+  return { iterations: evaluations, terminal };
+}
+
+interface VerdictPayload {
+  result: OutcomeEvaluationRecord["result"];
+  explanation: string;
+  usage?: OutcomeUsage;
+  /** When false, the start span never fired this iteration — only used
+   *  on pre-flight or post-needs_revision failure paths. We still emit
+   *  the end span (so the aggregate has a row) but skip the
+   *  `outcome_evaluation_start_id` link. */
+  preStartFired: boolean;
+  startEventId?: string;
+  lastAgentMessageId?: string;
+}
+
+async function emitVerdict(
+  deps: OutcomeSupervisorDeps,
+  outcome: ActiveOutcomeState,
+  iteration: number,
+  payload: VerdictPayload,
+): Promise<OutcomeEvaluationRecord> {
+  const endEvent: SpanOutcomeEvaluationEndEvent = {
+    type: "span.outcome_evaluation_end",
+    outcome_id: outcome.outcome_id,
+    ...(payload.preStartFired && payload.startEventId
+      ? { outcome_evaluation_start_id: payload.startEventId }
+      : {}),
+    result: payload.result,
+    iteration,
+    explanation: payload.explanation,
+    // Back-compat alias: console + RL collector still read .feedback.
+    feedback: payload.explanation,
+    ...(payload.usage ? { usage: payload.usage } : {}),
+    ...(payload.lastAgentMessageId
+      ? { parent_event_id: payload.lastAgentMessageId }
+      : {}),
+  };
+  deps.appendAndBroadcast(endEvent);
+
+  const record: OutcomeEvaluationRecord = {
+    outcome_id: outcome.outcome_id,
+    result: payload.result,
+    iteration,
+    explanation: payload.explanation,
+    feedback: payload.explanation,
+    usage: payload.usage,
+    processed_at: endEvent.processed_at,
+  };
+
+  const prior = deps.readEvaluations();
+  const persisted = [...prior, record];
+
+  if (TERMINAL_RESULTS.has(record.result)) {
+    // Terminal — drop active outcome, keep the aggregate.
+    deps.persistState({ outcome: null, outcome_evaluations: persisted });
+  } else {
+    deps.persistState({
+      outcome,
+      outcome_iteration: iteration,
+      outcome_evaluations: persisted,
+    });
+  }
+  return record;
+}
+
+function clampMaxIterations(n: number | undefined): number {
+  // AMA spec: default 3, max 20.
+  if (typeof n !== "number" || !Number.isFinite(n) || n < 1) return 3;
+  return Math.min(20, Math.floor(n));
+}
+
+function describe(err: unknown): string {
+  if (err instanceof Error) return err.message || err.name || "unknown error";
+  return String(err);
+}
+
+function findLastAgentMessageId(
+  events: StoredEvent[] | SessionEvent[],
+): string | undefined {
+  for (let i = events.length - 1; i >= 0; i--) {
+    const e = events[i] as SessionEvent;
+    if (e.type === "agent.message") {
+      return (e as AgentMessageEvent).id;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Build the minimal Trajectory the verifier needs. We deliberately don't
+ * call eval-core's `buildTrajectory` (which expects async event/status
+ * fetchers + agent_config + environment_config snapshots) because the
+ * supervisor only needs `events` for verifier consumption. Stub fields
+ * stay valid for any verifier that ignores them (script / verifiable /
+ * llm_judge); composite verifiers that recurse into reward_model would
+ * need richer construction — handle that when the use case lands.
+ */
+function makeMinimalTrajectory(
+  events: StoredEvent[] | SessionEvent[],
+): Trajectory {
+  // Both StoredEvent and SessionEvent satisfy the eval-core scorer
+  // helpers' minimal expectations (`{type, data?}`). The cast is safe
+  // because verifier consumers only read these fields.
+  return {
+    schema_version: "oma.trajectory.v1",
+    trajectory_id: "supervisor-inline",
+    session_id: "supervisor-inline",
+    agent_config: {} as Trajectory["agent_config"],
+    environment_config: {} as Trajectory["environment_config"],
+    model: { id: "supervisor-inline", provider: "" },
+    started_at: new Date(0).toISOString(),
+    outcome: "running",
+    events: events as StoredEvent[],
+    summary: {
+      num_events: events.length,
+      num_turns: 0,
+      num_tool_calls: 0,
+      num_tool_errors: 0,
+      num_threads: 0,
+      duration_ms: 0,
+      token_usage: {
+        input_tokens: 0,
+        output_tokens: 0,
+        cache_read_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+      },
+    },
+  };
+}

--- a/apps/agent/src/runtime/resolve-rubric.ts
+++ b/apps/agent/src/runtime/resolve-rubric.ts
@@ -1,0 +1,95 @@
+// Resolve `user.define_outcome.rubric` to plain markdown text. AMA accepts:
+//   - inline:  { type: "text", content }
+//   - by ref:  { type: "file", file_id }   ← needs an R2 fetch
+// Plus the legacy bare-string form, treated as inline text.
+//
+// Used by the outcome supervisor loop in session-do.ts. Resolution is
+// lazy + cached on `state.outcome.rubric_content`: re-iteration after a
+// `needs_revision` verdict reuses the cached text rather than re-fetching
+// the file.
+//
+// Failure mode: returns `{ ok: false, error }`. Caller surfaces the
+// failure as `span.outcome_evaluation_end.result = "failed"` with the
+// error string in `explanation`.
+
+import type { RubricSpec } from "@open-managed-agents/shared";
+import { fileR2Key } from "@open-managed-agents/shared";
+
+export type RubricResolution =
+  | { ok: true; content: string }
+  | { ok: false; error: string };
+
+interface ResolveRubricDeps {
+  /** Tenant the session belongs to — used to compute the R2 key for file
+   *  rubrics. */
+  tenantId: string;
+  /** R2 bucket binding. When null/undefined the file branch fails fast. */
+  filesBucket: R2Bucket | null | undefined;
+}
+
+export async function resolveRubric(
+  rubric: string | RubricSpec | undefined,
+  deps: ResolveRubricDeps,
+): Promise<RubricResolution> {
+  if (rubric === undefined) {
+    return { ok: false, error: "no rubric provided" };
+  }
+
+  // Legacy: bare string is treated as inline text. Pre-Phase-4 callers
+  // that haven't migrated keep working.
+  if (typeof rubric === "string") {
+    return rubric.trim().length > 0
+      ? { ok: true, content: rubric }
+      : { ok: false, error: "rubric is empty" };
+  }
+
+  if (rubric.type === "text") {
+    if (!rubric.content || !rubric.content.trim()) {
+      return { ok: false, error: "rubric.content is empty" };
+    }
+    return { ok: true, content: rubric.content };
+  }
+
+  if (rubric.type === "file") {
+    if (!rubric.file_id) {
+      return { ok: false, error: "rubric.file_id is empty" };
+    }
+    if (!deps.filesBucket) {
+      return {
+        ok: false,
+        error: `rubric file fetch failed: FILES_BUCKET binding not configured`,
+      };
+    }
+    const key = fileR2Key(deps.tenantId, rubric.file_id);
+    try {
+      const obj = await deps.filesBucket.get(key);
+      if (!obj) {
+        return {
+          ok: false,
+          error: `rubric file fetch failed: not found (file_id=${rubric.file_id})`,
+        };
+      }
+      const text = await obj.text();
+      if (!text.trim()) {
+        return {
+          ok: false,
+          error: `rubric file fetch failed: empty body (file_id=${rubric.file_id})`,
+        };
+      }
+      return { ok: true, content: text };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return {
+        ok: false,
+        error: `rubric file fetch failed: ${msg.slice(0, 200)}`,
+      };
+    }
+  }
+
+  // Exhaustive check — TypeScript will surface any missed RubricSpec branch.
+  const _exhaustive: never = rubric;
+  return {
+    ok: false,
+    error: `unknown rubric shape: ${JSON.stringify(_exhaustive)}`,
+  };
+}

--- a/apps/agent/src/runtime/session-do.ts
+++ b/apps/agent/src/runtime/session-do.ts
@@ -1569,19 +1569,46 @@ export class SessionDO extends DurableObject<Env> {
       return Response.json({ data: threadEvents });
     }
 
-    // GET /full-status — session status with usage and outcome evaluations
+    // GET /full-status — session status with usage and outcome evaluations.
+    //
+    // Phase 4 / AMA alignment: outcome_evaluations is now sourced from
+    // `state.outcome_evaluations` (written by the supervisor loop on every
+    // terminal `span.outcome_evaluation_end`). Falls back to scanning the
+    // event log for legacy spellings (`session.outcome_evaluated`,
+    // `outcome.evaluation_end`, `span.outcome_evaluation_end`) so sessions
+    // written before this change still surface their verdicts.
     if (request.method === "GET" && url.pathname === "/full-status") {
       const history = new SqliteHistory(this.ctx.storage.sql, this.env.FILES_BUCKET ?? null, `t/${this.state.tenant_id ?? "default"}/sessions/${this.state.session_id ?? "unknown"}`);
-      const allEvents = history.getEvents();
 
-      // Collect outcome evaluations
-      const outcomeEvaluations = allEvents
-        .filter((e) => e.type === "session.outcome_evaluated")
-        .map((e: any) => ({
-          result: e.result,
-          iteration: e.iteration,
-          feedback: e.feedback,
-        }));
+      const stateEvaluations = this.state.outcome_evaluations ?? [];
+      let outcomeEvaluations: PersistedOutcomeEvaluation[] = stateEvaluations;
+      if (outcomeEvaluations.length === 0) {
+        // Back-compat scan. Only runs for sessions whose supervisor never
+        // wrote into state.outcome_evaluations[] (pre-Phase-4 emit
+        // sites). Cheap because the event scan is local to this DO.
+        const allEvents = history.getEvents();
+        outcomeEvaluations = allEvents
+          .filter(
+            (e) =>
+              e.type === "session.outcome_evaluated" ||
+              e.type === "outcome.evaluation_end" ||
+              e.type === "span.outcome_evaluation_end",
+          )
+          .map((e: SessionEvent) => {
+            const ev = e as Partial<PersistedOutcomeEvaluation> & {
+              feedback?: string;
+            };
+            return {
+              outcome_id: ev.outcome_id ?? "",
+              result: (ev.result ?? "needs_revision") as PersistedOutcomeEvaluation["result"],
+              iteration: typeof ev.iteration === "number" ? ev.iteration : 0,
+              explanation: ev.explanation ?? ev.feedback,
+              feedback: ev.feedback ?? ev.explanation,
+              usage: ev.usage,
+              processed_at: (e as { processed_at?: string }).processed_at,
+            };
+          });
+      }
 
       return Response.json({
         status: this.deriveStatus(),

--- a/apps/agent/src/runtime/session-do.ts
+++ b/apps/agent/src/runtime/session-do.ts
@@ -11,7 +11,7 @@ import {
   type PartialStream,
 } from "./turn-runtime";
 import type { Env } from "@open-managed-agents/shared";
-import { logWarn, generateEventId } from "@open-managed-agents/shared";
+import { logWarn, generateEventId, generateOutcomeId } from "@open-managed-agents/shared";
 import {
   CfDoStreamRepo,
   ensureSchema as ensureEventLogSchema,
@@ -28,9 +28,14 @@ import type {
   UserToolConfirmationEvent,
   UserCustomToolResultEvent,
   UserDefineOutcomeEvent,
+  RubricSpec,
+  OutcomeVerifierSpec,
   OutcomeEvaluationEvent,
   AgentMessageEvent,
   AgentToolUseEvent,
+  SpanOutcomeEvaluationStartEvent,
+  SpanOutcomeEvaluationOngoingEvent,
+  SpanOutcomeEvaluationEndEvent,
 } from "@open-managed-agents/shared";
 import type { HarnessContext, HarnessInterface, HistoryStore, SandboxExecutor, ProcessHandle } from "../harness/interface";
 import { resolveHarness } from "../harness/registry";
@@ -111,6 +116,56 @@ interface PendingToolCall {
  * Persistent session state managed by Agent's setState/state system.
  * Automatically persisted to SQLite and broadcast to WebSocket clients.
  */
+/**
+ * Currently-active outcome (Phase 4 / AMA alignment). Sessions may chain
+ * outcomes sequentially; only one is active at a time. After a terminal
+ * `span.outcome_evaluation_end` (satisfied / max_iterations_reached /
+ * failed / interrupted) this slot clears, and the resolved evaluation
+ * lands in `state.outcome_evaluations[]`.
+ */
+interface ActiveOutcome {
+  /** AMA-spec id, prefix `outc_`. Echoed on every event tied to this outcome. */
+  outcome_id: string;
+  description: string;
+  /**
+   * Rubric as received on the wire. May be a bare string (legacy) or a
+   * `{type:"text"|"file", ...}` envelope. The resolved markdown lives in
+   * `rubric_content` after first read so re-iteration doesn't re-fetch.
+   */
+  rubric?: string | RubricSpec;
+  /** Resolved rubric markdown — populated lazily at supervisor build time. */
+  rubric_content?: string;
+  /** OMA-superset rule-based check. Mutually exclusive with the LLM-judge path. */
+  verifier?: OutcomeVerifierSpec;
+  max_iterations?: number;
+}
+
+/**
+ * Aggregate row returned by GET /v1/sessions/:id `.outcome_evaluations[]`.
+ * Mirrors AMA's session-retrieve response shape.
+ */
+interface PersistedOutcomeEvaluation {
+  outcome_id: string;
+  result:
+    | "satisfied"
+    | "needs_revision"
+    | "max_iterations_reached"
+    | "failed"
+    | "interrupted";
+  iteration: number;
+  /** AMA-name; pre-Phase-4 events used `feedback`. Both kept on persist. */
+  explanation?: string;
+  /** Back-compat alias of explanation. Old consumers read this. */
+  feedback?: string;
+  usage?: {
+    input_tokens: number;
+    output_tokens: number;
+    cache_creation_input_tokens?: number;
+    cache_read_input_tokens?: number;
+  };
+  processed_at?: string;
+}
+
 interface SessionState {
   agent_id: string;
   environment_id: string;
@@ -133,8 +188,15 @@ interface SessionState {
   output_tokens: number;
   vault_ids: string[];
   pending_tool_calls: PendingToolCall[];
-  outcome: { description: string; rubric?: string; max_iterations?: number } | null;
+  outcome: ActiveOutcome | null;
   outcome_iteration: number;
+  /**
+   * Phase 4: AMA-aligned aggregate of every terminal `span.outcome_evaluation_end`
+   * for this session. Returned as-is by GET /v1/sessions/:id under
+   * `outcome_evaluations`. Sequential outcomes (each kicked off by a fresh
+   * `user.define_outcome`) append here in iteration order.
+   */
+  outcome_evaluations?: PersistedOutcomeEvaluation[];
   /**
    * Tenant config snapshots provided at /init by main worker. Used by
    * getAgentConfig/getEnvConfig/getVaultCredentials so SessionDO doesn't
@@ -1195,9 +1257,47 @@ export class SessionDO extends DurableObject<Env> {
 
       if (body.type === "user.define_outcome") {
         const e = body as UserDefineOutcomeEvent;
-        this.setState({ ...this.state, outcome: { description: e.description, rubric: e.rubric, max_iterations: e.max_iterations }, outcome_iteration: 1 });
-        history.append(e);
-        this.broadcastEvent(e);
+        // AMA-spec: validate at-least-one-of(rubric|verifier). Reject the
+        // event before persisting so callers get a clean 400 instead of a
+        // silently degraded supervisor loop.
+        const hasRubric =
+          typeof e.rubric === "string"
+            ? e.rubric.trim().length > 0
+            : !!e.rubric && (
+                (e.rubric.type === "text" && !!e.rubric.content) ||
+                (e.rubric.type === "file" && !!e.rubric.file_id)
+              );
+        if (!hasRubric && !e.verifier) {
+          return new Response(
+            "user.define_outcome requires at least one of `rubric` or `verifier`",
+            { status: 400 },
+          );
+        }
+        // Mint outcome_id server-side (AMA-style `outc_…` prefix). Honour
+        // a client-supplied id only when it's already prefixed (used by
+        // tests / replays); otherwise mint fresh.
+        const outcome_id =
+          e.outcome_id && e.outcome_id.startsWith("outc_")
+            ? e.outcome_id
+            : generateOutcomeId();
+        const echoed: UserDefineOutcomeEvent = { ...e, outcome_id };
+        // Sequential outcomes: any prior `state.outcome` is dropped (it
+        // either already terminated and was nulled by the supervisor, or
+        // we're explicitly replacing it). Existing `outcome_evaluations`
+        // history stays intact.
+        this.setState({
+          ...this.state,
+          outcome: {
+            outcome_id,
+            description: echoed.description,
+            rubric: echoed.rubric,
+            verifier: echoed.verifier,
+            max_iterations: echoed.max_iterations,
+          },
+          outcome_iteration: 0,
+        });
+        history.append(echoed);
+        this.broadcastEvent(echoed);
         return new Response(null, { status: 202 });
       }
 

--- a/apps/agent/src/runtime/session-do.ts
+++ b/apps/agent/src/runtime/session-do.ts
@@ -28,21 +28,21 @@ import type {
   UserToolConfirmationEvent,
   UserCustomToolResultEvent,
   UserDefineOutcomeEvent,
-  RubricSpec,
-  OutcomeVerifierSpec,
-  OutcomeEvaluationEvent,
   AgentMessageEvent,
   AgentToolUseEvent,
-  SpanOutcomeEvaluationStartEvent,
-  SpanOutcomeEvaluationOngoingEvent,
-  SpanOutcomeEvaluationEndEvent,
 } from "@open-managed-agents/shared";
 import type { HarnessContext, HarnessInterface, HistoryStore, SandboxExecutor, ProcessHandle } from "../harness/interface";
 import { resolveHarness } from "../harness/registry";
 import { resolveModel } from "../harness/provider";
 import type { ApiCompat } from "../harness/provider";
 import type { LanguageModel } from "ai";
-import { evaluateOutcome } from "../harness/outcome-evaluator";
+import { generateText } from "ai";
+import { extractTextFromContent } from "@open-managed-agents/shared";
+import {
+  runOutcomeSupervisor,
+  type ActiveOutcomeState,
+  type OutcomeEvaluationRecord,
+} from "./outcome-supervisor";
 import { buildTools } from "../harness/tools";
 import { MemoryStoreService } from "@open-managed-agents/memory-store";
 import { buildCfServices, getCfServicesForTenant } from "@open-managed-agents/services";
@@ -117,54 +117,15 @@ interface PendingToolCall {
  * Automatically persisted to SQLite and broadcast to WebSocket clients.
  */
 /**
- * Currently-active outcome (Phase 4 / AMA alignment). Sessions may chain
- * outcomes sequentially; only one is active at a time. After a terminal
- * `span.outcome_evaluation_end` (satisfied / max_iterations_reached /
- * failed / interrupted) this slot clears, and the resolved evaluation
- * lands in `state.outcome_evaluations[]`.
+ * `ActiveOutcomeState` (one slot — only one outcome supported at a time,
+ * per AMA spec) and `OutcomeEvaluationRecord` (the aggregate row written
+ * to `state.outcome_evaluations[]` on every terminal verdict) are
+ * defined in outcome-supervisor.ts so the supervisor unit-test fixture
+ * has a single source of truth. Re-exported here as the local aliases
+ * the SessionState below uses.
  */
-interface ActiveOutcome {
-  /** AMA-spec id, prefix `outc_`. Echoed on every event tied to this outcome. */
-  outcome_id: string;
-  description: string;
-  /**
-   * Rubric as received on the wire. May be a bare string (legacy) or a
-   * `{type:"text"|"file", ...}` envelope. The resolved markdown lives in
-   * `rubric_content` after first read so re-iteration doesn't re-fetch.
-   */
-  rubric?: string | RubricSpec;
-  /** Resolved rubric markdown — populated lazily at supervisor build time. */
-  rubric_content?: string;
-  /** OMA-superset rule-based check. Mutually exclusive with the LLM-judge path. */
-  verifier?: OutcomeVerifierSpec;
-  max_iterations?: number;
-}
-
-/**
- * Aggregate row returned by GET /v1/sessions/:id `.outcome_evaluations[]`.
- * Mirrors AMA's session-retrieve response shape.
- */
-interface PersistedOutcomeEvaluation {
-  outcome_id: string;
-  result:
-    | "satisfied"
-    | "needs_revision"
-    | "max_iterations_reached"
-    | "failed"
-    | "interrupted";
-  iteration: number;
-  /** AMA-name; pre-Phase-4 events used `feedback`. Both kept on persist. */
-  explanation?: string;
-  /** Back-compat alias of explanation. Old consumers read this. */
-  feedback?: string;
-  usage?: {
-    input_tokens: number;
-    output_tokens: number;
-    cache_creation_input_tokens?: number;
-    cache_read_input_tokens?: number;
-  };
-  processed_at?: string;
-}
+type ActiveOutcome = ActiveOutcomeState;
+type PersistedOutcomeEvaluation = OutcomeEvaluationRecord;
 
 interface SessionState {
   agent_id: string;
@@ -3178,99 +3139,111 @@ export class SessionDO extends DurableObject<Env> {
         }
       }
 
-      // Outcome self-evaluation loop (properly loops until satisfied or max iterations)
+      // Outcome self-evaluation loop. Phase 4 / AMA-aligned: delegated
+      // to the standalone supervisor module which builds a Verifier
+      // (verifierForSpec for the OMA-superset rule-based path,
+      // LlmJudgeVerifier for the AMA-default LLM-judge path), runs it
+      // against a Trajectory built from the current event log, maps the
+      // Score onto the AMA 5-result enum, emits
+      // span.outcome_evaluation_{start,ongoing,end}, and persists each
+      // terminal verdict to state.outcome_evaluations[]. The loop
+      // re-injects the verifier's `reason` as a user.message + re-runs
+      // the harness on `needs_revision`.
       const outcome = this.state.outcome;
       if (outcome) {
-        let iteration = this.state.outcome_iteration || 1;
-        const maxIterations = Math.min(outcome.max_iterations || 3, 20);
-        const outcomeModelId = typeof agent.model === "string" ? agent.model : agent.model?.id;
-        const model = resolveModel(outcomeModelId || ctx.env.ANTHROPIC_MODEL || "claude-sonnet-4-6", ctx.env.ANTHROPIC_API_KEY, ctx.env.ANTHROPIC_BASE_URL);
-
-        while (iteration <= maxIterations) {
-          // Collect agent output from recent events
-          const recentEvents = history.getEvents();
-          const agentMessages = recentEvents.filter(
-            (e: SessionEvent) => e.type === "agent.message",
+        const outcomeModelId =
+          typeof agent.model === "string" ? agent.model : agent.model?.id;
+        const judgeModel = resolveModel(
+          outcomeModelId ||
+            ctx.env.ANTHROPIC_MODEL ||
+            "claude-sonnet-4-6",
+          ctx.env.ANTHROPIC_API_KEY,
+          ctx.env.ANTHROPIC_BASE_URL,
+        );
+        try {
+          await runOutcomeSupervisor({
+            outcome,
+            initialIteration: this.state.outcome_iteration ?? 0,
+            tenantId: this.state.tenant_id,
+            filesBucket: this.env.FILES_BUCKET ?? null,
+            abortSignal: effectiveAbortSignal,
+            judgeModelId: outcomeModelId,
+            getEvents: () => history.getEvents(),
+            appendAndBroadcast: (event) => {
+              history.append(event);
+              this.broadcastEvent(event);
+            },
+            broadcastOnly: (event) => this.broadcastEvent(event),
+            persistState: (delta) => {
+              const next = { ...this.state };
+              if ("outcome" in delta) next.outcome = delta.outcome ?? null;
+              if (typeof delta.outcome_iteration === "number") {
+                next.outcome_iteration = delta.outcome_iteration;
+              }
+              if (delta.outcome_evaluations) {
+                next.outcome_evaluations = delta.outcome_evaluations;
+              }
+              this.setState(next);
+            },
+            readEvaluations: () => this.state.outcome_evaluations ?? [],
+            makeVerifierContext: () => ({
+              sessionId: this.state.session_id,
+              runExec: async (cmd, opts) => {
+                const sb = this.getOrCreateSandbox();
+                const raw = await sb.exec(cmd, opts?.timeoutMs ?? 600_000);
+                // sandbox.exec returns "exit=N\n<merged-output>"
+                const m = raw.match(/^exit=(-?\d+)\n([\s\S]*)$/);
+                return m
+                  ? { exit_code: parseInt(m[1], 10), output: m[2] }
+                  : { exit_code: -1, output: raw };
+              },
+            }),
+            makeJudgeFn: () => async (prompt, signal) => {
+              const result = await generateText({
+                model: judgeModel,
+                system: prompt.system,
+                messages: [{ role: "user", content: prompt.user }],
+                maxOutputTokens: 800,
+                abortSignal: signal,
+              });
+              const text =
+                result.text ||
+                extractTextFromContent(
+                  (result as unknown as { content?: unknown }).content,
+                );
+              const u = (result as unknown as {
+                usage?: {
+                  inputTokens?: number;
+                  outputTokens?: number;
+                  cachedInputTokens?: number;
+                  cacheReadInputTokens?: number;
+                  cacheCreationInputTokens?: number;
+                };
+              }).usage;
+              const usage = u
+                ? {
+                    input_tokens: u.inputTokens ?? 0,
+                    output_tokens: u.outputTokens ?? 0,
+                    cache_creation_input_tokens:
+                      u.cacheCreationInputTokens ?? u.cachedInputTokens,
+                    cache_read_input_tokens: u.cacheReadInputTokens,
+                  }
+                : undefined;
+              return { text, usage };
+            },
+            runHarnessTurn: async (msg) => {
+              await harness.run({ ...ctx, userMessage: msg });
+            },
+          });
+        } catch (err) {
+          // Supervisor itself blew up (e.g. a persistState callback
+          // threw). Surface as a session warning — the supervisor's own
+          // failure path already handled verifier-internal errors and
+          // emitted a `failed` end span.
+          logWarn(
+            { op: "outcome.supervisor", session_id: this.state.session_id, err },
+            "outcome supervisor crashed",
           );
-          const agentOutput = agentMessages
-            .map((e: SessionEvent) => {
-              const msg = e as AgentMessageEvent;
-              return msg.content?.map((b) => b.type === "text" ? b.text : "").join("") || "";
-            })
-            .join("\n");
-          // v1-additive (docs/trajectory-v1-spec.md "Causality"):
-          // outcome.evaluation_end.parent_event_id → the agent.message
-          // being evaluated. The eval rolls up *all* recent agent.message
-          // events into one verdict; the last one is the most recent
-          // turn the model produced and is what callers walking the
-          // ancestry care about ("which turn did this verdict apply to").
-          const lastAgentMessageId = agentMessages.length > 0
-            ? (agentMessages[agentMessages.length - 1] as AgentMessageEvent).id
-            : undefined;
-
-          // Span: outcome evaluation start
-          this.broadcastEvent({ type: "span.outcome_evaluation_start", iteration });
-
-          const ongoingEvent: SessionEvent = {
-            type: "span.outcome_evaluation_ongoing",
-            iteration,
-          };
-          history.append(ongoingEvent);
-          this.broadcastEvent(ongoingEvent);
-
-          const evalResult = await evaluateOutcome(model, outcome, agentOutput);
-
-          if (evalResult.result === "satisfied") {
-            const evalEvent: OutcomeEvaluationEvent = {
-              type: "outcome.evaluation_end",
-              result: "satisfied",
-              iteration,
-              feedback: evalResult.feedback,
-              ...(lastAgentMessageId ? { parent_event_id: lastAgentMessageId } : {}),
-            };
-            history.append(evalEvent);
-            this.broadcastEvent(evalEvent);
-            this.setState({ ...this.state, outcome: null });
-            break;
-          }
-
-          if (iteration >= maxIterations) {
-            const evalEvent: OutcomeEvaluationEvent = {
-              type: "outcome.evaluation_end",
-              result: "max_iterations_reached",
-              iteration,
-              ...(lastAgentMessageId ? { parent_event_id: lastAgentMessageId } : {}),
-            };
-            history.append(evalEvent);
-            this.broadcastEvent(evalEvent);
-            this.setState({ ...this.state, outcome: null });
-            break;
-          }
-
-          // Needs revision — inject feedback and re-run
-          const evalEvent: OutcomeEvaluationEvent = {
-            type: "outcome.evaluation_end",
-            result: "needs_revision",
-            iteration,
-            feedback: evalResult.feedback,
-            ...(lastAgentMessageId ? { parent_event_id: lastAgentMessageId } : {}),
-          };
-          history.append(evalEvent);
-          this.broadcastEvent(evalEvent);
-
-          iteration += 1;
-          this.setState({ ...this.state, outcome_iteration: iteration });
-
-          const feedbackMsg: UserMessageEvent = {
-            type: "user.message",
-            content: [{
-              type: "text",
-              text: `[Outcome Evaluation - Iteration ${iteration - 1}] Needs revision:\n${evalResult.feedback}\n\nPlease address the feedback and try again.`,
-            }],
-          };
-          history.append(feedbackMsg);
-          this.broadcastEvent(feedbackMsg);
-          await harness.run({ ...ctx, userMessage: feedbackMsg });
         }
       }
 

--- a/apps/agent/tests/outcome-supervisor.test.ts
+++ b/apps/agent/tests/outcome-supervisor.test.ts
@@ -1,0 +1,428 @@
+// Outcome supervisor unit tests — exercises runOutcomeSupervisor()
+// directly with fake deps (no Durable Object, no live LLM, no live
+// sandbox). Covers the six scenarios from Phase 4 spec:
+//   1. rubric: text → llm_judge verifier path
+//   2. verifier: { type: "script", verify_script: "exit 0" } → satisfied
+//   3. verifier: { type: "verifiable", scorer: "fileWritten" } →
+//      satisfied / needs_revision
+//   4. max_iterations exhausted → max_iterations_reached
+//   5. verifier throws → failed
+//   6. user.interrupt mid-eval → interrupted
+//   7. sequential outcomes — second user.define_outcome after first
+//      terminates starts fresh
+//
+// The supervisor is provider-agnostic — these tests do not touch
+// `cloudflare:workers` or any DO API surface, just the supervisor
+// closure and its injected deps.
+
+// @ts-nocheck
+import { describe, it, expect } from "vitest";
+import {
+  runOutcomeSupervisor,
+  type ActiveOutcomeState,
+  type OutcomeEvaluationRecord,
+  type OutcomeSupervisorDeps,
+} from "../src/runtime/outcome-supervisor";
+import type { JudgeFn } from "@open-managed-agents/shared";
+
+// ---------- shared fake harness ----------
+
+interface FakeHarness {
+  events: any[];
+  evaluations: OutcomeEvaluationRecord[];
+  state: {
+    outcome: ActiveOutcomeState | null;
+    outcome_iteration: number;
+    outcome_evaluations: OutcomeEvaluationRecord[];
+  };
+  deps: Partial<OutcomeSupervisorDeps>;
+  abortController: AbortController;
+}
+
+function makeFakeHarness(opts: {
+  outcome: ActiveOutcomeState;
+  initialEvents?: any[];
+  judge?: JudgeFn;
+  runExec?: (cmd: string) => Promise<{ exit_code: number; output: string }>;
+  filesBucketGet?: (key: string) => Promise<{ text(): Promise<string> } | null>;
+  /** Called after every needs_revision; tests can append a synthetic
+   *  agent.message here, simulating the agent reacting to feedback. */
+  onHarnessTurn?: (
+    msg: any,
+    h: FakeHarness,
+  ) => Promise<void> | void;
+}): FakeHarness {
+  const ctrl = new AbortController();
+  const h: FakeHarness = {
+    events: [...(opts.initialEvents ?? [])],
+    evaluations: [],
+    state: {
+      outcome: opts.outcome,
+      outcome_iteration: 0,
+      outcome_evaluations: [],
+    },
+    deps: {},
+    abortController: ctrl,
+  };
+
+  h.deps = {
+    outcome: opts.outcome,
+    initialIteration: 0,
+    tenantId: "tnt-test",
+    filesBucket: opts.filesBucketGet
+      ? ({ get: opts.filesBucketGet } as unknown as R2Bucket)
+      : null,
+    abortSignal: ctrl.signal,
+    judgeModelId: "fake-model",
+    getEvents: () => h.events,
+    appendAndBroadcast: (e) => h.events.push(e),
+    broadcastOnly: (e) => h.events.push(e),
+    persistState: (delta) => {
+      if ("outcome" in delta) h.state.outcome = delta.outcome ?? null;
+      if (typeof delta.outcome_iteration === "number")
+        h.state.outcome_iteration = delta.outcome_iteration;
+      if (delta.outcome_evaluations) {
+        h.state.outcome_evaluations = delta.outcome_evaluations;
+        h.evaluations = delta.outcome_evaluations;
+      }
+    },
+    readEvaluations: () => h.state.outcome_evaluations,
+    makeVerifierContext: () => ({
+      sessionId: "sess-test",
+      runExec:
+        opts.runExec ??
+        (async () => ({ exit_code: 0, output: "" })),
+    }),
+    makeJudgeFn: () =>
+      opts.judge ??
+      (async () => ({
+        text: JSON.stringify({
+          result: "satisfied",
+          explanation: "default fake judge",
+        }),
+      })),
+    runHarnessTurn: async (msg) => {
+      if (opts.onHarnessTurn) await opts.onHarnessTurn(msg, h);
+    },
+  };
+  return h;
+}
+
+function agentMessage(text: string, id = `evt-${Math.random()}`) {
+  return { type: "agent.message", id, content: [{ type: "text", text }] };
+}
+
+// ---------- Scenario 1: rubric: text → llm_judge satisfied ----------
+
+describe("runOutcomeSupervisor", () => {
+  it("rubric: text → llm_judge satisfied", async () => {
+    const h = makeFakeHarness({
+      outcome: {
+        outcome_id: "outc_test1",
+        description: "Print hello world",
+        rubric: { type: "text", content: "Output must contain 'hello'" },
+        max_iterations: 3,
+      },
+      initialEvents: [agentMessage("hello world")],
+      judge: async () => ({
+        text: JSON.stringify({
+          result: "satisfied",
+          explanation: "Output contains 'hello'.",
+        }),
+        usage: {
+          input_tokens: 100,
+          output_tokens: 20,
+          cache_read_input_tokens: 0,
+          cache_creation_input_tokens: 0,
+        },
+      }),
+    });
+
+    const report = await runOutcomeSupervisor(h.deps as any);
+    expect(report.terminal.result).toBe("satisfied");
+    expect(report.terminal.explanation).toMatch(/hello/i);
+    expect(report.terminal.usage?.input_tokens).toBe(100);
+    expect(h.state.outcome).toBeNull(); // active outcome cleared
+    expect(h.state.outcome_evaluations).toHaveLength(1);
+
+    // span events emitted: ongoing + end (start is broadcast-only and
+    // also lands in events here because broadcastOnly pushes to the
+    // shared events array in this fake)
+    const spanTypes = h.events
+      .map((e) => e.type)
+      .filter((t) => t.startsWith("span.outcome_evaluation"));
+    expect(spanTypes).toContain("span.outcome_evaluation_start");
+    expect(spanTypes).toContain("span.outcome_evaluation_ongoing");
+    expect(spanTypes).toContain("span.outcome_evaluation_end");
+
+    const endSpan = h.events.find(
+      (e) => e.type === "span.outcome_evaluation_end",
+    );
+    expect(endSpan.outcome_id).toBe("outc_test1");
+    expect(endSpan.iteration).toBe(0);
+    expect(endSpan.usage.input_tokens).toBe(100);
+    expect(endSpan.explanation).toBeTruthy();
+    expect(endSpan.feedback).toBe(endSpan.explanation); // back-compat alias
+  });
+
+  // ---------- Scenario 2: script verifier exit 0 → satisfied ----------
+
+  it("verifier: script exit 0 → satisfied", async () => {
+    const h = makeFakeHarness({
+      outcome: {
+        outcome_id: "outc_test2",
+        description: "Run pytest",
+        verifier: {
+          type: "script",
+          verify_script: "exit 0",
+        },
+        max_iterations: 3,
+      },
+      runExec: async (cmd) => {
+        expect(cmd).toBe("exit 0");
+        return { exit_code: 0, output: "" };
+      },
+    });
+
+    const report = await runOutcomeSupervisor(h.deps as any);
+    expect(report.terminal.result).toBe("satisfied");
+    expect(h.state.outcome).toBeNull();
+  });
+
+  // ---------- Scenario 3: verifiable scorer ----------
+
+  it("verifier: verifiable fileWritten → needs_revision then satisfied", async () => {
+    let bashCallSent = false;
+    const h = makeFakeHarness({
+      outcome: {
+        outcome_id: "outc_test3",
+        description: "Write /workspace/x.txt",
+        verifier: {
+          type: "verifiable",
+          scorer: "fileWritten",
+          opts: { path: "/workspace/x.txt" },
+        },
+        max_iterations: 3,
+      },
+      // No tool_use events yet → fileWritten scorer fails first iteration.
+      onHarnessTurn: async (_msg, h) => {
+        // Simulate the agent finally writing the file: emit the write
+        // tool_use that fileWritten scorer looks for (it filters on
+        // name === "write" + input.file_path).
+        bashCallSent = true;
+        h.events.push({
+          type: "agent.tool_use",
+          id: "tu-1",
+          name: "write",
+          input: { file_path: "/workspace/x.txt", content: "done" },
+        });
+        h.events.push({
+          type: "agent.tool_result",
+          tool_use_id: "tu-1",
+          content: "",
+          is_error: false,
+        });
+      },
+    });
+
+    const report = await runOutcomeSupervisor(h.deps as any);
+    expect(bashCallSent).toBe(true); // harness was re-invoked
+    expect(report.terminal.result).toBe("satisfied");
+    expect(report.iterations.length).toBeGreaterThanOrEqual(2);
+    expect(report.iterations[0].result).toBe("needs_revision");
+  });
+
+  // ---------- Scenario 4: max_iterations exhausted ----------
+
+  it("max_iterations exhausted → max_iterations_reached", async () => {
+    let iters = 0;
+    const h = makeFakeHarness({
+      outcome: {
+        outcome_id: "outc_test4",
+        description: "Always fail",
+        rubric: { type: "text", content: "rubric" },
+        max_iterations: 2,
+      },
+      judge: async () => {
+        iters++;
+        return {
+          text: JSON.stringify({
+            result: "needs_revision",
+            explanation: `still wrong (try ${iters})`,
+          }),
+        };
+      },
+    });
+
+    const report = await runOutcomeSupervisor(h.deps as any);
+    expect(report.terminal.result).toBe("max_iterations_reached");
+    expect(report.iterations.length).toBe(2);
+    expect(report.iterations[0].result).toBe("needs_revision");
+    expect(report.iterations[1].result).toBe("max_iterations_reached");
+    // Iterations are 0-indexed.
+    expect(report.iterations[0].iteration).toBe(0);
+    expect(report.iterations[1].iteration).toBe(1);
+  });
+
+  // ---------- Scenario 5: verifier throws → failed ----------
+  //
+  // We use a script verifier whose runExec throws synchronously — the
+  // ScriptVerifier turns runExec failure into a not-pass score (it
+  // catches), but a verifierForSpec on a malformed RewardSpec
+  // (`type: "verifiable", scorer: "doesNotExist"`) throws at
+  // construction time, which the supervisor surfaces as `failed`.
+
+  it("verifier throws → failed", async () => {
+    const h = makeFakeHarness({
+      outcome: {
+        outcome_id: "outc_test5",
+        description: "Will crash",
+        // verifierForSpec throws at construction time on unknown scorers,
+        // which the supervisor catches and surfaces as a "failed" verdict.
+        verifier: {
+          type: "verifiable",
+          scorer: "definitelyDoesNotExist",
+        },
+        max_iterations: 3,
+      },
+    });
+
+    const report = await runOutcomeSupervisor(h.deps as any);
+    expect(report.terminal.result).toBe("failed");
+    expect(report.terminal.explanation).toMatch(/verifier construction failed/);
+    expect(h.state.outcome).toBeNull();
+  });
+
+  // ---------- Scenario 6: user.interrupt mid-eval → interrupted ----------
+
+  it("user.interrupt mid-eval → interrupted", async () => {
+    const h = makeFakeHarness({
+      outcome: {
+        outcome_id: "outc_test6",
+        description: "Slow judge",
+        rubric: { type: "text", content: "rubric" },
+        max_iterations: 3,
+      },
+      judge: async (_p, signal) => {
+        // Wait for abort, then throw an AbortError-shaped error.
+        await new Promise<void>((resolve, reject) => {
+          if (signal?.aborted) {
+            const err = new Error("aborted");
+            err.name = "AbortError";
+            return reject(err);
+          }
+          signal?.addEventListener("abort", () => {
+            const err = new Error("aborted");
+            err.name = "AbortError";
+            reject(err);
+          });
+        });
+        return { text: "" };
+      },
+    });
+
+    // Fire abort shortly after kicking off the supervisor.
+    setTimeout(() => h.abortController.abort(), 5);
+
+    const report = await runOutcomeSupervisor(h.deps as any);
+    expect(report.terminal.result).toBe("interrupted");
+    expect(h.state.outcome).toBeNull();
+  });
+
+  // ---------- Scenario 7: sequential outcomes ----------
+
+  it("sequential outcomes — second user.define_outcome starts fresh", async () => {
+    // First outcome: satisfied.
+    const h = makeFakeHarness({
+      outcome: {
+        outcome_id: "outc_first",
+        description: "first",
+        rubric: { type: "text", content: "rubric" },
+        max_iterations: 3,
+      },
+      judge: async () => ({
+        text: JSON.stringify({ result: "satisfied", explanation: "ok" }),
+      }),
+    });
+    const r1 = await runOutcomeSupervisor(h.deps as any);
+    expect(r1.terminal.result).toBe("satisfied");
+    expect(h.state.outcome_evaluations).toHaveLength(1);
+    expect(h.state.outcome_evaluations[0].outcome_id).toBe("outc_first");
+
+    // Now run a SECOND supervisor against the same fake harness state —
+    // mirrors what session-do does after the user posts another
+    // user.define_outcome. The aggregate keeps growing; the new
+    // verdict carries the new outcome_id; iteration restarts at 0.
+    const secondOutcome: ActiveOutcomeState = {
+      outcome_id: "outc_second",
+      description: "second",
+      rubric: { type: "text", content: "second rubric" },
+      max_iterations: 3,
+    };
+    h.state.outcome = secondOutcome;
+    h.state.outcome_iteration = 0;
+    h.deps.outcome = secondOutcome;
+    h.deps.initialIteration = 0;
+    h.deps.makeJudgeFn = () => async () => ({
+      text: JSON.stringify({
+        result: "satisfied",
+        explanation: "second ok",
+      }),
+    });
+
+    const r2 = await runOutcomeSupervisor(h.deps as any);
+    expect(r2.terminal.result).toBe("satisfied");
+    expect(r2.terminal.outcome_id).toBe("outc_second");
+    expect(r2.terminal.iteration).toBe(0);
+    expect(h.state.outcome_evaluations).toHaveLength(2);
+    expect(h.state.outcome_evaluations[0].outcome_id).toBe("outc_first");
+    expect(h.state.outcome_evaluations[1].outcome_id).toBe("outc_second");
+  });
+
+  // ---------- Scenario 8: file rubric → R2 fetch ----------
+
+  it("rubric: file → resolves via FILES_BUCKET", async () => {
+    let getCalls: string[] = [];
+    const h = makeFakeHarness({
+      outcome: {
+        outcome_id: "outc_file",
+        description: "from file",
+        rubric: { type: "file", file_id: "file-abc" },
+        max_iterations: 2,
+      },
+      filesBucketGet: async (key) => {
+        getCalls.push(key);
+        return { text: async () => "rubric loaded from R2" };
+      },
+      judge: async (prompt) => {
+        // The resolved markdown should appear in the user-side prompt.
+        expect(prompt.user).toContain("rubric loaded from R2");
+        return {
+          text: JSON.stringify({ result: "satisfied", explanation: "ok" }),
+        };
+      },
+    });
+
+    const report = await runOutcomeSupervisor(h.deps as any);
+    expect(report.terminal.result).toBe("satisfied");
+    expect(getCalls).toEqual(["t/tnt-test/files/file-abc"]);
+  });
+
+  // ---------- Scenario 9: file rubric not found → failed ----------
+
+  it("rubric: file 404 → failed", async () => {
+    const h = makeFakeHarness({
+      outcome: {
+        outcome_id: "outc_file_missing",
+        description: "from missing file",
+        rubric: { type: "file", file_id: "file-missing" },
+        max_iterations: 2,
+      },
+      filesBucketGet: async () => null, // R2 miss
+    });
+
+    const report = await runOutcomeSupervisor(h.deps as any);
+    expect(report.terminal.result).toBe("failed");
+    expect(report.terminal.explanation).toMatch(/rubric file fetch failed/);
+  });
+});

--- a/apps/console/src/lib/trajectory.ts
+++ b/apps/console/src/lib/trajectory.ts
@@ -1,0 +1,86 @@
+// Console-side Trajectory v1 types (subset).
+//
+// The canonical types live in `packages/eval-core/src/trajectory/types.ts`.
+// We keep a minimal mirror here so the console doesn't pull in the eval-core
+// workspace package (and its transitive deps) just to read four fields off a
+// JSON response. If the spec ever lands stable types in @open-managed-agents/
+// api-types, swap this import.
+//
+// See docs/trajectory-v1-spec.md for the authoritative shape.
+
+export type TrajectoryOutcome =
+  | "success"
+  | "failure"
+  | "timeout"
+  | "interrupted"
+  | "running";
+
+export interface RewardResult {
+  raw_rewards: Record<string, number>;
+  final_reward: number;
+  verifier_id?: string;
+  computed_at?: string;
+}
+
+export interface TrajectorySummary {
+  num_events: number;
+  num_turns: number;
+  num_tool_calls: number;
+  num_tool_errors: number;
+  num_threads: number;
+  duration_ms: number;
+  token_usage: {
+    input_tokens: number;
+    output_tokens: number;
+    cache_read_input_tokens: number;
+    cache_creation_input_tokens?: number;
+  };
+}
+
+/** Minimal Trajectory envelope as the console consumes it. The wire payload
+ *  carries more (events, agent_config, environment_config, completions); we
+ *  type those as `unknown` so we don't have to mirror the full schema. */
+export interface Trajectory {
+  schema_version: "oma.trajectory.v1";
+  trajectory_id: string;
+  session_id: string;
+  group_id?: string;
+  task_id?: string;
+
+  agent_config: unknown;
+  environment_config: unknown;
+  model: { id: string; provider: string; base_url?: string };
+
+  started_at: string;
+  ended_at?: string;
+  outcome: TrajectoryOutcome;
+
+  events: unknown[];
+
+  reward?: RewardResult;
+  completions?: unknown[];
+  group_stats?: unknown;
+
+  summary: TrajectorySummary;
+}
+
+/** Render the headline for a reward: "PASS" / "FAIL" / "0.42". */
+export function rewardHeadline(reward: RewardResult): string {
+  const v = reward.final_reward;
+  if (!Number.isFinite(v)) return "—";
+  if (v >= 0.99) return "PASS";
+  if (v <= 0) return "FAIL";
+  return v.toFixed(2);
+}
+
+/** Map TrajectoryOutcome → StatusPill `status` token (Badge.tsx) so the
+ *  pill picks up the right color tone. */
+export function outcomeToStatusTone(outcome: TrajectoryOutcome): string {
+  switch (outcome) {
+    case "success":     return "completed";
+    case "failure":     return "errored";
+    case "timeout":     return "errored";
+    case "interrupted": return "terminated";
+    case "running":     return "running";
+  }
+}

--- a/apps/console/src/pages/EvalRunDetail.tsx
+++ b/apps/console/src/pages/EvalRunDetail.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router";
 import { useApi } from "../lib/api";
+import type { Trajectory } from "../lib/trajectory";
+import { rewardHeadline } from "../lib/trajectory";
 
 interface EvalTrial {
   trial_index: number;
@@ -76,6 +78,15 @@ export function EvalRunDetail() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  /** Cache of trajectory fetches keyed by session_id. Populated lazily when
+   *  the user expands a task row — we don't pull every trial's trajectory
+   *  on initial page load (could be hundreds of trials per run). The
+   *  sentinel "loading" / "error" states keep the UI honest while inflight
+   *  / after a failure (404 = trajectory not built yet, 5xx = sandbox flaky)
+   *  so we don't retry on every render. */
+  const [trajectories, setTrajectories] = useState<
+    Map<string, Trajectory | "loading" | "error">
+  >(new Map());
 
   useEffect(() => {
     if (!id) return;
@@ -110,6 +121,40 @@ export function EvalRunDetail() {
       else next.add(taskId);
       return next;
     });
+    // Lazy-fetch trajectories for any trial in this task that has a
+    // session_id and hasn't been requested yet. The fetch result lands in
+    // `trajectories` keyed by session_id; render reads from that map.
+    const task = run?.tasks.find(t => t.id === taskId);
+    if (!task) return;
+    for (const tr of task.trials) {
+      if (!tr.session_id) continue;
+      // Avoid re-fetching anything already in flight, completed, or failed.
+      if (trajectories.has(tr.session_id)) continue;
+      void fetchTrajectory(tr.session_id);
+    }
+  }
+
+  async function fetchTrajectory(sessionId: string) {
+    setTrajectories(prev => {
+      if (prev.has(sessionId)) return prev;
+      const next = new Map(prev);
+      next.set(sessionId, "loading");
+      return next;
+    });
+    try {
+      const traj = await api<Trajectory>(`/v1/sessions/${sessionId}/trajectory`);
+      setTrajectories(prev => {
+        const next = new Map(prev);
+        next.set(sessionId, traj);
+        return next;
+      });
+    } catch {
+      setTrajectories(prev => {
+        const next = new Map(prev);
+        next.set(sessionId, "error");
+        return next;
+      });
+    }
   }
 
   if (loading) {
@@ -264,13 +309,10 @@ export function EvalRunDetail() {
                                 </span>
                               </td>
                               <td className="py-1 pr-3">
-                                {tr.reward != null ? (
-                                  <span className={tr.reward >= 1 ? "text-success font-semibold" : "text-fg-subtle"}>
-                                    {tr.reward}
-                                  </span>
-                                ) : (
-                                  <span className="text-fg-subtle">—</span>
-                                )}
+                                <TrialReward
+                                  fallback={tr.reward}
+                                  trajectory={tr.session_id ? trajectories.get(tr.session_id) : undefined}
+                                />
                               </td>
                               <td className="py-1 pr-3 font-mono text-fg-muted">{tr.exit_code ?? "—"}</td>
                               <td className="py-1 pr-3 text-fg-muted">{durationStr(tr.started_at, tr.ended_at)}</td>
@@ -291,6 +333,29 @@ export function EvalRunDetail() {
                           ))}
                         </tbody>
                       </table>
+
+                      {t.trials.some(tr => tr.session_id && trajectories.get(tr.session_id) && trajectories.get(tr.session_id) !== "loading" && trajectories.get(tr.session_id) !== "error") && (
+                        <details>
+                          <summary className="cursor-pointer text-xs text-fg-subtle hover:text-fg">
+                            reward breakdown
+                          </summary>
+                          <div className="mt-1 space-y-2">
+                            {t.trials.map(tr => {
+                              if (!tr.session_id) return null;
+                              const traj = trajectories.get(tr.session_id);
+                              if (!traj || traj === "loading" || traj === "error") return null;
+                              if (!traj.reward) return null;
+                              return (
+                                <RewardBreakdown
+                                  key={tr.trial_index}
+                                  trialIndex={tr.trial_index}
+                                  reward={traj.reward}
+                                />
+                              );
+                            })}
+                          </div>
+                        </details>
+                      )}
 
                       {t.trials.some(tr => tr.error) && (
                         <div className="text-xs text-danger space-y-0.5">
@@ -348,6 +413,104 @@ export function EvalRunDetail() {
           </tbody>
         </table>
       </div>
+    </div>
+  );
+}
+
+/** Reward cell on a trial row.
+ *
+ *  Prefers `Trajectory.reward.final_reward` (the unified Verifier output)
+ *  when the lazy-fetched trajectory is available — that's the v1 story.
+ *  Falls back to the legacy `EvalTrialResult.reward` (from when the eval
+ *  runner stamped a single number directly on the trial) so trials whose
+ *  trajectory isn't built yet still render something useful.
+ *
+ *  Sentinel handling:
+ *   - "loading" → small dim placeholder (no extra chrome)
+ *   - "error"   → fallback + "trajectory unavailable" tooltip
+ *   - undefined → fallback only (parent task wasn't expanded yet) */
+function TrialReward({
+  fallback,
+  trajectory,
+}: {
+  fallback: number | undefined;
+  trajectory: Trajectory | "loading" | "error" | undefined;
+}) {
+  if (trajectory && trajectory !== "loading" && trajectory !== "error" && trajectory.reward) {
+    const r = trajectory.reward;
+    const headline = rewardHeadline(r);
+    const isPass = r.final_reward >= 0.99;
+    const isFail = r.final_reward <= 0;
+    const cls = isPass
+      ? "text-success font-semibold"
+      : isFail
+      ? "text-danger font-semibold"
+      : "text-fg";
+    return (
+      <div className="leading-tight">
+        <div className={cls}>{headline}</div>
+        {r.verifier_id && (
+          <div className="text-[10px] text-fg-subtle font-mono">graded by {r.verifier_id}</div>
+        )}
+      </div>
+    );
+  }
+  if (trajectory === "loading") {
+    return <span className="text-fg-subtle text-[10px]">loading…</span>;
+  }
+  if (fallback != null) {
+    const tooltip = trajectory === "error" ? "trajectory unavailable; using legacy reward" : undefined;
+    return (
+      <span
+        className={fallback >= 1 ? "text-success font-semibold" : "text-fg-subtle"}
+        title={tooltip}
+      >
+        {fallback}
+      </span>
+    );
+  }
+  if (trajectory === "error") {
+    return <span className="text-fg-subtle text-[10px]" title="trajectory fetch failed">trajectory unavailable</span>;
+  }
+  return <span className="text-fg-subtle">—</span>;
+}
+
+/** Per-trial raw_rewards table. Renders one row per criterion in
+ *  `RewardResult.raw_rewards`. Hidden in a <details> in the parent so
+ *  large multi-criterion verifiers don't blow out the row height. */
+function RewardBreakdown({
+  trialIndex,
+  reward,
+}: {
+  trialIndex: number;
+  reward: { raw_rewards: Record<string, number>; final_reward: number; verifier_id?: string };
+}) {
+  const entries = Object.entries(reward.raw_rewards);
+  return (
+    <div className="border border-border rounded p-2 bg-bg">
+      <div className="text-[11px] text-fg-subtle mb-1 flex items-baseline gap-2">
+        <span>trial {trialIndex}</span>
+        {reward.verifier_id && (
+          <span className="font-mono">{reward.verifier_id}</span>
+        )}
+        <span className="ml-auto text-fg">
+          final = <span className="font-semibold">{reward.final_reward.toFixed(2)}</span>
+        </span>
+      </div>
+      {entries.length === 0 ? (
+        <div className="text-[11px] text-fg-subtle italic">no raw_rewards recorded</div>
+      ) : (
+        <table className="w-full text-[11px]">
+          <tbody>
+            {entries.map(([k, v]) => (
+              <tr key={k} className="border-t border-border/40">
+                <td className="py-0.5 pr-2 font-mono text-fg-muted">{k}</td>
+                <td className="py-0.5 text-right text-fg">{Number.isFinite(v) ? v.toFixed(2) : String(v)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
     </div>
   );
 }

--- a/apps/console/src/pages/SessionDetail.tsx
+++ b/apps/console/src/pages/SessionDetail.tsx
@@ -4,9 +4,13 @@ import { useApi } from "../lib/api";
 import { Markdown } from "../components/Markdown";
 import { formatDuration, formatRelative, shortenId } from "../lib/format";
 import { Badge, StatusPill } from "../components/Badge";
+import { Modal } from "../components/Modal";
+import { Button } from "../components/Button";
 import { AgentIcon, ClockIcon, DurationIcon, EnvIcon, VaultIcon } from "../components/icons";
 import { TimelineView } from "../components/timeline/TimelineView";
 import type { Event } from "../lib/events";
+import type { Trajectory, TrajectoryOutcome } from "../lib/trajectory";
+import { rewardHeadline, outcomeToStatusTone } from "../lib/trajectory";
 
 type View = "chat" | "timeline";
 
@@ -57,6 +61,14 @@ export function SessionDetail() {
     eventKind?: string;
   } | null>(null);
   const [status, setStatus] = useState("idle");
+  /** Lazy-fetched Trajectory v1 envelope. Drives the outcome + reward
+   *  chips in the header strip and the Trajectory viewer modal. We don't
+   *  block initial render on this — chips render as `—` until it lands.
+   *  Sentinels mirror EvalRunDetail: "loading" while in flight, "error"
+   *  if the fetch failed (404 = trajectory not built yet, 5xx = sandbox
+   *  flaky); both keep the trigger from re-firing every render. */
+  const [trajectory, setTrajectory] = useState<Trajectory | "loading" | "error" | undefined>(undefined);
+  const [showTrajectory, setShowTrajectory] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);
   const seenKeys = useRef(new Set<string>());
   const abortRef = useRef<AbortController | null>(null);
@@ -298,6 +310,18 @@ export function SessionDetail() {
     abortRef.current = abort;
     streamEvents(id, addEvent, abort.signal);
 
+    // Lazy-fetch the Trajectory envelope so the header chips have the
+    // outcome + reward to show. Decoupled from session/events fetches —
+    // trajectory builds on-demand off the events log, so a 5xx here is
+    // independent of session metadata loading. We do this once per
+    // session id and let the user reopen the page to refresh. Live
+    // sessions intentionally don't poll: trajectory.outcome === "running"
+    // is fine, the StatusPill already shows the live status.
+    setTrajectory("loading");
+    api<Trajectory>(`/v1/sessions/${id}/trajectory`)
+      .then((t) => setTrajectory(t))
+      .catch(() => setTrajectory("error"));
+
     return () => { abort.abort(); };
   }, [id]);
 
@@ -333,6 +357,15 @@ export function SessionDetail() {
         </div>
         <div className="flex items-center gap-2 flex-wrap">
           <StatusPill status={status as "idle" | "running" | "terminated" | "error" | string} />
+          {/* Trajectory outcome chip — only when the trajectory has actually
+              finished. While the session is still running we let StatusPill
+              carry the "Running…" signal alone (per Phase 3 spec) instead of
+              double-pilling. */}
+          <TrajectoryOutcomeChip trajectory={trajectory} />
+          {/* Reward chip — final_reward + verifier_id tooltip. Hidden when
+              the verifier hasn't run (no trajectory.reward) so we don't
+              imply "no reward = score 0". */}
+          <TrajectoryRewardChip trajectory={trajectory} />
           {/* Always render env + agent + vault badges so an operator can
               see what makes up this session at a glance. Name falls back
               to a short ID slice if the snapshot didn't carry one — better
@@ -375,6 +408,24 @@ export function SessionDetail() {
         {view === "timeline" && (
           <span className="ml-auto text-xs text-fg-subtle font-mono">{events.length} events</span>
         )}
+        {/* Trajectory viewer trigger — pushed to the right edge of the tab
+            row. Disabled until the lazy fetch resolves so the click never
+            opens an empty modal. Errors keep the button enabled (the modal
+            shows the error). */}
+        <button
+          onClick={() => setShowTrajectory(true)}
+          disabled={trajectory === undefined || trajectory === "loading"}
+          className={`${view === "timeline" ? "ml-3" : "ml-auto"} text-xs text-fg-muted hover:text-fg disabled:opacity-40 disabled:cursor-not-allowed border border-border hover:border-border-strong rounded px-2 py-1 transition-colors my-1.5`}
+          title={
+            trajectory === "loading"
+              ? "Loading trajectory…"
+              : trajectory === "error"
+              ? "Trajectory unavailable — click to inspect error"
+              : "View raw Trajectory v1 envelope"
+          }
+        >
+          Trajectory
+        </button>
       </div>
 
       {/* Linear context (when triggered by a Linear webhook) */}
@@ -496,7 +547,127 @@ export function SessionDetail() {
           />
         )}
       </div>
+      <TrajectoryViewerModal
+        open={showTrajectory}
+        onClose={() => setShowTrajectory(false)}
+        sessionId={id ?? ""}
+        trajectory={trajectory}
+      />
     </div>
+  );
+}
+
+/** Outcome chip rendered in the session header strip. Hidden while
+ *  the trajectory is loading / errored / still running so we never
+ *  paint an inaccurate state. The "running" outcome is intentionally
+ *  squelched here — StatusPill already renders the live status. */
+function TrajectoryOutcomeChip({
+  trajectory,
+}: {
+  trajectory: Trajectory | "loading" | "error" | undefined;
+}) {
+  if (!trajectory || trajectory === "loading" || trajectory === "error") return null;
+  if (trajectory.outcome === "running") return null;
+  const tone = outcomeToStatusTone(trajectory.outcome);
+  return (
+    <StatusPill
+      status={tone}
+      label={`Outcome: ${trajectory.outcome}`}
+    />
+  );
+}
+
+/** Reward chip rendered in the session header strip. Pure read-out of
+ *  the verifier output; tooltip shows verifier_id for debugging. */
+function TrajectoryRewardChip({
+  trajectory,
+}: {
+  trajectory: Trajectory | "loading" | "error" | undefined;
+}) {
+  if (!trajectory || trajectory === "loading" || trajectory === "error") return null;
+  const r = trajectory.reward;
+  if (!r) return null;
+  const headline = rewardHeadline(r);
+  const isPass = r.final_reward >= 0.99;
+  const isFail = r.final_reward <= 0;
+  // Reuse StatusPill tone tokens so the visual language stays consistent
+  // with the outcome chip next to it (success = same green, failure = red).
+  const tone = isPass ? "completed" : isFail ? "errored" : "neutral";
+  const titleParts = [
+    `Reward: ${r.final_reward.toFixed(4)}`,
+    r.verifier_id ? `verifier: ${r.verifier_id}` : null,
+    r.computed_at ? `computed: ${new Date(r.computed_at).toLocaleString()}` : null,
+  ].filter(Boolean) as string[];
+  return (
+    <span title={titleParts.join(" · ")}>
+      <StatusPill status={tone} label={`Reward: ${headline}`} />
+    </span>
+  );
+}
+
+/** Trajectory viewer modal — Phase 3 minimum-viable: pretty-printed
+ *  JSON with a Download button. Anthropic Messages / Inspect AI / OTel
+ *  projections are Phase 4. The download uses an in-memory blob URL
+ *  so we don't have to round-trip to a server endpoint. */
+function TrajectoryViewerModal({
+  open,
+  onClose,
+  sessionId,
+  trajectory,
+}: {
+  open: boolean;
+  onClose: () => void;
+  sessionId: string;
+  trajectory: Trajectory | "loading" | "error" | undefined;
+}) {
+  const ready = trajectory && trajectory !== "loading" && trajectory !== "error";
+  const json = ready ? JSON.stringify(trajectory, null, 2) : "";
+
+  function download() {
+    if (!ready) return;
+    const blob = new Blob([json], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `trajectory-${sessionId}.json`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  }
+
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      title="Trajectory"
+      subtitle={ready ? `${trajectory.trajectory_id} · session ${sessionId}` : `session ${sessionId}`}
+      maxWidth="max-w-4xl"
+      footer={
+        <>
+          <Button variant="ghost" onClick={onClose}>Close</Button>
+          <Button onClick={download} disabled={!ready}>Download JSON</Button>
+        </>
+      }
+    >
+      {trajectory === "loading" && (
+        <div className="text-sm text-fg-subtle">Loading trajectory…</div>
+      )}
+      {trajectory === "error" && (
+        <div className="text-sm text-danger">
+          Trajectory unavailable. The session may not have any events yet, or the
+          sandbox worker is unreachable. Retry by reloading the page.
+        </div>
+      )}
+      {trajectory === undefined && (
+        <div className="text-sm text-fg-subtle">No trajectory loaded yet.</div>
+      )}
+      {ready && (
+        <pre className="font-mono text-[11px] bg-bg-surface border border-border rounded px-3 py-2 overflow-auto max-h-[60vh] text-fg whitespace-pre">
+          {json}
+        </pre>
+      )}
+    </Modal>
   );
 }
 

--- a/apps/main/src/eval-runner.ts
+++ b/apps/main/src/eval-runner.ts
@@ -12,15 +12,15 @@
 // writeSetupFiles below), then (3) send the spec's first user message and
 // wait for idle, repeating for each subsequent message.
 
-import type { Env, AgentConfig, EnvironmentConfig, StoredEvent } from "@open-managed-agents/shared";
-import { buildTrajectory } from "@open-managed-agents/shared";
+import type { Env, AgentConfig, EnvironmentConfig, StoredEvent, Trajectory, RewardResult, VerifierContext } from "@open-managed-agents/shared";
+import { buildTrajectory, verifierForSpec, NoRunVerifier } from "@open-managed-agents/shared";
 import { logWarn } from "@open-managed-agents/shared";
 import type { SessionRecord, FullStatus } from "@open-managed-agents/shared";
 import { buildCfServices, getCfServicesForTenant, type Services } from "@open-managed-agents/services";
 import type { EvalRunRow, EvalRunStatus } from "@open-managed-agents/evals-store";
 import { toEnvironmentConfig } from "@open-managed-agents/environments-store";
 import { kvKey } from "./kv-helpers";
-import type { EvalRunRecord, EvalTaskResult, EvalTaskSpec } from "./routes/evals";
+import type { EvalRunRecord, EvalTaskResult, EvalTaskSpec, EvalTrialResult } from "./routes/evals";
 
 // ---------- Sandbox helpers (mirrors routes/sessions.ts) ----------
 
@@ -330,13 +330,148 @@ async function getSessionStatus(env: Env, run: EvalRunRecord, sessionId: string)
   }
 }
 
+/**
+ * Build a VerifierContext that lets a Verifier reach back into the agent
+ * sandbox via /exec. Used by `script` + (future) `composite` Verifiers.
+ * Stays a function (not closure-captured at module scope) so each call
+ * resolves the binding fresh — environments can re-enter ready/not-ready
+ * state during a long run.
+ */
+function buildVerifierContext(env: Env, run: EvalRunRecord, sessionId: string): VerifierContext {
+  return {
+    sessionId,
+    runExec: async (cmd, opts) => {
+      const binding = await getSandboxBinding(env, run.environment_id, run.tenant_id);
+      if (!binding) throw new Error("environment binding lost");
+      const res = await fwd(binding, `/sessions/${sessionId}/exec`, "POST", JSON.stringify({
+        command: cmd,
+        timeout_ms: opts?.timeoutMs ?? 600_000,
+      }));
+      if (!res.ok) {
+        const body = await res.text().catch(() => "");
+        return { exit_code: -1, output: `HTTP ${res.status}: ${body.slice(0, 200)}` };
+      }
+      const data = (await res.json()) as { exit_code?: number; output?: string };
+      return { exit_code: data.exit_code ?? -1, output: data.output ?? "" };
+    },
+  };
+}
+
+/**
+ * Run the trial's RewardSpec against the built trajectory and return a
+ * RewardResult ready to drop into `Trajectory.reward`. When no spec is
+ * declared on the task, fall back to the Phase 1 placeholder (idle =
+ * pass) so existing eval runs keep producing the same reward semantics.
+ */
+async function runVerifier(
+  env: Env,
+  run: EvalRunRecord,
+  task: EvalTaskResult,
+  trial: EvalTrialResult,
+  sessionId: string,
+  trajectory: Trajectory,
+): Promise<RewardResult> {
+  const computedAt = new Date().toISOString();
+  const reward = task.spec.reward;
+
+  // No spec → Phase 1 fallback. "Trial reached idle without timeout/error"
+  // is the implicit verifier; eval-runner gates this entry point on that
+  // being true, so always 1. Marked with a stable verifier_id so consumers
+  // can distinguish unconfigured-task rewards from real verifier output.
+  if (!reward) {
+    return {
+      raw_rewards: { outcome: 1 },
+      final_reward: 1,
+      verifier_id: "eval-runner.trial-status.v1",
+      computed_at: computedAt,
+    };
+  }
+
+  const ctx = buildVerifierContext(env, run, sessionId);
+  let verifier;
+  try {
+    verifier = verifierForSpec(reward, ctx);
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    logWarn(
+      { op: "eval.verifier.spec_invalid", run_id: run.id, task_id: task.spec.id, err: msg },
+      "verifier spec rejected; recording 0 reward",
+    );
+    return {
+      raw_rewards: { spec_invalid: 0 },
+      final_reward: 0,
+      verifier_id: "verifier-spec-invalid.v1",
+      computed_at: computedAt,
+    };
+  }
+
+  let score;
+  try {
+    score = await verifier.check(trajectory);
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    logWarn(
+      { op: "eval.verifier.check_threw", run_id: run.id, task_id: task.spec.id, verifier_id: verifier.id, err: msg },
+      "verifier check threw; recording 0 reward",
+    );
+    return {
+      raw_rewards: { verifier_error: 0 },
+      final_reward: 0,
+      verifier_id: verifier.id,
+      computed_at: computedAt,
+    };
+  }
+
+  // Translate Score → RewardResult. `criteria` (if provided by the
+  // verifier) is the breakdown; otherwise we reify a single-key map so
+  // downstream code (Console reward bar, RL reward stats) sees a stable
+  // shape regardless of which Verifier produced it.
+  const criteria = (score.metadata as { criteria?: Record<string, number> } | undefined)?.criteria;
+  const rawRewards = criteria && Object.keys(criteria).length > 0
+    ? criteria
+    : { value: score.value };
+  // Avoid mutating verifier-owned structures (CompositeVerifier reuses
+  // `criteria` across its own metadata and downstream propagation).
+  const persisted: Record<string, number> = {};
+  for (const [k, v] of Object.entries(rawRewards)) {
+    if (typeof v === "number" && Number.isFinite(v)) persisted[k] = v;
+  }
+
+  return {
+    raw_rewards: persisted,
+    final_reward: score.value,
+    verifier_id: verifier.id,
+    computed_at: computedAt,
+  };
+}
+
+/**
+ * Synthesize a RewardResult for a failure trial — there's no useful
+ * execution to grade, so we tag the trajectory with NoRunVerifier so
+ * Console / RL stats can distinguish "scored 0" from "never scored".
+ */
+async function synthesizeNoRunReward(reasonHint: string): Promise<RewardResult> {
+  // NoRunVerifier ignores its trajectory arg; we still call it so the
+  // reward field is built via the same Verifier abstraction as everything
+  // else (one code path = one shape).
+  const verifier = new NoRunVerifier(reasonHint);
+  const score = await verifier.check({} as Trajectory);
+  return {
+    raw_rewards: { failure: 0 },
+    final_reward: score.value,
+    verifier_id: verifier.id,
+    computed_at: new Date().toISOString(),
+  };
+}
+
 async function buildAndStoreTrajectory(
   env: Env,
   run: EvalRunRecord,
   task: EvalTaskResult,
-  trial: import("./routes/evals").EvalTrialResult,
+  trial: EvalTrialResult,
   sessionId: string,
-  finalReward: number,
+  reward: RewardResult,
+  outcomeOverride?: Trajectory["outcome"],
 ): Promise<{ trajectory_id: string; final_reward: number }> {
   const t = run.tenant_id;
   const services = await getServices(env, t);
@@ -381,42 +516,64 @@ async function buildAndStoreTrajectory(
     },
   });
 
-  // --- Trajectory v1 Phase 1 enrichment ---
+  // --- Trajectory v1 envelope enrichment ---
   // Wire eval-runner-owned fields into the envelope BEFORE storage so the
   // persisted trajectory carries reward / task_id / group_id / a corrected
-  // outcome on its own. Phase 3 (Console UI) will read these directly;
-  // Phase 2 will swap the static reward for a Verifier abstraction.
+  // outcome on its own. Phase 3 (Console UI) will read these directly.
 
   // task_id / group_id — eval-runner is the only caller that knows them.
-  // Non-eval session trajectories (built via /v1/sessions/:id/trajectory)
-  // correctly leave both undefined.
   trajectory.task_id = task.spec.id;
   trajectory.group_id = run.id;
 
-  // outcome timeout override — `deriveOutcome` can't see eval-runner's
-  // wall-clock budget. We do. If the trial bailed via the per-trial
-  // timeout_ms guard (the `trial timeout: ...` error string is set by
-  // advanceTrial) the trajectory's outcome should be `timeout`, not
-  // whatever deriveOutcome produced (likely `running` — the session
-  // never reached status_idle / status_terminated / session.error).
-  if (trial.error && /timeout/i.test(trial.error)) {
+  // outcome override — `deriveOutcome` can't see eval-runner's wall-clock
+  // budget or setup-error short-circuits. Caller passes the right outcome
+  // when known (timeout / failure on bootstrap-error trials). Otherwise
+  // we infer from the trial's error string for the "trial timeout" path.
+  if (outcomeOverride) {
+    trajectory.outcome = outcomeOverride;
+  } else if (trial.error && /timeout/i.test(trial.error)) {
     trajectory.outcome = "timeout";
   }
 
-  // reward — Phase 1 placeholder verifier. Caller provides the scalar
-  // (today: 0/1 from did-the-trial-finalize-successfully). Phase 2 will
-  // replace this with the unified Verifier abstraction (see
-  // docs/handoff-verifier-framework.md).
-  trajectory.reward = {
-    raw_rewards: { outcome: finalReward },
-    final_reward: finalReward,
-    verifier_id: "eval-runner.trial-status.v1",
-    computed_at: new Date().toISOString(),
-  };
+  trajectory.reward = reward;
 
   // Store trajectory under a stable key; for now use trajectory_id as the only key
   await env.CONFIG_KV.put(kvKey(t, "trajectory", trajectory.trajectory_id), JSON.stringify(trajectory));
-  return { trajectory_id: trajectory.trajectory_id, final_reward: finalReward };
+  return { trajectory_id: trajectory.trajectory_id, final_reward: reward.final_reward };
+}
+
+/**
+ * Best-effort no-run trajectory persistence for failure trials. Used
+ * when a trial dies before producing useful execution (setup error,
+ * postUserMessage failure, per-trial wall-clock timeout). Synthesizes a
+ * reward with NoRunVerifier so the Console / RL stats can still query
+ * the failure timeline through the canonical Trajectory envelope.
+ *
+ * Failure to build the trajectory is logged and swallowed — we still
+ * want the trial.status=failed transition to land even if the events
+ * endpoint is currently 500-ing.
+ */
+async function persistFailureTrajectory(
+  env: Env,
+  run: EvalRunRecord,
+  task: EvalTaskResult,
+  trial: EvalTrialResult,
+  sessionId: string,
+  outcome: Trajectory["outcome"],
+  reasonHint: string,
+): Promise<void> {
+  try {
+    const reward = await synthesizeNoRunReward(reasonHint);
+    const result = await buildAndStoreTrajectory(env, run, task, trial, sessionId, reward, outcome);
+    trial.trajectory_id = result.trajectory_id;
+    trial.reward = result.final_reward;
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    logWarn(
+      { op: "eval.failure_trajectory.skip", run_id: run.id, task_id: task.spec.id, session_id: sessionId, err: msg },
+      "could not build failure-trial trajectory; trial.failed without trajectory_id",
+    );
+  }
 }
 
 // ---------- Single-tick advance (per-trial) ----------
@@ -425,15 +582,16 @@ async function advanceTrial(
   env: Env,
   run: EvalRunRecord,
   task: EvalTaskResult,
-  trial: import("./routes/evals").EvalTrialResult,
+  trial: EvalTrialResult,
 ): Promise<boolean> {
   // Returns true if any progress was made (caller should save).
   if (trial.status === "completed" || trial.status === "failed") return false;
 
   // Bootstrap: create session + write setup_files (if any) + send first message
   if (trial.status === "pending") {
+    let sessionId: string | undefined;
     try {
-      const sessionId = await createTaskSession(env, run, task);
+      sessionId = await createTaskSession(env, run, task);
       trial.session_id = sessionId;
       trial.status = "running";
       trial.started_at = new Date().toISOString();
@@ -454,6 +612,15 @@ async function advanceTrial(
       trial.status = "failed";
       trial.error = err instanceof Error ? err.message : String(err);
       trial.ended_at = new Date().toISOString();
+      // Phase 2 failure-trial gap fix: when a session was successfully
+      // created but the trial died before producing useful execution
+      // (setup_files, setup_script, or first postUserMessage failed),
+      // build a no-run trajectory so the failure is queryable through
+      // the canonical Trajectory envelope. If `createTaskSession` itself
+      // threw there's no sessionId — nothing to build, leave it bare.
+      if (sessionId) {
+        await persistFailureTrajectory(env, run, task, trial, sessionId, "failure", trial.error);
+      }
       return true;
     }
   }
@@ -477,6 +644,11 @@ async function advanceTrial(
       trial.status = "failed";
       trial.error = `trial timeout: ${Math.round(elapsed / 1000)}s exceeded budget ${Math.round(timeoutMs / 1000)}s (m_idx=${trial.current_message_index ?? 0})`;
       trial.ended_at = new Date().toISOString();
+      // Phase 2 failure-trial gap fix: stale-session timeout is the most
+      // diagnostically valuable failure shape (model hung mid-tool,
+      // sandbox crashed, status endpoint broken). The trajectory will
+      // contain the partial event stream up to the freeze point.
+      await persistFailureTrajectory(env, run, task, trial, trial.session_id, "timeout", trial.error);
       return true;
     }
   }
@@ -495,28 +667,54 @@ async function advanceTrial(
       trial.status = "failed";
       trial.error = err instanceof Error ? err.message : String(err);
       trial.ended_at = new Date().toISOString();
+      // Phase 2 failure-trial gap fix: postUserMessage failure mid-run
+      // — the agent already produced N-1 turns of trajectory worth
+      // archiving even if turn N can't be sent.
+      await persistFailureTrajectory(env, run, task, trial, trial.session_id, "failure", trial.error);
       return true;
     }
   }
 
-  // All messages sent and session idle → build trajectory and finalize.
-  // Reaching this point means every spec.messages[] turn ran to idle without
-  // exceeding timeout_ms or hitting an error path; per Phase 1's
-  // trial-status-as-reward (the placeholder until the Verifier abstraction
-  // lands in Phase 2), that's a 1.0. Trajectory storage failure below is
-  // infrastructure, not verification — rolls back to running for retry,
-  // gives up at 3 attempts and demotes to failed (with the trajectory then
-  // never persisted, so no reward to write).
+  // All messages sent and session idle → build trajectory + run verifier.
+  // Reaching this point means every spec.messages[] turn ran to idle
+  // without exceeding timeout_ms or hitting an error path; the verifier
+  // (or the Phase 1 placeholder fallback when no spec is declared)
+  // grades the resulting trajectory and supplies the reward. Trajectory
+  // storage failure below is infrastructure, not verification — rolls
+  // back to running for retry, gives up at 3 attempts and demotes to
+  // failed (with the trajectory then never persisted, so no reward to
+  // write).
   try {
-    const finalReward = 1;
-    const result = await buildAndStoreTrajectory(env, run, task, trial, trial.session_id, finalReward);
-    trial.trajectory_id = result.trajectory_id;
+    // Build the trajectory once and run the verifier against it. The
+    // verifier may itself reach back into the sandbox via /exec (script
+    // RewardSpec); the canonical Trajectory is what gets graded.
+    // Synthesize a placeholder reward first so buildAndStoreTrajectory
+    // has something to wire in; immediately replace with the verified
+    // reward and re-store so persisted state matches what the verifier
+    // produced. Two writes is fine — eval finalize is bounded once per
+    // trial, the second store atomically overwrites the first.
+    const placeholder = await synthesizeNoRunReward("pre-verify placeholder");
+    const built = await buildAndStoreTrajectory(env, run, task, trial, trial.session_id, placeholder);
+    // Re-fetch the trajectory we just wrote (the verifier needs the
+    // enriched envelope: events + summary + outcome). Cheap: it's local KV.
+    const t = run.tenant_id;
+    const stored = await env.CONFIG_KV.get(kvKey(t, "trajectory", built.trajectory_id), "text");
+    if (!stored) throw new Error(`trajectory ${built.trajectory_id} disappeared after store`);
+    const trajectory = JSON.parse(stored) as Trajectory;
+    const reward = await runVerifier(env, run, task, trial, trial.session_id, trajectory);
+    trajectory.reward = reward;
+    await env.CONFIG_KV.put(
+      kvKey(t, "trajectory", built.trajectory_id),
+      JSON.stringify(trajectory),
+    );
+
+    trial.trajectory_id = built.trajectory_id;
     trial.status = "completed";
     trial.ended_at = new Date().toISOString();
     // Mirror Trajectory.reward.final_reward onto the trial for Console
     // back-compat. Phase 3 will switch the UI to read trajectory.reward
     // directly and this can drop.
-    trial.reward = result.final_reward;
+    trial.reward = reward.final_reward;
     return true;
   } catch (err: unknown) {
     // Bounded retry: events fetch can transiently 500 under storage

--- a/apps/main/src/routes/evals.ts
+++ b/apps/main/src/routes/evals.ts
@@ -1,5 +1,5 @@
 import { Hono } from "hono";
-import type { Env } from "@open-managed-agents/shared";
+import type { Env, RewardSpec } from "@open-managed-agents/shared";
 import type { EvalRunStatus } from "@open-managed-agents/evals-store";
 import type { Services } from "@open-managed-agents/services";
 import { kvKey } from "../kv-helpers";
@@ -27,6 +27,22 @@ export interface EvalTaskSpec {
   // Default 1. When > 1, server spawns N sessions per task and stores N
   // trajectory_ids; pass@k / pass^k computed by downstream scorer layer.
   trials?: number;
+  /**
+   * Phase 2: declarative reward / verification spec. Optional.
+   *   - undefined  → eval-runner falls back to "trial reached idle = pass"
+   *                 (the Phase 1 placeholder; reward.verifier_id =
+   *                 "eval-runner.trial-status.v1")
+   *   - { type: "script", verify_script } → ScriptVerifier runs the script
+   *                 in the sandbox via /exec and grades by exit code
+   *   - { type: "verifiable", scorer, opts } → wraps a named Scorer from
+   *                 packages/eval-core/src/scorers/scorers.ts
+   *   - { type: "composite", components: [...] } → weighted aggregate
+   *   - { type: "reward_model", endpoint } → external HTTP grader
+   *
+   * JSON wire shape matches RLTask.reward so the same task definitions
+   * work for both eval and RL. See packages/eval-core/src/verifier/types.ts.
+   */
+  reward?: RewardSpec;
 }
 
 export type { EvalRunStatus };

--- a/apps/main/src/routes/sessions.ts
+++ b/apps/main/src/routes/sessions.ts
@@ -678,7 +678,24 @@ app.get("/:id", async (c) => {
       const fullStatus = (await fullStatusRes.json()) as {
         status: string;
         usage: { input_tokens: number; output_tokens: number };
-        outcome_evaluations: Array<{ result: string; iteration: number; feedback?: string }>;
+        // Phase 4 / AMA-aligned: every terminal `span.outcome_evaluation_end`
+        // for this session, in iteration order. AMA returns this verbatim
+        // under `outcome_evaluations[]` from GET /v1/sessions/:id.
+        outcome_evaluations: Array<{
+          outcome_id?: string;
+          result: string;
+          iteration: number;
+          explanation?: string;
+          /** @deprecated alias of `explanation`. */
+          feedback?: string;
+          usage?: {
+            input_tokens: number;
+            output_tokens: number;
+            cache_creation_input_tokens?: number;
+            cache_read_input_tokens?: number;
+          };
+          processed_at?: string;
+        }>;
       };
       response.status = fullStatus.status;
       response.usage = fullStatus.usage;

--- a/packages/api-types/src/types.ts
+++ b/packages/api-types/src/types.ts
@@ -435,12 +435,59 @@ export interface AgentMcpToolResultEvent extends EventBase {
 
 export interface UserDefineOutcomeEvent extends EventBase {
   type: "user.define_outcome";
+  /**
+   * Server-minted on ingest, prefix `outc_`. Echoed back on the persisted
+   * event so downstream `span.outcome_evaluation_*` events can name which
+   * outcome they pertain to. AMA-spec compatible.
+   */
   outcome_id?: string;
   description: string;
-  rubric?: string;  // text rubric or file reference
+  /**
+   * Rubric for the LLM-judge path. AMA accepts either inline text or a
+   * pointer to an uploaded file.
+   *
+   * Back-compat: a bare string is treated as `{ type: "text", content }` —
+   * old clients that pre-date this schema bump keep working.
+   *
+   * Mutually exclusive with `verifier`; at least one of the two is required.
+   */
+  rubric?: string | RubricSpec;
+  /**
+   * OMA superset over AMA: a deterministic / scriptable check. When set,
+   * takes precedence over `rubric`. Wire shape mirrors @oma/eval-core
+   * `RewardSpec` (script / verifiable / composite / reward_model). Typed
+   * structurally here so api-types stays a leaf package.
+   */
+  verifier?: OutcomeVerifierSpec;
   max_iterations?: number; // default 3, max 20
 }
 
+/**
+ * AMA outcome rubric union. The `file` variant resolves the rubric content
+ * from the OMA Files API at outcome trigger time; the resolved text is
+ * cached in session state so re-iteration doesn't re-fetch.
+ */
+export type RubricSpec =
+  | { type: "text"; content: string }
+  | { type: "file"; file_id: string };
+
+/**
+ * Wire shape of @oma/eval-core RewardSpec, restated here so api-types
+ * stays a leaf (eval-core depends on api-types). Validation + dispatch
+ * lives in eval-core; this type just keeps `user.define_outcome` typed
+ * end-to-end.
+ */
+export interface OutcomeVerifierSpec {
+  type: "script" | "verifiable" | "composite" | "reward_model";
+  [key: string]: unknown;
+}
+
+/**
+ * @deprecated Legacy spelling — emit `span.outcome_evaluation_end` instead.
+ * Kept as a type alias so old persisted events parse, and rl/collector
+ * keeps reading historical sessions. New emit sites use
+ * `SpanOutcomeEvaluationEndEvent`.
+ */
 export interface OutcomeEvaluationEvent extends EventBase {
   type: "outcome.evaluation_end";
   result: "satisfied" | "needs_revision" | "max_iterations_reached" | "failed";
@@ -605,6 +652,12 @@ export interface SpanModelRequestEndEvent extends EventBase {
 
 export interface SpanOutcomeEvaluationStartEvent extends EventBase {
   type: "span.outcome_evaluation_start";
+  /** AMA-spec: which outcome this iteration belongs to. Optional for
+   *  back-compat — pre-Phase-4 events lack it. */
+  outcome_id?: string;
+  /** 0-indexed revision counter. AMA: `0` = first evaluation, `1` = first
+   *  re-evaluation after revision, etc. Pre-Phase-4 emitters used 1-indexed;
+   *  consumers should treat both as monotonic counters when comparing. */
   iteration: number;
 }
 
@@ -631,14 +684,57 @@ export interface SpanCompactionSummarizeEndEvent extends EventBase {
 
 export interface SpanOutcomeEvaluationOngoingEvent extends EventBase {
   type: "span.outcome_evaluation_ongoing";
-  iteration: number;
+  /** AMA-spec: which outcome this heartbeat belongs to. Optional for
+   *  back-compat. */
+  outcome_id?: string;
+  /** 0-indexed iteration this heartbeat belongs to. Optional — heartbeats
+   *  may fire before the start span has the iteration cemented. */
+  iteration?: number;
 }
 
 export interface SpanOutcomeEvaluationEndEvent extends EventBase {
   type: "span.outcome_evaluation_end";
-  result: "satisfied" | "needs_revision" | "max_iterations_reached" | "failed";
+  /** AMA-spec: matches the parent `span.outcome_evaluation_start.id`.
+   *  Optional for back-compat. */
+  outcome_evaluation_start_id?: string;
+  /** AMA-spec: which outcome this verdict belongs to. Optional for
+   *  back-compat. */
+  outcome_id?: string;
+  /**
+   * Verdict enum, AMA-aligned (5 values):
+   *   - `satisfied` — rubric met, session transitions to idle
+   *   - `needs_revision` — agent gets the explanation back, starts a new
+   *     iteration cycle
+   *   - `max_iterations_reached` — terminal, no further evaluation cycles
+   *   - `failed` — verifier threw / returned malformed score / rubric
+   *     fundamentally doesn't match the task
+   *   - `interrupted` — `user.interrupt` arrived mid-evaluation; only
+   *     emitted if the matching `span.outcome_evaluation_start` had already
+   *     fired
+   */
+  result:
+    | "satisfied"
+    | "needs_revision"
+    | "max_iterations_reached"
+    | "failed"
+    | "interrupted";
+  /** 0-indexed iteration this verdict applies to. */
   iteration: number;
+  /** Human-readable rationale for the verdict. AMA names this
+   *  `explanation`; pre-Phase-4 emitters used `feedback`. Both fields are
+   *  populated on emit so old consumers keep working. */
+  explanation?: string;
+  /** @deprecated Use `explanation`. Kept on the wire for back-compat with
+   *  consumers that haven't migrated. New emitters set both. */
   feedback?: string;
+  /** AMA-spec grader token usage. Populated when the verifier reports it
+   *  via `Score.metadata.usage` or by accumulating in-process LLM calls. */
+  usage?: {
+    input_tokens: number;
+    output_tokens: number;
+    cache_creation_input_tokens?: number;
+    cache_read_input_tokens?: number;
+  };
 }
 
 // Aux events — platform-internal LLM calls made on behalf of a tool

--- a/packages/eval-core/src/index.ts
+++ b/packages/eval-core/src/index.ts
@@ -13,3 +13,4 @@ export * from "./trajectory/types";
 export * from "./trajectory/build";
 export * from "./trajectory/projections/anthropic-messages";
 export * from "./scorers";
+export * from "./verifier";

--- a/packages/eval-core/src/verifier/builtins/composite.ts
+++ b/packages/eval-core/src/verifier/builtins/composite.ts
@@ -1,0 +1,71 @@
+// Composite Verifier — wraps N sub-Verifiers and aggregates their
+// `score.value` by weighted average. Each sub-score becomes a key in
+// the composite's `criteria`.
+//
+// Use case: a task that wants both "tests pass" (script) and "code is
+// idiomatic" (reward_model judge) signals combined into a single
+// reward scalar. The sub-Verifiers run in parallel — one slow LLM
+// judge doesn't stall the script verifier.
+
+import type { Trajectory } from "../../trajectory/types.js";
+import type { Score } from "../../scorers/types.js";
+import type { Verifier, VerifierContext, CompositeRewardSpec } from "../types.js";
+import { verifierForSpec } from "../registry.js";
+
+export class CompositeVerifier implements Verifier {
+  readonly id = "composite.v1";
+
+  constructor(
+    private readonly spec: CompositeRewardSpec,
+    private readonly ctx: VerifierContext,
+  ) {}
+
+  async check(traj: Trajectory): Promise<Score> {
+    const components = this.spec.components;
+    if (!components || components.length === 0) {
+      return {
+        pass: false,
+        value: 0,
+        reason: "composite verifier has no components",
+        metadata: { criteria: {} },
+      };
+    }
+
+    // Parallel execution — composite latency is max(child), not sum.
+    const settled = await Promise.allSettled(
+      components.map(async (c) => ({
+        name: c.name,
+        weight: c.weight,
+        score: await verifierForSpec(c.verifier, this.ctx).check(traj),
+      })),
+    );
+
+    const criteria: Record<string, number> = {};
+    const reasons: string[] = [];
+    let weightedSum = 0;
+    let totalWeight = 0;
+    let allPass = true;
+
+    for (const s of settled) {
+      if (s.status === "rejected") {
+        allPass = false;
+        reasons.push(`unknown_child_failed: ${String(s.reason).slice(0, 100)}`);
+        continue;
+      }
+      const { name, weight, score } = s.value;
+      criteria[name] = score.value;
+      weightedSum += score.value * weight;
+      totalWeight += weight;
+      reasons.push(`${name}=${score.value.toFixed(3)} (${score.reason.slice(0, 80)})`);
+      if (!score.pass) allPass = false;
+    }
+
+    const value = totalWeight > 0 ? weightedSum / totalWeight : 0;
+    return {
+      pass: allPass,
+      value,
+      reason: `composite: ${reasons.join("; ")}`,
+      metadata: { criteria },
+    };
+  }
+}

--- a/packages/eval-core/src/verifier/builtins/llm_judge.ts
+++ b/packages/eval-core/src/verifier/builtins/llm_judge.ts
@@ -1,0 +1,263 @@
+// LLM-Judge Verifier — in-process LLM evaluation against a rubric.
+//
+// This is the AMA-default outcome path: the supervisor passes the agent's
+// configured aux model and the resolved rubric markdown, and the verifier
+// returns a Score driven by the model's "satisfied | needs_revision"
+// verdict.
+//
+// Why a separate verifier (not an extension of RewardModelVerifier)?
+//   - RewardModelVerifier POSTs to an HTTP endpoint. The supervisor
+//     already holds an in-process `LanguageModel` handle (via the AI
+//     SDK's `generateText`); routing through HTTP back to ourselves
+//     would double-cost and double-fail.
+//   - Outcome judging needs token-usage propagation back to
+//     `span.outcome_evaluation_end.usage` (AMA spec). The HTTP path
+//     loses that.
+//
+// Why not a JSON RewardSpec branch?
+//   - RewardSpec is the JSON wire format that lives on persisted tasks.
+//     A `LanguageModel` handle is not serializable, so it has no place
+//     in RewardSpec. Instead the supervisor calls
+//     `createLlmJudgeVerifier(...)` with the runtime-resolved model.
+//
+// Decoupling from the AI SDK:
+//   The verifier doesn't import `ai`; it accepts a `JudgeFn` callback
+//   the caller wraps around `generateText`. Keeps @oma/eval-core a
+//   leaf package.
+
+import type { Score } from "../../scorers/types.js";
+import type { Trajectory } from "../../trajectory/types.js";
+import type { Verifier } from "../types.js";
+import { extractTextFromContent } from "../../scorers/scorers.js";
+
+/** Token-usage shape mirroring AMA's `span.outcome_evaluation_end.usage`. */
+export interface JudgeUsage {
+  input_tokens: number;
+  output_tokens: number;
+  cache_creation_input_tokens?: number;
+  cache_read_input_tokens?: number;
+}
+
+/**
+ * Caller-supplied wrapper around an in-process LLM. The supervisor
+ * loop in apps/agent passes a closure over the AI SDK's `generateText`;
+ * tests pass a fake. Letting this be a function (rather than a typed
+ * `LanguageModel`) keeps eval-core dep-free of `ai`.
+ */
+export type JudgeFn = (
+  prompt: { system: string; user: string },
+  signal?: AbortSignal,
+) => Promise<{ text: string; usage?: JudgeUsage }>;
+
+export interface LlmJudgeOpts {
+  /**
+   * Already-resolved rubric markdown. File rubrics are fetched at the
+   * supervisor layer (see apps/agent/src/runtime/resolve-rubric.ts);
+   * this verifier never touches the Files API.
+   */
+  rubric: string;
+  judge: JudgeFn;
+  /** Free-form id appended to the verifier id (for logs / Score.metadata). */
+  modelId?: string;
+  /**
+   * The agent's task description, surfaced to the judge alongside the
+   * rubric so the verdict reflects "did the agent do the requested task
+   * by the rubric's standards" rather than rubric-only matching.
+   */
+  description?: string;
+  /** Max retries on parse failure / transient JudgeFn errors. */
+  maxRetries?: number;
+  /** Optional cancellation; passed through to JudgeFn. */
+  abortSignal?: AbortSignal;
+}
+
+const MAX_RETRIES_DEFAULT = 3;
+const BASE_DELAY_MS = 1000;
+const TRANSCRIPT_CHAR_BUDGET = 50_000;
+
+export class LlmJudgeVerifier implements Verifier {
+  readonly id: string;
+
+  constructor(private readonly opts: LlmJudgeOpts) {
+    this.id = `llm_judge${opts.modelId ? `.${opts.modelId}` : ""}.v1`;
+  }
+
+  async check(traj: Trajectory): Promise<Score> {
+    return this.runJudge(traj, this.opts.rubric);
+  }
+
+  /**
+   * Judge with a runtime-supplied rubric. Useful when a single verifier
+   * instance grades many trajectories with task-specific rubrics (e.g.
+   * eval-runner re-grading historical sessions).
+   */
+  async judge(traj: Trajectory, rubric: string): Promise<Score> {
+    return this.runJudge(traj, rubric);
+  }
+
+  private async runJudge(traj: Trajectory, rubric: string): Promise<Score> {
+    const transcript = buildAgentTranscript(traj);
+    const description = this.opts.description ?? "";
+    const maxRetries = this.opts.maxRetries ?? MAX_RETRIES_DEFAULT;
+
+    const system =
+      `You are an outcome evaluator. Read the rubric, the task description, and the agent's transcript. ` +
+      `Reply with EXACTLY one JSON object: {"result": "satisfied" | "needs_revision", "explanation": "..."}. ` +
+      `Use "satisfied" only when every rubric criterion is clearly met by the transcript. ` +
+      `Use "needs_revision" otherwise, and use the explanation field to describe the specific gaps.`;
+    const user =
+      (description ? `## Task\n${description}\n\n` : "") +
+      `## Rubric\n${rubric}\n\n` +
+      `## Agent transcript\n${transcript || "(empty — the agent produced no messages)"}\n\n` +
+      `Respond with the JSON object only.`;
+
+    let lastErr = "";
+    let lastUsage: JudgeUsage | undefined;
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
+      try {
+        const { text, usage } = await this.opts.judge(
+          { system, user },
+          this.opts.abortSignal,
+        );
+        if (usage) lastUsage = mergeUsage(lastUsage, usage);
+        const candidate = text || "";
+        const parsed = parseRubricVerdict(candidate);
+        if (parsed) {
+          const pass = parsed.result === "satisfied";
+          return {
+            pass,
+            value: pass ? 1 : 0,
+            reason:
+              parsed.explanation ||
+              (pass ? "rubric satisfied" : "rubric not yet satisfied"),
+            metadata: {
+              criteria: { satisfied: pass ? 1 : 0 },
+              explanation: parsed.explanation,
+              ...(lastUsage ? { usage: lastUsage } : {}),
+            },
+          };
+        }
+        lastErr = `parse failure (text=${candidate.slice(0, 200)})`;
+      } catch (err: unknown) {
+        if ((err as { name?: string }).name === "AbortError") {
+          // Bubble — supervisor turns this into a "interrupted" verdict
+          // before persisting.
+          throw err;
+        }
+        lastErr = err instanceof Error ? err.message : String(err);
+      }
+
+      if (attempt >= maxRetries) break;
+      const delay = Math.min(
+        8000,
+        BASE_DELAY_MS * Math.pow(2, attempt) * (0.75 + Math.random() * 0.5),
+      );
+      await new Promise((r) => setTimeout(r, delay));
+    }
+
+    // Out of retries — return needs_revision with the failure reason in
+    // `reason`. The supervisor turns a non-pass score into either
+    // `needs_revision` or `max_iterations_reached`, never `failed` (which
+    // is reserved for verifier throws). If the operator wants a hard
+    // failure on judge failure they can switch to a deterministic
+    // verifier or raise.
+    return {
+      pass: false,
+      value: 0,
+      reason: `llm judge exhausted retries: ${lastErr.slice(0, 200)}`,
+      metadata: {
+        criteria: { satisfied: 0 },
+        ...(lastUsage ? { usage: lastUsage } : {}),
+      },
+    };
+  }
+}
+
+/** Convenience factory — mirrors the eval-core export style. */
+export function createLlmJudgeVerifier(opts: LlmJudgeOpts): LlmJudgeVerifier {
+  return new LlmJudgeVerifier(opts);
+}
+
+/**
+ * Build a compact agent-only transcript. Mirrors what the old
+ * evaluateOutcome inlined: concat all `agent.message` text content.
+ * Keeps the verdict comparable across the migration so an existing
+ * outcome that satisfied under the old judge keeps satisfying under the
+ * new one (modulo prompt wording).
+ */
+function buildAgentTranscript(traj: Trajectory): string {
+  const out: string[] = [];
+  let used = 0;
+  for (const e of traj.events) {
+    if (e.type !== "agent.message") continue;
+    const parsed = parseEventData(e);
+    const content = (parsed as { content?: unknown })?.content;
+    const text = extractTextFromContent(content);
+    if (!text) continue;
+    if (used + text.length > TRANSCRIPT_CHAR_BUDGET) {
+      out.push(text.slice(0, TRANSCRIPT_CHAR_BUDGET - used));
+      out.push("\n…(truncated)");
+      break;
+    }
+    out.push(text);
+    used += text.length;
+  }
+  return out.join("\n\n");
+}
+
+function parseEventData(e: { data: string | object }): unknown {
+  if (typeof e.data === "string") {
+    try {
+      return JSON.parse(e.data);
+    } catch {
+      return null;
+    }
+  }
+  return e.data;
+}
+
+interface RubricVerdict {
+  result: "satisfied" | "needs_revision";
+  explanation: string;
+}
+
+/**
+ * Tolerant parser: scans for the first JSON object in the model's reply,
+ * tries to read either `explanation` (AMA spelling) or `feedback`
+ * (legacy spelling) for the rationale. Returns null if no usable object
+ * was found — caller retries.
+ */
+function parseRubricVerdict(text: string): RubricVerdict | null {
+  if (!text.trim()) return null;
+  const m = text.match(/\{[\s\S]*?\}/);
+  if (!m) return null;
+  try {
+    const parsed = JSON.parse(m[0]) as {
+      result?: string;
+      explanation?: string;
+      feedback?: string;
+    };
+    const result =
+      parsed.result === "satisfied" ? "satisfied" : "needs_revision";
+    return {
+      result,
+      explanation: parsed.explanation || parsed.feedback || "",
+    };
+  } catch {
+    return null;
+  }
+}
+
+function mergeUsage(prev: JudgeUsage | undefined, next: JudgeUsage): JudgeUsage {
+  if (!prev) return { ...next };
+  return {
+    input_tokens: prev.input_tokens + next.input_tokens,
+    output_tokens: prev.output_tokens + next.output_tokens,
+    cache_creation_input_tokens:
+      (prev.cache_creation_input_tokens ?? 0) +
+      (next.cache_creation_input_tokens ?? 0) || undefined,
+    cache_read_input_tokens:
+      (prev.cache_read_input_tokens ?? 0) + (next.cache_read_input_tokens ?? 0) ||
+      undefined,
+  };
+}

--- a/packages/eval-core/src/verifier/builtins/no_run.ts
+++ b/packages/eval-core/src/verifier/builtins/no_run.ts
@@ -1,0 +1,31 @@
+// No-Run Verifier — synthetic Verifier emitted for trials that died
+// before the agent ever produced a useful execution (setup error,
+// postUserMessage failure, per-trial wall-clock timeout). There's
+// nothing meaningful to score, so we record `value=0, pass=false`
+// with a stable verifier_id so consumers can distinguish "scored as
+// failure" from "no scoring attempted".
+//
+// Phase 2 use: eval-runner uses this for the failure-trial trajectory
+// gap fix (Phase 1 left it on purpose: failure trials had no
+// trajectory built; Phase 2 builds the trajectory and tags it
+// no-run.v1 so the failure timeline is still queryable).
+
+import type { Trajectory } from "../../trajectory/types.js";
+import type { Score } from "../../scorers/types.js";
+import type { Verifier } from "../types.js";
+
+export class NoRunVerifier implements Verifier {
+  readonly id = "no-run.v1";
+
+  constructor(private readonly reasonHint?: string) {}
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async check(_traj: Trajectory): Promise<Score> {
+    return {
+      pass: false,
+      value: 0,
+      reason: this.reasonHint ? `no-run: ${this.reasonHint}` : "no-run",
+      metadata: { criteria: { failure: 0 } },
+    };
+  }
+}

--- a/packages/eval-core/src/verifier/builtins/reward_model.ts
+++ b/packages/eval-core/src/verifier/builtins/reward_model.ts
@@ -1,0 +1,93 @@
+// Reward-Model Verifier — POSTs the trajectory + rubric to an external
+// HTTP endpoint and parses the response as a Score.
+//
+// Standard wire format the endpoint must produce:
+//   {
+//     "value": number,        // 0..1
+//     "pass": boolean,
+//     "reasoning"?: string,
+//     "criteria"?: Record<string, number>
+//   }
+//
+// Failure modes (network error, non-2xx, malformed body, timeout) are
+// converted to a deterministic 0-score so the trial doesn't hang. The
+// underlying error is surfaced in `reasoning` so the trajectory still
+// records why scoring failed.
+//
+// `judge(traj, rubric)` overrides whatever rubric was configured at
+// construction time — eval-core consumers should wire it from the
+// task's runtime rubric (e.g. `state.outcome.rubric` for the supervisor
+// loop).
+
+import type { Trajectory } from "../../trajectory/types.js";
+import type { Score } from "../../scorers/types.js";
+import type { Verifier, VerifierContext, RewardModelRewardSpec } from "../types.js";
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+interface RewardModelResponse {
+  value?: number;
+  pass?: boolean;
+  reasoning?: string;
+  criteria?: Record<string, number>;
+}
+
+export class RewardModelVerifier implements Verifier {
+  readonly id = "reward_model.v1";
+
+  constructor(
+    private readonly spec: RewardModelRewardSpec,
+    private readonly _ctx: VerifierContext,
+  ) {}
+
+  async check(traj: Trajectory): Promise<Score> {
+    return this.callRewardModel(traj, this.spec.prompt_template);
+  }
+
+  async judge(traj: Trajectory, rubric: string): Promise<Score> {
+    return this.callRewardModel(traj, rubric);
+  }
+
+  private async callRewardModel(traj: Trajectory, rubric?: string): Promise<Score> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), DEFAULT_TIMEOUT_MS);
+    try {
+      const res = await fetch(this.spec.endpoint, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ trajectory: traj, rubric: rubric ?? "" }),
+        signal: controller.signal,
+      });
+      if (!res.ok) {
+        const body = await res.text().catch(() => "");
+        return zero(`reward_model HTTP ${res.status}: ${body.slice(0, 200)}`);
+      }
+      const parsed = (await res.json().catch(() => null)) as RewardModelResponse | null;
+      if (!parsed || typeof parsed.value !== "number") {
+        return zero(`reward_model malformed response (no numeric value)`);
+      }
+      const value = clamp01(parsed.value);
+      const pass = typeof parsed.pass === "boolean" ? parsed.pass : value >= 0.5;
+      return {
+        pass,
+        value,
+        reason: parsed.reasoning || `reward_model value=${value.toFixed(3)}`,
+        metadata: { criteria: parsed.criteria ?? { value } },
+      };
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return zero(`reward_model error: ${msg.slice(0, 200)}`);
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+}
+
+function clamp01(n: number): number {
+  if (!Number.isFinite(n)) return 0;
+  return Math.max(0, Math.min(1, n));
+}
+
+function zero(reason: string): Score {
+  return { pass: false, value: 0, reason, metadata: { criteria: { value: 0 } } };
+}

--- a/packages/eval-core/src/verifier/builtins/script.ts
+++ b/packages/eval-core/src/verifier/builtins/script.ts
@@ -1,0 +1,57 @@
+// Script Verifier — runs a bash script in the agent's sandbox via /exec
+// and translates the exit code to a Score.
+//
+// This is the single most common Verifier shape in production today
+// (every terminal-bench task uses it: pytest the agent's output, exit 0
+// = pass). Replaces the inline /exec logic that previously lived inline
+// in eval-runner / rl-rollout / TB run-cloud — same wire format, single
+// implementation.
+
+import type { Trajectory } from "../../trajectory/types.js";
+import type { Score } from "../../scorers/types.js";
+import type { Verifier, VerifierContext, ScriptRewardSpec } from "../types.js";
+
+const DEFAULT_TIMEOUT_MS = 10 * 60 * 1000; // 10 min — matches existing TB call-sites
+
+export class ScriptVerifier implements Verifier {
+  readonly id = "script.v1";
+
+  constructor(
+    private readonly spec: ScriptRewardSpec,
+    private readonly ctx: VerifierContext,
+  ) {}
+
+  async check(_traj: Trajectory): Promise<Score> {
+    const timeout = this.spec.timeout_ms ?? DEFAULT_TIMEOUT_MS;
+    let exitCode = -1;
+    let output = "";
+    try {
+      const res = await this.ctx.runExec(this.spec.verify_script, { timeoutMs: timeout });
+      exitCode = res.exit_code;
+      output = res.output ?? "";
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return {
+        pass: false,
+        value: 0,
+        reason: `script verifier failed before running: ${msg.slice(0, 200)}`,
+        metadata: { exit_code: -1, output: "", error: msg },
+      };
+    }
+
+    const pass = exitCode === 0;
+    return {
+      pass,
+      value: pass ? 1 : 0,
+      reason: pass
+        ? `verify_script exited 0`
+        : `verify_script exited ${exitCode}`,
+      metadata: {
+        exit_code: exitCode,
+        // Truncate output — long pytest dumps would balloon the trajectory
+        // envelope on KV. Keep tail (where the failure summary usually is).
+        output: output.length > 4000 ? output.slice(-4000) : output,
+      },
+    };
+  }
+}

--- a/packages/eval-core/src/verifier/builtins/verifiable.ts
+++ b/packages/eval-core/src/verifier/builtins/verifiable.ts
@@ -1,0 +1,97 @@
+// Verifiable Verifier — wraps one of the named, pure-function Scorers
+// from packages/eval-core/src/scorers/scorers.ts as a Verifier.
+//
+// This is the bridge that activates the scorer library: existing
+// `bashExit` / `fileWritten` / `idleNoError` / `regex` / etc. become
+// referenceable from a JSON RewardSpec via:
+//
+//   { "type": "verifiable", "scorer": "bashExit", "opts": { "expectedCode": 0 } }
+//
+// SCORER_REGISTRY is the only piece that knows about each scorer's
+// constructor signature — keeps scorers.ts unchanged (they remain
+// pure higher-order functions) and gives JSON callers a typed entry
+// point. Adding a new scorer = appending to SCORER_REGISTRY.
+
+import type { Trajectory } from "../../trajectory/types.js";
+import type { Score, Scorer } from "../../scorers/types.js";
+import type { Verifier, VerifierContext, VerifiableRewardSpec } from "../types.js";
+import {
+  agentMessageContains,
+  bashExit,
+  bashOutputMarker,
+  bashSuccess,
+  fileWritten,
+  gaiaMatch,
+  idleNoError,
+  includes,
+  regex,
+  threadCreated,
+  toolNotUsed,
+  toolUsed,
+} from "../../scorers/scorers.js";
+
+type ScorerFactory = (opts: Record<string, unknown>) => Scorer;
+
+/**
+ * Mapping table: scorer name (used in JSON RewardSpec.scorer) →
+ * factory that adapts `opts` into the existing scorer signature.
+ *
+ * Entries here cover the 11 production scorers shipped today. New
+ * additions: keep the entry minimal (just unwrap `opts.<arg>`); the
+ * scorer factory in scorers.ts stays the source of truth.
+ */
+export const SCORER_REGISTRY: Record<string, ScorerFactory> = {
+  includes: (opts) =>
+    includes(String(opts.target ?? ""), { caseInsensitive: opts.caseInsensitive !== false }),
+
+  regex: (opts) => {
+    const pattern = opts.pattern;
+    const flags = typeof opts.flags === "string" ? opts.flags : "";
+    if (pattern instanceof RegExp) return regex(pattern);
+    return regex(new RegExp(String(pattern ?? ""), flags));
+  },
+
+  toolUsed: (opts) => toolUsed(String(opts.name ?? "")),
+  toolNotUsed: (opts) => toolNotUsed(String(opts.name ?? "")),
+
+  bashExit: (opts) => {
+    const expectedCode = typeof opts.expectedCode === "number" ? opts.expectedCode : 0;
+    return bashExit(expectedCode);
+  },
+  bashSuccess: () => bashSuccess(),
+  bashOutputMarker: (opts) => bashOutputMarker(String(opts.marker ?? "")),
+
+  fileWritten: (opts) => fileWritten(String(opts.filePath ?? opts.path ?? "")),
+
+  idleNoError: () => idleNoError(),
+
+  agentMessageContains: (opts) =>
+    agentMessageContains(String(opts.target ?? ""), {
+      caseInsensitive: opts.caseInsensitive !== false,
+    }),
+
+  threadCreated: (opts) =>
+    threadCreated(typeof opts.minCount === "number" ? opts.minCount : 1),
+
+  gaiaMatch: (opts) => gaiaMatch(String(opts.expected ?? "")),
+};
+
+export class VerifiableVerifier implements Verifier {
+  readonly id: string;
+  private readonly scorer: Scorer;
+
+  constructor(spec: VerifiableRewardSpec, _ctx: VerifierContext) {
+    const factory = SCORER_REGISTRY[spec.scorer];
+    if (!factory) {
+      throw new Error(
+        `verifiable: unknown scorer "${spec.scorer}" — known: ${Object.keys(SCORER_REGISTRY).join(", ")}`,
+      );
+    }
+    this.id = `verifiable.${spec.scorer}.v1`;
+    this.scorer = factory(spec.opts ?? {});
+  }
+
+  async check(traj: Trajectory): Promise<Score> {
+    return Promise.resolve(this.scorer(traj));
+  }
+}

--- a/packages/eval-core/src/verifier/index.ts
+++ b/packages/eval-core/src/verifier/index.ts
@@ -1,0 +1,9 @@
+// Verifier subsystem barrel — see types.ts for design notes.
+
+export * from "./types";
+export * from "./registry";
+export { ScriptVerifier } from "./builtins/script";
+export { CompositeVerifier } from "./builtins/composite";
+export { VerifiableVerifier, SCORER_REGISTRY } from "./builtins/verifiable";
+export { RewardModelVerifier } from "./builtins/reward_model";
+export { NoRunVerifier } from "./builtins/no_run";

--- a/packages/eval-core/src/verifier/index.ts
+++ b/packages/eval-core/src/verifier/index.ts
@@ -7,3 +7,10 @@ export { CompositeVerifier } from "./builtins/composite";
 export { VerifiableVerifier, SCORER_REGISTRY } from "./builtins/verifiable";
 export { RewardModelVerifier } from "./builtins/reward_model";
 export { NoRunVerifier } from "./builtins/no_run";
+export {
+  LlmJudgeVerifier,
+  createLlmJudgeVerifier,
+  type JudgeFn,
+  type JudgeUsage,
+  type LlmJudgeOpts,
+} from "./builtins/llm_judge";

--- a/packages/eval-core/src/verifier/registry.ts
+++ b/packages/eval-core/src/verifier/registry.ts
@@ -1,0 +1,30 @@
+// verifierForSpec: maps a RewardSpec to a concrete Verifier instance.
+//
+// One factory function so all consumers (eval-runner, rl-rollout, the
+// supervisor outcome loop, future Console "Re-grade" button) reach the
+// same implementations from a single dispatch point. Adding a new
+// RewardSpec branch lands here only.
+
+import type { Verifier, VerifierContext, RewardSpec } from "./types.js";
+import { ScriptVerifier } from "./builtins/script.js";
+import { CompositeVerifier } from "./builtins/composite.js";
+import { VerifiableVerifier } from "./builtins/verifiable.js";
+import { RewardModelVerifier } from "./builtins/reward_model.js";
+
+export function verifierForSpec(spec: RewardSpec, ctx: VerifierContext): Verifier {
+  switch (spec.type) {
+    case "script":
+      return new ScriptVerifier(spec, ctx);
+    case "composite":
+      return new CompositeVerifier(spec, ctx);
+    case "verifiable":
+      return new VerifiableVerifier(spec, ctx);
+    case "reward_model":
+      return new RewardModelVerifier(spec, ctx);
+    default: {
+      // exhaustiveness check — every RewardSpec branch must be handled
+      const _exhaustive: never = spec;
+      throw new Error(`unknown RewardSpec type: ${JSON.stringify(_exhaustive)}`);
+    }
+  }
+}

--- a/packages/eval-core/src/verifier/types.ts
+++ b/packages/eval-core/src/verifier/types.ts
@@ -1,0 +1,116 @@
+// OMA Verifier framework — Phase 2 of the Trajectory v1 unification plan.
+//
+// Replaces the three parallel verification paths that grew up independently:
+//   - eval-runner: ad-hoc /exec verify_script + exit_code
+//   - outcome-evaluator: standalone LLM judge
+//   - rl/verifier: turn-based heuristic checks
+//
+// Now: one Verifier interface, three consumers (eval / outcome / RL), one
+// canonical RewardSpec wire format. Trajectory.reward.verifier_id records
+// which Verifier produced a given reward, so a session can be re-graded
+// with a different one without re-executing.
+//
+// Design rule (per docs/handoff-verifier-framework.md):
+//   Task + Agent execution + Verifier → Score
+//     Outcome: score → needs_revision/satisfied (supervisor loop)
+//     Eval:    score → pass/fail (quality report)
+//     RL:      score → reward signal (training)
+
+import type { Trajectory } from "../trajectory/types.js";
+import type { Score } from "../scorers/types.js";
+
+/** Sandbox + session handle the script Verifier needs to run a verify
+ *  command. Ignored by Verifiers that don't touch the sandbox. */
+export interface VerifierContext {
+  /** Session whose sandbox the verifier should use. */
+  sessionId: string;
+  /**
+   * Run a shell command in the session's sandbox via /exec. Returns the
+   * exit code and combined stdout+stderr. Wall-clock timeout is the
+   * caller's responsibility — implementations should pass through
+   * `timeoutMs` when supplied.
+   */
+  runExec(cmd: string, opts?: { timeoutMs?: number }): Promise<{ exit_code: number; output: string }>;
+}
+
+/**
+ * One verifier — produces a Score from a Trajectory.
+ *
+ * Two modes:
+ *   - check(traj): deterministic inspection (script exit, file existence,
+ *     tool-use pattern match, …). Always available.
+ *   - judge(traj, rubric): LLM-based qualitative assessment. Optional;
+ *     consumers must fall back to check() when undefined.
+ */
+export interface Verifier {
+  /** Stable id used as `RewardResult.verifier_id` and for logging. */
+  readonly id: string;
+  /** Deterministic check — pure inspection of the trajectory. */
+  check(traj: Trajectory): Promise<Score>;
+  /**
+   * Optional LLM-judge variant when the task ships a rubric. Verifiers
+   * that don't have a judge mode should leave this undefined; consumers
+   * fall back to `check`.
+   */
+  judge?(traj: Trajectory, rubric: string): Promise<Score>;
+}
+
+/**
+ * Reward spec shapes that ship today. Verifier registry maps each to
+ * a concrete implementation. Keeps the existing JSON wire format
+ * (`type: "verifiable" | "script" | "reward_model" | "composite"`)
+ * intact so old task JSONs keep working.
+ *
+ * `weights` is consumer-defined metadata — composite uses per-component
+ * weight (see ScriptRewardSpec); leaf shapes carry it for forward-compat
+ * with future aggregators (e.g. multi-criterion scorers).
+ */
+export type RewardSpec =
+  | ScriptRewardSpec
+  | RewardModelRewardSpec
+  | CompositeRewardSpec
+  | VerifiableRewardSpec;
+
+export interface ScriptRewardSpec {
+  type: "script";
+  /** Bash script to run in the agent's sandbox. exit 0 = pass. */
+  verify_script: string;
+  /** Optional: per-component weights (currently informational). */
+  weights?: Record<string, number>;
+  /** Optional per-script wall-clock timeout in ms. Default at the runner. */
+  timeout_ms?: number;
+}
+
+export interface RewardModelRewardSpec {
+  type: "reward_model";
+  /** External HTTP endpoint the trajectory + rubric are POSTed to. */
+  endpoint: string;
+  /** Optional rubric / prompt template the endpoint will use. */
+  prompt_template?: string;
+  weights?: Record<string, number>;
+}
+
+export interface CompositeRewardSpec {
+  type: "composite";
+  components: Array<{
+    /** Sub-Verifier RewardSpec. */
+    verifier: RewardSpec;
+    /** Weight applied to this sub-Verifier's `score.value` during aggregation. */
+    weight: number;
+    /** Human-readable name used as the criteria key. */
+    name: string;
+  }>;
+}
+
+export interface VerifiableRewardSpec {
+  type: "verifiable";
+  /**
+   * Name of a registered Scorer (eval-core/src/scorers/scorers.ts —
+   * `bashExit`, `fileWritten`, `idleNoError`, `regex`, …). Resolved by
+   * the verifiable builtin's mapping table.
+   */
+  scorer: string;
+  /** Constructor opts forwarded to the named scorer factory. */
+  opts?: Record<string, unknown>;
+  weights?: Record<string, number>;
+}

--- a/packages/eval-core/tests/verifier.test.ts
+++ b/packages/eval-core/tests/verifier.test.ts
@@ -1,0 +1,234 @@
+// Phase 2 acceptance test for the Verifier framework.
+//
+// Goal: prove that verifierForSpec correctly resolves each RewardSpec
+// branch and that the verifiable builtin's SCORER_REGISTRY actually
+// reaches the named scorer factory in scorers.ts. Anything more
+// elaborate (live /exec, real reward_model HTTP) is integration.
+
+// @ts-nocheck
+import { describe, it, expect } from "vitest";
+import {
+  verifierForSpec,
+  SCORER_REGISTRY,
+  ScriptVerifier,
+  CompositeVerifier,
+  VerifiableVerifier,
+  RewardModelVerifier,
+  NoRunVerifier,
+} from "@open-managed-agents/eval-core";
+import type { Trajectory } from "@open-managed-agents/eval-core";
+
+function ev(seq: number, type: string, data: object = {}) {
+  return { seq, type, data: JSON.stringify({ type, ...data }), ts: "2026-04-17T10:00:00Z" };
+}
+
+function makeTrajectory(events: any[]): Trajectory {
+  return {
+    schema_version: "oma.trajectory.v1",
+    trajectory_id: "tr-1",
+    session_id: "sess-1",
+    agent_config: {} as any,
+    environment_config: {} as any,
+    model: { id: "test-model", provider: "" },
+    started_at: "2026-04-17T10:00:00Z",
+    outcome: "success",
+    events,
+    summary: {} as any,
+  };
+}
+
+const dummyCtx = {
+  sessionId: "sess-1",
+  runExec: async () => ({ exit_code: 0, output: "" }),
+};
+
+describe("verifierForSpec dispatch", () => {
+  it("resolves type:'script' to ScriptVerifier", () => {
+    const v = verifierForSpec({ type: "script", verify_script: "true" }, dummyCtx);
+    expect(v).toBeInstanceOf(ScriptVerifier);
+    expect(v.id).toBe("script.v1");
+  });
+
+  it("resolves type:'composite' to CompositeVerifier", () => {
+    const v = verifierForSpec(
+      {
+        type: "composite",
+        components: [
+          { name: "a", weight: 1, verifier: { type: "script", verify_script: "true" } },
+        ],
+      },
+      dummyCtx,
+    );
+    expect(v).toBeInstanceOf(CompositeVerifier);
+    expect(v.id).toBe("composite.v1");
+  });
+
+  it("resolves type:'verifiable' to VerifiableVerifier with the named scorer", () => {
+    const v = verifierForSpec(
+      { type: "verifiable", scorer: "bashExit", opts: { expectedCode: 0 } },
+      dummyCtx,
+    );
+    expect(v).toBeInstanceOf(VerifiableVerifier);
+    expect(v.id).toBe("verifiable.bashExit.v1");
+  });
+
+  it("resolves type:'reward_model' to RewardModelVerifier", () => {
+    const v = verifierForSpec(
+      { type: "reward_model", endpoint: "https://example.test/score" },
+      dummyCtx,
+    );
+    expect(v).toBeInstanceOf(RewardModelVerifier);
+    expect(v.id).toBe("reward_model.v1");
+  });
+
+  it("rejects an unknown scorer name with the registry's known list", () => {
+    expect(() =>
+      verifierForSpec({ type: "verifiable", scorer: "doesNotExist" }, dummyCtx),
+    ).toThrow(/unknown scorer "doesNotExist"/);
+  });
+});
+
+describe("VerifiableVerifier (the bashExit registry path)", () => {
+  it("returns pass when the last bash tool call exited 0", async () => {
+    const traj = makeTrajectory([
+      ev(1, "user.message", { content: [{ type: "text", text: "ls" }] }),
+      ev(2, "agent.tool_use", { id: "tu1", name: "bash", input: { command: "ls" } }),
+      ev(3, "agent.tool_result", { tool_use_id: "tu1", content: "file1\nfile2\nexit=0" }),
+      ev(4, "session.status_idle"),
+    ]);
+    const v = verifierForSpec(
+      { type: "verifiable", scorer: "bashExit", opts: { expectedCode: 0 } },
+      dummyCtx,
+    );
+    const score = await v.check(traj);
+    expect(score.pass).toBe(true);
+    expect(score.value).toBe(1);
+  });
+
+  it("returns fail when the last bash tool call exited non-zero", async () => {
+    const traj = makeTrajectory([
+      ev(1, "user.message", { content: [{ type: "text", text: "false" }] }),
+      ev(2, "agent.tool_use", { id: "tu1", name: "bash", input: { command: "false" } }),
+      ev(3, "agent.tool_result", { tool_use_id: "tu1", content: "exit=1" }),
+      ev(4, "session.status_idle"),
+    ]);
+    const v = verifierForSpec(
+      { type: "verifiable", scorer: "bashExit", opts: { expectedCode: 0 } },
+      dummyCtx,
+    );
+    const score = await v.check(traj);
+    expect(score.pass).toBe(false);
+    expect(score.value).toBe(0);
+  });
+
+  it("registry exposes all 11 production scorers", () => {
+    // Lock the registry surface so adding a scorer to scorers.ts and
+    // forgetting to wire it through the JSON RewardSpec layer fails fast.
+    expect(Object.keys(SCORER_REGISTRY).sort()).toEqual([
+      "agentMessageContains",
+      "bashExit",
+      "bashOutputMarker",
+      "bashSuccess",
+      "fileWritten",
+      "gaiaMatch",
+      "idleNoError",
+      "includes",
+      "regex",
+      "threadCreated",
+      "toolNotUsed",
+      "toolUsed",
+    ]);
+  });
+});
+
+describe("ScriptVerifier", () => {
+  it("returns pass when ctx.runExec exits 0", async () => {
+    const ctx = {
+      sessionId: "sess-1",
+      runExec: async () => ({ exit_code: 0, output: "all tests passed" }),
+    };
+    const v = verifierForSpec({ type: "script", verify_script: "pytest" }, ctx);
+    const score = await v.check({} as any);
+    expect(score.pass).toBe(true);
+    expect(score.value).toBe(1);
+    expect((score.metadata as any).exit_code).toBe(0);
+  });
+
+  it("returns fail when ctx.runExec exits non-zero, surfaces output tail", async () => {
+    const longOutput = "a".repeat(5000) + "FAIL line";
+    const ctx = {
+      sessionId: "sess-1",
+      runExec: async () => ({ exit_code: 1, output: longOutput }),
+    };
+    const v = verifierForSpec({ type: "script", verify_script: "pytest" }, ctx);
+    const score = await v.check({} as any);
+    expect(score.pass).toBe(false);
+    expect(score.value).toBe(0);
+    expect((score.metadata as any).exit_code).toBe(1);
+    // Truncated to 4000 chars (tail kept where pytest summary lives)
+    expect((score.metadata as any).output.length).toBe(4000);
+    expect((score.metadata as any).output.endsWith("FAIL line")).toBe(true);
+  });
+
+  it("returns fail with reason on runExec throw", async () => {
+    const ctx = {
+      sessionId: "sess-1",
+      runExec: async () => {
+        throw new Error("network unreachable");
+      },
+    };
+    const v = verifierForSpec({ type: "script", verify_script: "pytest" }, ctx);
+    const score = await v.check({} as any);
+    expect(score.pass).toBe(false);
+    expect(score.value).toBe(0);
+    expect(score.reason).toMatch(/network unreachable/);
+  });
+});
+
+describe("CompositeVerifier", () => {
+  it("aggregates child scores by weighted average", async () => {
+    let callCount = 0;
+    const ctx = {
+      sessionId: "sess-1",
+      // Two script children — first passes (1.0), second fails (0.0)
+      runExec: async () => {
+        callCount++;
+        return { exit_code: callCount === 1 ? 0 : 1, output: "" };
+      },
+    };
+    const v = verifierForSpec(
+      {
+        type: "composite",
+        components: [
+          { name: "tests", weight: 3, verifier: { type: "script", verify_script: "pytest" } },
+          { name: "lint", weight: 1, verifier: { type: "script", verify_script: "ruff check" } },
+        ],
+      },
+      ctx,
+    );
+    const score = await v.check({} as any);
+    // Weighted average = (3*1 + 1*0) / 4 = 0.75
+    expect(score.value).toBeCloseTo(0.75, 5);
+    // pass=false because at least one child failed
+    expect(score.pass).toBe(false);
+    expect((score.metadata as any).criteria).toEqual({ tests: 1, lint: 0 });
+  });
+
+  it("returns 0 with empty components array", async () => {
+    const v = verifierForSpec({ type: "composite", components: [] }, dummyCtx);
+    const score = await v.check({} as any);
+    expect(score.value).toBe(0);
+    expect(score.pass).toBe(false);
+  });
+});
+
+describe("NoRunVerifier", () => {
+  it("always returns 0 with stable verifier_id", async () => {
+    const v = new NoRunVerifier("setup_files write failed");
+    const score = await v.check({} as any);
+    expect(v.id).toBe("no-run.v1");
+    expect(score.pass).toBe(false);
+    expect(score.value).toBe(0);
+    expect(score.reason).toMatch(/no-run: setup_files write failed/);
+  });
+});

--- a/packages/shared/src/id.ts
+++ b/packages/shared/src/id.ts
@@ -17,3 +17,8 @@ export const generateResourceId = () => `sesrsc-${nanoid()}`;
 export const generateEventId = () => `sevt-${nanoid()}`;
 export const generateModelCardId = () => `mdl-${nanoid()}`;
 export const generateEvalRunId = () => `evrun-${nanoid()}`;
+// Outcome id — Anthropic Managed Agents spec uses an `outc_` prefix on every
+// `user.define_outcome` echo so subsequent `span.outcome_evaluation_*`
+// events can name which outcome they pertain to (sessions can chain
+// outcomes sequentially; same session, different outcome ids).
+export const generateOutcomeId = () => `outc_${nanoid()}`;

--- a/rl/collector.ts
+++ b/rl/collector.ts
@@ -45,7 +45,10 @@ interface CollectorConfig {
 
 function rewardFromFeedback(events: SSEEvent[]): RewardResult | null {
   const outcomeEvents = events.filter(
-    (e) => e.type === "session.outcome_evaluated" || e.type === "outcome.evaluation_end",
+    (e) =>
+      e.type === "session.outcome_evaluated" ||
+      e.type === "outcome.evaluation_end" ||
+      e.type === "span.outcome_evaluation_end",
   );
   if (outcomeEvents.length === 0) return null;
 

--- a/rl/rollout.ts
+++ b/rl/rollout.ts
@@ -1,12 +1,13 @@
 import type { RLTask, RLTaskSet, RolloutConfig, RolloutResult, Trajectory, TokenUsage } from "./types.js";
 import { eventsToTrajectory } from "./trajectory.js";
 import { computeReward, batchRewardStats } from "./reward.js";
-import { runScriptVerifier } from "./verifier.js";
+import { verifierForSpec, type VerifierContext } from "../packages/eval-core/src/index.js";
 import {
   createAgent,
   createSession,
   deleteAgent,
   deleteSession,
+  execInSandbox,
   sendAndWait,
   setupFiles,
   getOrCreateEnvironment,
@@ -17,6 +18,22 @@ const DEFAULT_TOOLS = [
 ];
 
 const DEFAULT_SYSTEM = "You are a helpful assistant. Complete tasks precisely and efficiently.";
+
+/**
+ * Build a VerifierContext for the given session that runs verify_scripts
+ * directly in the sandbox via /exec. Replaces the prior runScriptVerifier
+ * approach (which sent a follow-up message asking the model to run the
+ * script and emit `EXIT_CODE=N`) — that flow consumed model tokens, was
+ * non-deterministic (model could refuse / paraphrase), and had no
+ * timeout discipline. The Verifier framework's ScriptVerifier uses this
+ * ctx.runExec to talk to the sandbox directly.
+ */
+function buildVerifierContext(sessionId: string): VerifierContext {
+  return {
+    sessionId,
+    runExec: (cmd, opts) => execInSandbox(sessionId, cmd, opts?.timeoutMs ?? 600_000),
+  };
+}
 
 class SessionPool {
   private available: Array<{ sessionId: string; agentId: string }> = [];
@@ -93,13 +110,21 @@ async function executeTask(
 
     if (task.reward.type === "script" && task.reward.verify_script) {
       try {
-        const vr = await runScriptVerifier(
-          sendAndWait,
-          handle.sessionId,
-          task.reward.verify_script,
-          600_000,
+        // Phase 2 unification: route through ScriptVerifier (single
+        // verify_script implementation across eval-runner + RL rollout).
+        // Pass an empty Trajectory placeholder — ScriptVerifier doesn't
+        // inspect it, only runs the script and grades by exit code.
+        const ctx = buildVerifierContext(handle.sessionId);
+        const verifier = verifierForSpec(
+          { type: "script", verify_script: task.reward.verify_script },
+          ctx,
         );
-        trajectory.metadata.verifier_result = vr;
+        const score = await verifier.check({} as never);
+        const meta = score.metadata as { exit_code?: number; output?: string } | undefined;
+        trajectory.metadata.verifier_result = {
+          exit_code: typeof meta?.exit_code === "number" ? meta.exit_code : score.pass ? 0 : -1,
+          output: typeof meta?.output === "string" ? meta.output : "",
+        };
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         trajectory.metadata.verifier_result = { exit_code: -1, output: `verifier_error: ${msg}` };

--- a/rl/verifier.ts
+++ b/rl/verifier.ts
@@ -69,6 +69,13 @@ function checkSandboxExec(_trajectory: Trajectory, _check: VerifyCheck): number 
 // --- Script verifier (run a verify_script in the sandbox via a follow-up turn) ---
 
 /**
+ * @deprecated Phase 2 (trajectory-v1) replaced this with the canonical
+ * `ScriptVerifier` from `@open-managed-agents/eval-core`, which executes
+ * `verify_script` directly in the sandbox via the `/exec` endpoint
+ * (deterministic, no model token cost, hard timeout). Kept exported only
+ * to avoid breaking external imports during the deprecation window;
+ * remove once no consumer imports it (Phase 4 cleanup).
+ *
  * Run a verify_script in the agent's sandbox by sending a follow-up message,
  * then parse the agent's reply for `EXIT_CODE=<n>`. Used for `RewardSpec.type
  * === "script"` tasks (e.g. terminal-bench pytest tests).

--- a/test/eval/client.ts
+++ b/test/eval/client.ts
@@ -375,6 +375,40 @@ export interface CleanupHandle {
   sessionIds: string[];
 }
 
+/**
+ * Run a raw shell command in this session's sandbox via /v1/sessions/:id/exec.
+ * Bypasses the agent — used by RL rollout's verify_script flow so the model
+ * doesn't have to re-execute deterministic infra.
+ *
+ * Mirrors the eval-runner-side helper in apps/main/src/eval-runner.ts —
+ * keeps a single sandbox-exec call shape across both runners.
+ */
+export async function execInSandbox(
+  sessionId: string,
+  command: string,
+  timeoutMs: number = 600_000,
+): Promise<{ exit_code: number; output: string }> {
+  const url = `${API_URL}/v1/sessions/${sessionId}/exec`;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs + 5_000); // extra slack
+  try {
+    const res = await fetch(url, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ command, timeout_ms: timeoutMs }),
+      signal: controller.signal,
+    });
+    if (!res.ok) {
+      const body = await res.text().catch(() => "");
+      return { exit_code: -1, output: `HTTP ${res.status}: ${body.slice(0, 200)}` };
+    }
+    const data = (await res.json()) as { exit_code?: number; output?: string };
+    return { exit_code: data.exit_code ?? -1, output: data.output ?? "" };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
 export async function cleanup(handle: CleanupHandle): Promise<void> {
   for (const sid of handle.sessionIds) {
     await deleteSession(sid);


### PR DESCRIPTION
> Bundles former #35 (phase2), #36 (phase3), and the original #37 (outcome-ama-align) into a single PR. Phase 1 already landed via #34.

## Summary

Closes the Trajectory v1 unification track in one shot. Previously stacked as 3 separate PRs; rebundled here per "一个 PR 原则".

## What lands

### Phase 2 — Verifier substrate (`packages/eval-core`)
- \`Verifier\` interface (\`check\` + optional \`judge\`)
- 5 built-ins: \`script\`, \`verifiable\` (11-scorer registry), \`composite\`, \`reward_model\`, \`no_run\`
- \`RewardSpec\` discriminated union
- 14-test acceptance suite (\`packages/eval-core/tests/verifier.test.ts\`)

### Phase 2 — Wire-through
- \`apps/main/src/eval-runner.ts\`: \`runVerifier()\` translates \`Score → RewardResult\`; \`synthesizeNoRunReward()\` keeps failure trials inside the framework
- \`apps/main\` outcome-evaluator → Score projection (lets supervisor consume the same shape)
- \`rl/rollout.ts\`: routes \`verify_script\` through canonical \`ScriptVerifier\`

### Phase 3 — Console visualization
- \`EvalRunDetail.tsx\`: lazy per-trial trajectory fetch on row expand; renders \`final_reward\`, \`verifier_id\`, \`raw_rewards\` breakdown
- \`SessionDetail.tsx\`: outcome chip + reward chip in header, "View Trajectory" modal (pretty JSON + Download)

### Phase 4 — Outcome ↔ AMA alignment + rule-based superset
- AMA event shapes: \`outcome_id\`, \`rubric: { type: "text" | "file" }\`, 5-result enum (\`pass | fail | failed | interrupted\`), \`usage\` field, 0-indexed iteration, \`outcome_evaluations[]\` aggregate on \`GET /v1/sessions/:id\`
- File rubric resolver (\`apps/agent/src/runtime/resolve-rubric.ts\`) — fetches \`rubric.file_id\` from \`FILES_BUCKET\` R2, caches into \`state.outcome.rubric_content\`
- Sequential outcomes: chain \`user.define_outcome\` after a terminal verdict
- OMA superset: \`verifier?: RewardSpec\` on \`user.define_outcome\` — when present, deterministic verifier path bypasses LLM judge entirely
- \`LlmJudgeVerifier\` (in-process \`LanguageModel\`-backed) so the supervisor uses the same Verifier interface for both judge-driven and rule-based paths
- \`outcome-supervisor.ts\` rewritten: single \`Verifier.check(traj) → Score → 5-result\` loop replaces inline \`evaluateOutcome\`; 9-test suite (\`apps/agent/tests/outcome-supervisor.test.ts\`)

## Compatibility

Additive on the wire — old \`outcome.description\` payloads still parse via back-compat (mapped to \`rubric.text\`). Old sessions render normally.

## Verification

- ✅ \`tsc --noEmit\` clean for \`apps/agent\` and \`apps/main\`
- ✅ Phase 2 verifier suite: 14/14 green
- ✅ Phase 4 supervisor suite: 9/9 green
- ⚠️  Pre-existing failures in \`test/unit/{unit,core,outbound-extended,tools-execution,workspace-backups,environment-images-*}.test.ts\` are inherited from \`main\` (not regressions from this PR)
- ⚠️  No live integration test for AMA event flow through \`SessionDO\` end-to-end yet — additive shape so failure mode is "old supervisor path still runs"

🤖 Generated with [Claude Code](https://claude.com/claude-code)