### PR TITLE
chore(release): @openma/cli 0.4.0 — bridge expand + service install + recover

### DIFF
--- a/.changeset/cli-0.4.0-bridge-expand.md
+++ b/.changeset/cli-0.4.0-bridge-expand.md
@@ -1,0 +1,17 @@
+---
+"@openma/cli": minor
+---
+
+Bridge: expand local ACP agent support to the full official registry,
+add cross-platform service install (launchd / systemd / Task Scheduler,
+all no-admin), and wire end-to-end conversation recovery so daemon
+restarts no longer drop context. `oma bridge setup` is now the single
+command on every platform — installs the system service, starts the
+daemon, and audits + offers ACP wrappers for install (npm packages or
+GitHub release tarballs). Includes `OMA_PROFILE` for prod/staging
+side-by-side daemons (default behavior unchanged for current users).
+
+Fixes a multi-profile bug where the launchd-spawned daemon silently
+dropped `OMA_PROFILE` and read the default profile's credentials,
+causing the "wrong" daemon to compete for the WS attach slot.
+


### PR DESCRIPTION
## Summary

Adds the changeset for #38, bumping `@openma/cli` 0.3.2 → 0.4.0.

## Why minor

New features (cross-platform service install, ACP recover via session/load, binary wrapper downloader, profile system) without breaking changes — default profile + existing commands behave byte-identically.

## What happens after merge

CI's release workflow opens a "Version Packages" PR; merging that publishes `@openma/cli@0.4.0` to npm via OIDC trusted publisher (no NPM_TOKEN needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
