### PR TITLE
fix(cli): force-exit setup after Done. + diagnose handle leaks

### DIFF
--- a/.changeset/cli-0.4.1-setup-exit.md
+++ b/.changeset/cli-0.4.1-setup-exit.md
@@ -1,0 +1,15 @@
+---
+"@openma/cli": patch
+---
+
+`oma bridge setup` now exits cleanly after "Done." instead of hanging
+for ~5 minutes on idle keep-alive HTTP sockets from the registry CDN
+fetch and the runtime-token probe. Daemon was already started by
+launchd / systemd / Task Scheduler — only the foreground setup process
+itself was waiting on the undici dispatcher to time out its sockets.
+Force-exits at end of runSetup, matching how npm / pnpm / gh handle
+the same constraint in their CLI commands.
+
+Adds an opt-in `OMA_DEBUG_HANDLES=1` env var that prints active
+handles + requests every 2s — useful for diagnosing future "process
+won't exit" regressions without redeploying.

--- a/packages/cli/src/bridge/commands/setup.ts
+++ b/packages/cli/src/bridge/commands/setup.ts
@@ -79,6 +79,44 @@ interface SetupOpts {
 
 
 export async function runSetup(opts: SetupOpts): Promise<void> {
+  // Diagnostic: if setup completes but the process doesn't exit, dump
+  // active handles + requests every 2s so we can find what's keeping
+  // the event loop alive. Opt-in via OMA_DEBUG_HANDLES=1 to keep it
+  // out of normal users' faces.
+  if (process.env.OMA_DEBUG_HANDLES) {
+    let tick = 0;
+    const probe = setInterval(() => {
+      tick += 1;
+      const handles = (process as unknown as { _getActiveHandles: () => unknown[] })._getActiveHandles();
+      const requests = (process as unknown as { _getActiveRequests: () => unknown[] })._getActiveRequests();
+      const hsum = handles.map((h) => (h as { constructor?: { name?: string } })?.constructor?.name ?? "?").reduce<Record<string, number>>((a, k) => { a[k] = (a[k] ?? 0) + 1; return a; }, {});
+      const rsum = requests.map((r) => (r as { constructor?: { name?: string } })?.constructor?.name ?? "?").reduce<Record<string, number>>((a, k) => { a[k] = (a[k] ?? 0) + 1; return a; }, {});
+      process.stderr.write(`\n[debug t=${tick * 2}s] handles: ${JSON.stringify(hsum)} requests: ${JSON.stringify(rsum)}\n`);
+    }, 2000);
+    probe.unref(); // don't let the probe itself keep the loop alive
+  }
+
+  try {
+    await runSetupInner(opts);
+  } finally {
+    // Force-exit the short-lived setup process. Node 18+'s built-in
+    // fetch uses an internal undici dispatcher that holds keep-alive
+    // HTTP(S) sockets open for ~5min; for a CLI command we'd rather
+    // return the user's prompt immediately than wait for those to time
+    // out. Without this, OMA_DEBUG_HANDLES shows 2x Socket + 1x
+    // TLSSocket lingering after "Done." prints (loadRegistry CDN +
+    // probeRuntimeToken API + postExchange API).
+    //
+    // process.exit(0) is the conventional fix in CLI tools (npm,
+    // pnpm, gh all do something equivalent). Anything that NEEDS to
+    // survive the exit (background analytics flush, etc.) must be
+    // done before this hits — there's nothing of that shape in
+    // setup today.
+    setImmediate(() => process.exit(0));
+  }
+}
+
+async function runSetupInner(opts: SetupOpts): Promise<void> {
   const profile = currentProfile();
   const profileTag = profile ? `  [profile=${profile}]` : "";
   printBanner(`setup — register this machine with ${opts.serverUrl}${profileTag}`, PKG_VERSION);


### PR DESCRIPTION
## Summary

`oma bridge setup` was hanging ~5 minutes after printing "Done." The daemon was already running (launchd / systemd / Task Scheduler started it before the print), but the user's foreground setup process couldn't return — keep-alive HTTP sockets from Node's built-in fetch held the event loop alive until server timeout.

Includes the changeset for `@openma/cli@0.4.1` so we don't repeat last PR's "forgot the changeset" multi-PR dance.

## Diagnosis

Caught via the newly-added `OMA_DEBUG_HANDLES=1` env-var instrumentation:

```
[debug t=8s] handles: {"Socket":2,"TLSSocket":1} requests: {}
[debug t=10s] handles: {"Socket":2,"TLSSocket":1} requests: {}
... still pinging every 2s for 5 min ...
```

Three sockets came from `loadRegistry` (CDN fetch) + `probeRuntimeToken` (staging API) + `postExchange` on the slow path. Node's built-in fetch uses an internal undici dispatcher we can't easily reach from userland to close.

## Fix

`setImmediate(() => process.exit(0))` at end of `runSetup`. Same pattern npm / pnpm / gh use for short-lived fetch-fan-out CLIs.

- `--no-service` / unsupported-platform path is unaffected: it `exec`s into the daemon process and never returns from `runSetupInner`, so the finally block doesn't fire.
- `OMA_DEBUG_HANDLES=1` is left in as opt-in — useful for diagnosing future "process won't exit" regressions without shipping new instrumentation.

## Test plan

- [x] Verified locally on staging: 7s elapsed, exit 0, prompt returned cleanly. Was previously hanging until manual Ctrl-C.
- [x] `--no-service` path: confirmed daemon still runs foreground (timeout-killed at 8s, daemon was alive throughout).
- [x] Build + typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
