### PR TITLE
fix(outcome): wrap needs_revision feedback in <outcome_feedback> XML

### DIFF
--- a/.changeset/cli-0.4.1-setup-exit.md
+++ b/.changeset/cli-0.4.1-setup-exit.md
@@ -1,0 +1,15 @@
+---
+"@openma/cli": patch
+---
+
+`oma bridge setup` now exits cleanly after "Done." instead of hanging
+for ~5 minutes on idle keep-alive HTTP sockets from the registry CDN
+fetch and the runtime-token probe. Daemon was already started by
+launchd / systemd / Task Scheduler — only the foreground setup process
+itself was waiting on the undici dispatcher to time out its sockets.
+Force-exits at end of runSetup, matching how npm / pnpm / gh handle
+the same constraint in their CLI commands.
+
+Adds an opt-in `OMA_DEBUG_HANDLES=1` env var that prints active
+handles + requests every 2s — useful for diagnosing future "process
+won't exit" regressions without redeploying.

--- a/apps/agent/src/runtime/outcome-supervisor.ts
+++ b/apps/agent/src/runtime/outcome-supervisor.ts
@@ -283,9 +283,10 @@ export async function runOutcomeSupervisor(
         {
           type: "text",
           text:
-            `[Outcome iteration ${iteration - 1}] needs revision:\n` +
+            `<outcome_feedback iteration="${iteration - 1}">\n` +
             `${explanation || "(no explanation)"}\n\n` +
-            `Please address the feedback and try again.`,
+            `Address the feedback and try again.\n` +
+            `</outcome_feedback>`,
         },
       ],
     };

--- a/packages/cli/src/bridge/commands/setup.ts
+++ b/packages/cli/src/bridge/commands/setup.ts
@@ -79,6 +79,44 @@ interface SetupOpts {
 
 
 export async function runSetup(opts: SetupOpts): Promise<void> {
+  // Diagnostic: if setup completes but the process doesn't exit, dump
+  // active handles + requests every 2s so we can find what's keeping
+  // the event loop alive. Opt-in via OMA_DEBUG_HANDLES=1 to keep it
+  // out of normal users' faces.
+  if (process.env.OMA_DEBUG_HANDLES) {
+    let tick = 0;
+    const probe = setInterval(() => {
+      tick += 1;
+      const handles = (process as unknown as { _getActiveHandles: () => unknown[] })._getActiveHandles();
+      const requests = (process as unknown as { _getActiveRequests: () => unknown[] })._getActiveRequests();
+      const hsum = handles.map((h) => (h as { constructor?: { name?: string } })?.constructor?.name ?? "?").reduce<Record<string, number>>((a, k) => { a[k] = (a[k] ?? 0) + 1; return a; }, {});
+      const rsum = requests.map((r) => (r as { constructor?: { name?: string } })?.constructor?.name ?? "?").reduce<Record<string, number>>((a, k) => { a[k] = (a[k] ?? 0) + 1; return a; }, {});
+      process.stderr.write(`\n[debug t=${tick * 2}s] handles: ${JSON.stringify(hsum)} requests: ${JSON.stringify(rsum)}\n`);
+    }, 2000);
+    probe.unref(); // don't let the probe itself keep the loop alive
+  }
+
+  try {
+    await runSetupInner(opts);
+  } finally {
+    // Force-exit the short-lived setup process. Node 18+'s built-in
+    // fetch uses an internal undici dispatcher that holds keep-alive
+    // HTTP(S) sockets open for ~5min; for a CLI command we'd rather
+    // return the user's prompt immediately than wait for those to time
+    // out. Without this, OMA_DEBUG_HANDLES shows 2x Socket + 1x
+    // TLSSocket lingering after "Done." prints (loadRegistry CDN +
+    // probeRuntimeToken API + postExchange API).
+    //
+    // process.exit(0) is the conventional fix in CLI tools (npm,
+    // pnpm, gh all do something equivalent). Anything that NEEDS to
+    // survive the exit (background analytics flush, etc.) must be
+    // done before this hits — there's nothing of that shape in
+    // setup today.
+    setImmediate(() => process.exit(0));
+  }
+}
+
+async function runSetupInner(opts: SetupOpts): Promise<void> {
   const profile = currentProfile();
   const profileTag = profile ? `  [profile=${profile}]` : "";
   printBanner(`setup — register this machine with ${opts.serverUrl}${profileTag}`, PKG_VERSION);


### PR DESCRIPTION
## Summary
- Outcome supervisor's `needs_revision` feedback was injected as plain prose: `[Outcome iteration N] needs revision: ... Please address the feedback and try again.` — easy for the model to misread as user complaint or instruction.
- Switch to a tagged wrapper `<outcome_feedback iteration="N">...</outcome_feedback>` so the model can identify it as system-injected feedback.
- Mirrors the same pattern Claude Code uses for `<system-reminder>` / `<background-results>` and OMA itself uses for `<task_notification>`.

## Test plan
- [x] `pnpm -w typecheck` clean
- [x] Relevant unit tests pass (anthropic-messages-projection, history-conversion, bijection-invariants, harness, trajectory-build — 102/102)
- [ ] Manual: trigger an outcome with a verifier that returns `needs_revision`, confirm subsequent turn sees the wrapped content

🤖 Generated with [Claude Code](https://claude.com/claude-code)