### PR TITLE
refactor(model-cards): split handle from wire model + simpler agent picker

### DIFF
--- a/apps/agent/src/runtime/session-do.ts
+++ b/apps/agent/src/runtime/session-do.ts
@@ -2377,20 +2377,26 @@ export class SessionDO extends DurableObject<Env> {
   }
 
   /**
-   * Resolve credentials for a model identifier (with optional explicit card).
+   * Resolve credentials and the wire-level model string for an agent's
+   * `model` value (which is a card.model_id handle, not the LLM API model).
    *
    * Lookup order:
-   *   1. Explicit `cardId` → KV `modelcard:<id>` + `modelcard:<id>:key`
-   *   2. Card whose `model_id` matches the requested model
+   *   1. Explicit `cardId` → `services.modelCards.get`
+   *   2. Card whose `model_id` (handle) matches the requested handle
    *   3. Env-var fallback (ANTHROPIC_API_KEY + ANTHROPIC_BASE_URL)
    *
-   * Used for both the agent's primary model and aux_model resolution
-   * (web_fetch summarization, future tool internals).
+   * Returns:
+   *   - `model` — the LLM string to send to the provider. card.model when a
+   *     card is found; otherwise the input handle (env-only path assumes
+   *     the user wrote a real LLM model name in agent.model).
+   *   - `apiKey`, `baseURL`, `apiCompat`, `customHeaders`, `cardId` — same
+   *     as before, source-of-truth depends on whether a card was matched.
    */
   private async resolveModelCardCredentials(
-    modelId: string,
+    handle: string,
     cardId?: string,
   ): Promise<{
+    model: string;
     apiKey: string;
     baseURL?: string;
     apiCompat: ApiCompat;
@@ -2402,6 +2408,7 @@ export class SessionDO extends DurableObject<Env> {
     let provider: string | undefined;
     let customHeaders: Record<string, string> | undefined;
     let resolvedCardId: string | undefined;
+    let wireModel = handle;
 
     if (this.env.AUTH_DB) {
       try {
@@ -2409,16 +2416,17 @@ export class SessionDO extends DurableObject<Env> {
         const tenantId = this.state.tenant_id;
         let card = cardId
           ? await services.modelCards.get({ tenantId, cardId })
-          : await services.modelCards.findByModelId({ tenantId, modelId });
+          : await services.modelCards.findByModelId({ tenantId, modelId: handle });
         if (card && !card.archived_at) {
           const key = await services.modelCards.getApiKey({ tenantId, cardId: card.id });
           if (key) {
             apiKey = key;
             provider = card.provider;
+            wireModel = card.model;
             if (card.base_url) baseURL = card.base_url;
             if (card.custom_headers) customHeaders = card.custom_headers;
             resolvedCardId = card.id;
-            console.log(`[model-card] resolved from D1: id=${card.id} model_id=${card.model_id} baseURL=${card.base_url ?? "(default)"} provider=${card.provider}`);
+            console.log(`[model-card] resolved from D1: id=${card.id} model_id=${card.model_id} model=${card.model} baseURL=${card.base_url ?? "(default)"} provider=${card.provider}`);
           }
         }
       } catch (err) {
@@ -2433,7 +2441,7 @@ export class SessionDO extends DurableObject<Env> {
       apiCompat = provider as ApiCompat;
     }
 
-    return { apiKey, baseURL, apiCompat, customHeaders, cardId: resolvedCardId };
+    return { model: wireModel, apiKey, baseURL, apiCompat, customHeaders, cardId: resolvedCardId };
   }
 
   /**
@@ -2447,10 +2455,10 @@ export class SessionDO extends DurableObject<Env> {
     modelInfo: { model_card_id?: string; model_id: string };
   } | null> {
     if (!agent.aux_model) return null;
-    const modelId = typeof agent.aux_model === "string" ? agent.aux_model : agent.aux_model.id;
-    const creds = await this.resolveModelCardCredentials(modelId, agent.aux_model_card_id);
-    const model = resolveModel(modelId, creds.apiKey, creds.baseURL, creds.apiCompat, creds.customHeaders);
-    return { model, modelInfo: { model_card_id: creds.cardId, model_id: modelId } };
+    const handle = typeof agent.aux_model === "string" ? agent.aux_model : agent.aux_model.id;
+    const creds = await this.resolveModelCardCredentials(handle, agent.aux_model_card_id);
+    const model = resolveModel(creds.model, creds.apiKey, creds.baseURL, creds.apiCompat, creds.customHeaders);
+    return { model, modelInfo: { model_card_id: creds.cardId, model_id: handle } };
   }
 
   /**
@@ -3033,11 +3041,12 @@ export class SessionDO extends DurableObject<Env> {
       memoryStoreService = (await getCfServicesForTenant(this.env, this.state.tenant_id)).memory;
     }
 
-    // Resolve model — look up model card credentials, fall back to env vars
-    const modelId = typeof agent.model === "string" ? agent.model : agent.model?.id;
-    const effectiveModelId = modelId || this.env.ANTHROPIC_MODEL || "claude-sonnet-4-6";
-    const creds = await this.resolveModelCardCredentials(effectiveModelId, agent.model_card_id);
-    const model = resolveModel(effectiveModelId, creds.apiKey, creds.baseURL, creds.apiCompat, creds.customHeaders);
+    // Resolve model — `agent.model` is a card.model_id handle. The card
+    // contains the wire-level LLM string we actually send to the provider.
+    const handle = typeof agent.model === "string" ? agent.model : agent.model?.id;
+    const effectiveHandle = handle || this.env.ANTHROPIC_MODEL || "claude-sonnet-4-6";
+    const creds = await this.resolveModelCardCredentials(effectiveHandle, agent.model_card_id);
+    const model = resolveModel(creds.model, creds.apiKey, creds.baseURL, creds.apiCompat, creds.customHeaders);
 
     // Build system prompt: agent.system + platform guidance (auth + loop-stop).
     // Skill / memory_store / appendable_prompt content is NOT appended here —

--- a/apps/console/src/pages/AgentsList.tsx
+++ b/apps/console/src/pages/AgentsList.tsx
@@ -111,6 +111,21 @@ export function AgentsList() {
 
   useEffect(() => { loadAux(); }, []);
 
+  // Pre-select default model card when entering the form step. (tenant_id,
+  // model_id) is UNIQUE in DB, so picking a card uniquely determines the
+  // model. Skip if user/paste already set model_card_id or model. Re-runs
+  // when modelCards arrives if the dialog opened before the aux fetch.
+  useEffect(() => {
+    if (createStep !== "form") return;
+    if (form.modelCardId || form.model) return;
+    if (modelCards.length === 0) return;
+    const def = modelCards.find((mc) => mc.is_default) ?? modelCards[0];
+    setForm((f) => ({ ...f, modelCardId: def.id, model: def.model_id }));
+    // Intentionally not depending on form.* — guards above prevent the
+    // re-trigger loop and we only want to hydrate on step entry / cards arrival.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [createStep, modelCards.length]);
+
   // Keep refresh hook reachable for create / archive callbacks.
   void refreshAgents;
 
@@ -296,6 +311,14 @@ export function AgentsList() {
   const inputCls = "w-full border border-border rounded-md px-3 py-2 text-sm bg-bg text-fg outline-none focus:border-brand transition-colors placeholder:text-fg-subtle";
   const tabCls = (t: string) => `px-3 py-1.5 text-sm rounded-md transition-colors ${tab === t ? "bg-brand text-brand-fg" : "text-fg-muted hover:bg-bg-surface"}`;
 
+  // Resolve which card the Model dropdown should highlight: explicit pick
+  // wins, otherwise derive from model_id (paste path / pre-select effect).
+  // Empty string when nothing matches (e.g. paste mode with an unknown model).
+  const selectedCardId =
+    form.modelCardId ||
+    modelCards.find((mc) => mc.model_id === form.model)?.id ||
+    "";
+
   const [search, setSearch] = useState("");
 
   const displayed = agents.filter((a) => {
@@ -467,60 +490,44 @@ export function AgentsList() {
                     <label className="text-sm text-fg-muted block mb-1">Name *</label>
                     <input value={form.name} onChange={(e) => setForm({ ...form, name: e.target.value })} className={inputCls} placeholder="Coding Assistant" />
                   </div>
-                  {/* Model + Model Card section. Cloud agents need the
-                      dropdown + a backing model_card to make API calls;
-                      local-runtime agents (form.runtimeId set) skip the
-                      whole thing because the ACP child running on the
-                      user's daemon brings its own LLM credentials —
-                      OMA's model_id and model_card never enter the
-                      picture. We show a one-line hint instead so it's
-                      clear this isn't a bug. */}
+                  {/* Model picker. (tenant_id, model_id) is UNIQUE in DB, so
+                      one card == one model_id == one credentials set; the
+                      old dual Model + Model Card dropdowns were redundant.
+                      Local-runtime agents (form.runtimeId set) skip this
+                      block — the ACP child brings its own LLM credentials.
+                      Default card is pre-selected via the useEffect above. */}
                   {!form.runtimeId && (
-                    <>
+                    modelCards.length === 0 ? (
+                      <p className="text-xs text-fg-subtle bg-bg-surface px-3 py-2 rounded-lg">
+                        No model cards configured. Cloud agents need at least one card to provide LLM credentials.{" "}
+                        <a href="/model-cards" className="underline hover:text-fg-muted">Add one</a>.
+                      </p>
+                    ) : (
                       <div>
                         <label className="text-sm text-fg-muted block mb-1">Model</label>
                         <select
-                          value={form.model}
-                          onChange={(e) => setForm({ ...form, model: e.target.value, modelCardId: "" })}
+                          value={selectedCardId}
+                          onChange={(e) => {
+                            const cardId = e.target.value;
+                            const card = modelCards.find((mc) => mc.id === cardId);
+                            setForm({ ...form, modelCardId: cardId, model: card?.model_id ?? "" });
+                          }}
                           className={inputCls}
-                          disabled={modelCards.length === 0}
                         >
-                          {modelCards.length === 0 && <option value="">— add a model card first —</option>}
-                          {Array.from(new Set(modelCards.map(mc => mc.model_id))).map(modelId => (
-                            <option key={modelId} value={modelId}>{modelId}</option>
+                          {/* Paste-mode: form.model came from YAML/JSON but doesn't
+                              match any card. Surface the mismatch instead of silently
+                              showing the first card as if it were chosen. */}
+                          {!selectedCardId && form.model && (
+                            <option value="">⚠ {form.model} — no matching card, pick one</option>
+                          )}
+                          {modelCards.map((mc) => (
+                            <option key={mc.id} value={mc.id}>
+                              {mc.is_default ? "★ " : ""}{mc.model_id}{mc.model !== mc.model_id ? ` (${mc.model})` : ""}
+                            </option>
                           ))}
                         </select>
                       </div>
-                      {modelCards.length > 0 && (
-                        <div>
-                          <label className="text-sm text-fg-muted block mb-1">Model Card</label>
-                          <select
-                            value={form.modelCardId}
-                            onChange={(e) => {
-                              const cardId = e.target.value;
-                              setForm({ ...form, modelCardId: cardId });
-                              if (cardId) {
-                                const card = modelCards.find(mc => mc.id === cardId);
-                                if (card) setForm(f => ({ ...f, modelCardId: cardId, model: card.model_id }));
-                              }
-                            }}
-                            className={inputCls}
-                          >
-                            <option value="">Auto-detect by model ID</option>
-                            {modelCards.map(mc => (
-                              <option key={mc.id} value={mc.id}>{mc.name} ({mc.model_id}) — ****{mc.api_key_preview}</option>
-                            ))}
-                          </select>
-                          <p className="text-xs text-fg-subtle mt-1">Select which API credentials to use for this agent.</p>
-                        </div>
-                      )}
-                      {modelCards.length === 0 && (
-                        <p className="text-xs text-fg-subtle bg-bg-surface px-3 py-2 rounded-lg">
-                          No model cards configured. Cloud agents need at least one card to provide LLM credentials.{" "}
-                          <a href="/model-cards" className="underline hover:text-fg-muted">Add one</a>.
-                        </p>
-                      )}
-                    </>
+                    )
                   )}
                   {form.runtimeId && (
                     <p className="text-xs text-fg-subtle bg-bg-surface px-3 py-2 rounded-lg">

--- a/apps/console/src/pages/ModelCardsList.tsx
+++ b/apps/console/src/pages/ModelCardsList.tsx
@@ -16,8 +16,12 @@ const PROVIDERS = [
 const OFFICIAL_PROVIDERS = new Set(["ant", "oai"]);
 
 const INITIAL_FORM = {
-  name: "", provider: "ant",
-  model_id: "", api_key: "", base_url: "", is_default: false,
+  provider: "ant",
+  model_id: "",
+  model: "",
+  api_key: "",
+  base_url: "",
+  is_default: false,
   custom_headers: [{ key: "", value: "" }] as Array<{ key: string; value: string }>,
 };
 
@@ -62,14 +66,21 @@ export function ModelCardsList() {
 
   const save = async () => {
     setError("");
-    if (!form.name || !form.model_id || (!editingId && !form.api_key)) {
-      setError("Name, Model ID, and API Key are required.");
+    if (!form.model_id || (!editingId && !form.api_key)) {
+      setError("Model ID and API Key are required.");
       return;
     }
     try {
       const payload: Record<string, unknown> = {
-        name: form.name, provider: form.provider, model_id: form.model_id,
-        api_key: form.api_key, is_default: form.is_default,
+        provider: form.provider,
+        model_id: form.model_id,
+        // model defaults to model_id when blank — common case is "the handle
+        // IS the LLM string". Users only fill `model` when they want a
+        // distinct wire-level value (e.g. handle "claude-prod" → wire
+        // "claude-sonnet-4-6").
+        model: form.model || form.model_id,
+        api_key: form.api_key,
+        is_default: form.is_default,
       };
       if (form.base_url) payload.base_url = form.base_url;
       // Serialize custom headers from array to object
@@ -98,8 +109,12 @@ export function ModelCardsList() {
       : [{ key: "", value: "" }];
     if (hdrs.length === 0) hdrs.push({ key: "", value: "" });
     setForm({
-      name: card.name, provider: card.provider, model_id: card.model_id,
-      api_key: "", base_url: card.base_url || "", is_default: card.is_default || false,
+      provider: card.provider,
+      model_id: card.model_id,
+      model: card.model,
+      api_key: "",
+      base_url: card.base_url || "",
+      is_default: card.is_default || false,
       custom_headers: hdrs,
     });
     setEditingId(card.id); setShowCreate(true); setError("");
@@ -140,11 +155,11 @@ export function ModelCardsList() {
       }
       columns={[
         {
-          key: "name",
-          label: "Name",
+          key: "model_id",
+          label: "Model ID",
           render: (c) => (
             <>
-              <div className="font-medium text-fg">{c.name}</div>
+              <div className="font-medium text-fg">{c.model_id}</div>
               <div className="text-xs text-fg-subtle font-mono">{c.id}</div>
             </>
           ),
@@ -159,10 +174,12 @@ export function ModelCardsList() {
           ),
         },
         {
-          key: "model_id",
-          label: "Model ID",
+          key: "model",
+          label: "Wire Model",
           className: "text-fg-muted font-mono text-xs",
-          render: (c) => c.model_id,
+          render: (c) => c.model === c.model_id
+            ? <span className="text-fg-subtle">(same)</span>
+            : c.model,
         },
         {
           key: "api_key",
@@ -195,12 +212,16 @@ export function ModelCardsList() {
       ]}
     >
       <Modal open={showCreate} onClose={closeDialog} title={editingId ? "Edit Model Card" : "New Model Card"}
-        footer={<><Button variant="ghost" onClick={closeDialog}>Cancel</Button><Button onClick={save} disabled={!form.name || !form.model_id || (!editingId && !form.api_key)}>{editingId ? "Save" : "Create"}</Button></>}>
+        footer={<><Button variant="ghost" onClick={closeDialog}>Cancel</Button><Button onClick={save} disabled={!form.model_id || (!editingId && !form.api_key)}>{editingId ? "Save" : "Create"}</Button></>}>
         <form autoComplete="off" onSubmit={(e) => e.preventDefault()} className="space-y-3">
           {error && <div className="text-sm text-danger bg-danger-subtle border border-danger/30 rounded-lg px-3 py-2">{error}</div>}
           <div>
-            <label className="text-sm text-fg-muted block mb-1">Name *</label>
-            <input value={form.name} onChange={(e) => setForm({ ...form, name: e.target.value })} className={inputCls} placeholder="My API Key" autoComplete="off" />
+            <label className="text-sm text-fg-muted block mb-1">
+              Model ID *
+              <span className="ml-1 text-xs text-fg-subtle">(tenant-unique handle agents reference)</span>
+            </label>
+            <input value={form.model_id} onChange={(e) => setForm({ ...form, model_id: e.target.value })} className={inputCls}
+              placeholder="claude-prod, claude-sonnet-4-6, bedrock-sonnet, ..." autoComplete="off" />
           </div>
           <div>
             <label className="text-sm text-fg-muted block mb-1">API Format *</label>
@@ -209,7 +230,7 @@ export function ModelCardsList() {
                 <button
                   key={p.value}
                   type="button"
-                  onClick={() => { setForm({ ...form, provider: p.value, model_id: "", base_url: "" }); setAvailableModels([]); }}
+                  onClick={() => { setForm({ ...form, provider: p.value, model: "", base_url: "" }); setAvailableModels([]); }}
                   className={`text-left px-3 py-2 border rounded-md text-sm transition-colors ${
                     form.provider === p.value
                       ? "border-brand bg-brand-subtle text-fg"
@@ -233,23 +254,26 @@ export function ModelCardsList() {
             )}
           </div>
           <div className="relative">
-            <label className="text-sm text-fg-muted block mb-1">Model ID *</label>
-            <input value={form.model_id}
-              onChange={(e) => { setForm({ ...form, model_id: e.target.value }); setShowModelSuggestions(true); }}
+            <label className="text-sm text-fg-muted block mb-1">
+              Wire Model
+              <span className="ml-1 text-xs text-fg-subtle">(sent to provider; defaults to Model ID)</span>
+            </label>
+            <input value={form.model}
+              onChange={(e) => { setForm({ ...form, model: e.target.value }); setShowModelSuggestions(true); }}
               onFocus={() => setShowModelSuggestions(true)}
               onBlur={() => setTimeout(() => setShowModelSuggestions(false), 150)}
               className={inputCls}
-              placeholder={OFFICIAL_PROVIDERS.has(form.provider)
+              placeholder={form.model_id || (OFFICIAL_PROVIDERS.has(form.provider)
                 ? (form.provider === "ant" ? "claude-sonnet-4-6" : "gpt-4o")
-                : "e.g. deepseek-chat, llama-3.1-70b, ..."}
-              autoComplete="off" name="model-id-field" />
+                : "e.g. deepseek-chat, llama-3.1-70b, ...")}
+              autoComplete="off" name="model-field" />
             {showModelSuggestions && availableModels.length > 0 && (
               <div className="absolute z-10 w-full mt-1 bg-bg border border-border rounded-md shadow-lg py-1 max-h-48 overflow-y-auto">
                 {availableModels
-                  .filter((m) => !form.model_id || m.id.includes(form.model_id) || m.name.toLowerCase().includes(form.model_id.toLowerCase()))
+                  .filter((m) => !form.model || m.id.includes(form.model) || m.name.toLowerCase().includes(form.model.toLowerCase()))
                   .map((m) => (
                     <button key={m.id} type="button"
-                      onMouseDown={() => { setForm({ ...form, model_id: m.id }); setShowModelSuggestions(false); }}
+                      onMouseDown={() => { setForm({ ...form, model: m.id }); setShowModelSuggestions(false); }}
                       className="w-full text-left px-3 py-1.5 text-sm hover:bg-bg-surface">
                       <span className="text-fg">{m.name !== m.id ? m.name : m.id}</span>
                       {m.name !== m.id && <span className="text-fg-subtle text-xs ml-2">{m.id}</span>}

--- a/apps/main/migrations/0015_model_card_handle_rename.sql
+++ b/apps/main/migrations/0015_model_card_handle_rename.sql
@@ -1,0 +1,35 @@
+-- 0015_model_card_handle_rename.sql
+--
+-- Reframe model_cards columns:
+--   * `model_id`  — was "the LLM API model string". Now repurposed as the
+--                   tenant-unique USER-FACING HANDLE that agents reference
+--                   via agent.model. The existing UNIQUE(tenant_id, model_id)
+--                   index keeps its shape; only the semantic shifts.
+--   * `model`     — NEW column. Holds the actual LLM API model string
+--                   (e.g. "claude-sonnet-4-6"). Sent verbatim to the
+--                   provider on each turn. No uniqueness constraint —
+--                   multiple cards may serve the same underlying LLM with
+--                   different keys / base_urls / providers.
+--   * `display_name` — DROPPED. The handle (`model_id`) is itself the
+--                   human-meaningful identifier; a separate label was a
+--                   second namespace nobody asked for.
+--
+-- Backfill is identity:
+--   - Pre-migration rows had model_id = "claude-sonnet-4-6" (the LLM string)
+--     and used display_name as a free-text label.
+--   - Post-migration: model_id stays "claude-sonnet-4-6" (now interpreted as
+--     the handle), and `model` is initialized to the same string so the
+--     first turn after deploy still hits the same provider endpoint.
+--   - Existing agent.model values ("claude-sonnet-4-6") continue to resolve
+--     against the same card by handle. Zero ref breakage.
+--
+-- D1 supports ALTER TABLE DROP COLUMN directly (see note in
+-- 0010_memory_anthropic_alignment.sql); using it here rather than the
+-- table-rebuild dance because there's only one column to drop and the
+-- add+update+drop sequence is naturally atomic at the migration level.
+
+ALTER TABLE "model_cards" ADD COLUMN "model" TEXT NOT NULL DEFAULT '';
+
+UPDATE "model_cards" SET "model" = "model_id" WHERE "model" = '';
+
+ALTER TABLE "model_cards" DROP COLUMN "display_name";

--- a/apps/main/src/routes/agents.ts
+++ b/apps/main/src/routes/agents.ts
@@ -57,9 +57,16 @@ function toApiAgent(row: AgentConfig & { tenant_id?: string }) {
 }
 
 /**
- * Validate that a model_card_id exists, or that the model string
- * matches at least one configured model card (by model_id).
- * If no model cards exist at all, skip validation (env-key fallback).
+ * Validate the agent's model reference. After the handle rename, agent.model
+ * is a string that should equal some card's model_id (the tenant-unique
+ * handle). The DB enforces UNIQUE(tenant_id, model_id) so the lookup returns
+ * at most one row.
+ *
+ * If model_card_id is also pinned, that's the explicit override path —
+ * verify the id exists and let the runtime use that card's wire-level
+ * `model` field for the API call.
+ *
+ * Skips validation entirely when no cards exist (env-var fallback path).
  */
 async function validateModel(
   services: Services,
@@ -73,20 +80,20 @@ async function validateModel(
   // No model cards configured — skip validation (uses env fallback)
   if (active.length === 0) return { valid: true };
 
-  // If explicit model_card_id, verify it exists
+  // Explicit pin: card id must exist.
   if (modelCardId) {
     const found = active.find((c) => c.id === modelCardId);
     if (!found) return { valid: false, error: `Model card "${modelCardId}" not found` };
     return { valid: true };
   }
 
-  // Otherwise, check if the model_id matches any card
+  // Implicit lookup: agent.model must match some card's model_id handle.
   const modelId = typeof model === "string" ? model : model.id;
   const match = active.find((c) => c.model_id === modelId);
   if (!match) {
     return {
       valid: false,
-      error: `No model card configured for model "${modelId}". Create a model card first or use a configured model.`,
+      error: `No model card with model_id "${modelId}". Create a card with that handle, or set agent.model to an existing card's model_id.`,
     };
   }
   return { valid: true };

--- a/apps/main/src/routes/model-cards.ts
+++ b/apps/main/src/routes/model-cards.ts
@@ -14,17 +14,16 @@ const app = new Hono<{
 }>();
 
 /**
- * Adapt a `ModelCardRow` to the legacy API shape that Console + CLI consume.
- * Differences vs. the row: `display_name` becomes `name`, optional fields are
- * surfaced as `undefined` (not `null`), and the row's internal `tenant_id` is
- * never exposed.
+ * Adapt a `ModelCardRow` to the public API shape. Drops the row's internal
+ * `tenant_id` and converts NULL → undefined for optional fields. Field names
+ * are 1:1 with the row otherwise.
  */
 function toApiShape(card: ModelCardRow) {
   return {
     id: card.id,
-    name: card.display_name,
-    provider: card.provider,
     model_id: card.model_id,
+    model: card.model,
+    provider: card.provider,
     api_key_preview: card.api_key_preview,
     base_url: card.base_url ?? undefined,
     custom_headers: card.custom_headers ?? undefined,
@@ -39,24 +38,26 @@ function toApiShape(card: ModelCardRow) {
 app.post("/", async (c) => {
   const t = c.get("tenant_id");
   const body = await c.req.json<{
-    name: string;
-    provider: string;
+    /** User-facing handle, UNIQUE per tenant. */
     model_id: string;
+    /** LLM string sent to provider. Defaults to model_id when omitted. */
+    model?: string;
+    provider: string;
     api_key: string;
     base_url?: string;
     custom_headers?: Record<string, string>;
     is_default?: boolean;
   }>();
 
-  if (!body.name || !body.provider || !body.model_id || !body.api_key) {
-    return c.json({ error: "name, provider, model_id, and api_key are required" }, 400);
+  if (!body.model_id || !body.provider || !body.api_key) {
+    return c.json({ error: "model_id, provider, and api_key are required" }, 400);
   }
   try {
     const card = await c.var.services.modelCards.create({
       tenantId: t,
       modelId: body.model_id,
       provider: body.provider,
-      displayName: body.name,
+      model: body.model,
       apiKey: body.api_key,
       baseUrl: body.base_url ?? null,
       customHeaders: body.custom_headers ?? null,
@@ -99,9 +100,9 @@ app.post("/:id", async (c) => {
   const t = c.get("tenant_id");
   const id = c.req.param("id");
   const body = await c.req.json<{
-    name?: string;
-    provider?: string;
     model_id?: string;
+    model?: string;
+    provider?: string;
     api_key?: string;
     base_url?: string | null;
     custom_headers?: Record<string, string> | null;
@@ -111,12 +112,10 @@ app.post("/:id", async (c) => {
     const updated = await c.var.services.modelCards.update({
       tenantId: t,
       cardId: id,
-      displayName: body.name,
-      provider: body.provider,
       modelId: body.model_id,
-      // Legacy route accepted `body.base_url || undefined` — translating
-      // empty string to "no change". Match for backward compat: explicitly
-      // set falsy → null (clear), undefined → leave alone.
+      model: body.model,
+      provider: body.provider,
+      // Empty string from the form means "clear"; undefined means "leave alone".
       baseUrl: body.base_url === undefined
         ? undefined
         : (body.base_url || null),

--- a/packages/api-types/src/types.ts
+++ b/packages/api-types/src/types.ts
@@ -2,9 +2,11 @@
 
 export interface ModelCard {
   id: string;
-  name: string;
+  /** Tenant-unique handle. Agents reference cards via `agent.model = card.model_id`. */
+  model_id: string;
+  /** LLM string sent to the provider on each turn (e.g. "claude-sonnet-4-6"). */
+  model: string;
   provider: string;             // API compat: "ant" | "oai" | "ant-compatible" | "oai-compatible"
-  model_id: string;        // e.g. "claude-sonnet-4-6", "gpt-4o", "deepseek-chat"
   api_key_preview?: string; // last 4 chars only, for display
   base_url?: string;        // custom base URL (compatible providers)
   custom_headers?: Record<string, string>; // custom HTTP headers (compatible providers)

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -932,20 +932,20 @@ const commands: Cmd[] = [
     usage: "oma models list", desc: "List model cards",
     http: "GET    /v1/model_cards",
     async run(config) {
-      const { data } = await apiFetch<{ data: Array<{ id: string; name: string; provider: string; model_id: string; api_key_preview: string; is_default: boolean }> }>(config, "/v1/model_cards");
+      const { data } = await apiFetch<{ data: Array<{ id: string; model_id: string; model: string; provider: string; api_key_preview: string; is_default: boolean }> }>(config, "/v1/model_cards");
       if (!data.length) { console.log("No model cards. Create one with: oma models create"); return; }
-      table([["NAME", "PROVIDER", "MODEL", "KEY", "DEFAULT"], ...data.map(c => [c.name, c.provider, c.model_id, `****${c.api_key_preview || ""}`, c.is_default ? "yes" : ""])]);
+      table([["MODEL_ID", "PROVIDER", "WIRE MODEL", "KEY", "DEFAULT"], ...data.map(c => [c.model_id, c.provider, c.model === c.model_id ? "(same)" : c.model, `****${c.api_key_preview || ""}`, c.is_default ? "yes" : ""])]);
     },
   },
   {
     group: "Model Cards", match: ["models", "create"],
-    usage: "oma models create --name <n> --model-id <id> --api-key <key> [--provider <p>]", desc: "Create model card",
-    http: "POST   /v1/model_cards {name, provider, model_id, api_key, base_url?, is_default?}",
+    usage: "oma models create --model-id <id> --api-key <key> [--model <wire>] [--provider <p>]", desc: "Create model card",
+    http: "POST   /v1/model_cards {model_id, provider, model?, api_key, base_url?, is_default?}",
     async run(config, args) {
-      const name = flag(args, "--name"); const provider = flag(args, "--provider") || "ant"; const modelId = flag(args, "--model-id"); const apiKey = flag(args, "--api-key"); const baseUrl = flag(args, "--base-url");
-      if (!name || !modelId || !apiKey) { console.error("Usage: oma models create --name <name> --model-id <id> --api-key <key> [--provider ant|oai|ant-compatible|oai-compatible] [--base-url <url>]"); process.exit(1); }
-      const card = await apiFetch<{ id: string; name: string }>(config, "/v1/model_cards", { method: "POST", body: JSON.stringify({ name, provider, model_id: modelId, api_key: apiKey, base_url: baseUrl }) });
-      console.log(`Model card created: ${card.name} (${card.id})`);
+      const modelId = flag(args, "--model-id"); const provider = flag(args, "--provider") || "ant"; const model = flag(args, "--model"); const apiKey = flag(args, "--api-key"); const baseUrl = flag(args, "--base-url");
+      if (!modelId || !apiKey) { console.error("Usage: oma models create --model-id <id> --api-key <key> [--model <wire>] [--provider ant|oai|ant-compatible|oai-compatible] [--base-url <url>]"); process.exit(1); }
+      const card = await apiFetch<{ id: string; model_id: string }>(config, "/v1/model_cards", { method: "POST", body: JSON.stringify({ model_id: modelId, provider, model, api_key: apiKey, base_url: baseUrl }) });
+      console.log(`Model card created: ${card.model_id} (${card.id})`);
     },
   },
 

--- a/packages/model-cards-store/src/adapters/sql-model-card-repo.ts
+++ b/packages/model-cards-store/src/adapters/sql-model-card-repo.ts
@@ -39,7 +39,7 @@ export class SqlModelCardRepo implements ModelCardRepo {
     const insertStmt = this.db
       .prepare(
         `INSERT INTO model_cards
-           (id, tenant_id, model_id, provider, display_name, base_url,
+           (id, tenant_id, model_id, provider, model, base_url,
             custom_headers, api_key_cipher, api_key_preview, is_default,
             created_at)
          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
@@ -49,7 +49,7 @@ export class SqlModelCardRepo implements ModelCardRepo {
         input.tenantId,
         input.modelId,
         input.provider,
-        input.displayName,
+        input.model,
         input.baseUrl,
         input.customHeaders !== null ? JSON.stringify(input.customHeaders) : null,
         input.apiKeyCipher,
@@ -77,7 +77,7 @@ export class SqlModelCardRepo implements ModelCardRepo {
   async get(tenantId: string, cardId: string): Promise<ModelCardRow | null> {
     const row = await this.db
       .prepare(
-        `SELECT id, tenant_id, model_id, provider, display_name, base_url,
+        `SELECT id, tenant_id, model_id, provider, model, base_url,
                 custom_headers, api_key_preview, is_default,
                 created_at, updated_at, archived_at
          FROM model_cards
@@ -91,7 +91,7 @@ export class SqlModelCardRepo implements ModelCardRepo {
   async list(tenantId: string): Promise<ModelCardRow[]> {
     const result = await this.db
       .prepare(
-        `SELECT id, tenant_id, model_id, provider, display_name, base_url,
+        `SELECT id, tenant_id, model_id, provider, model, base_url,
                 custom_headers, api_key_preview, is_default,
                 created_at, updated_at, archived_at
          FROM model_cards
@@ -111,7 +111,7 @@ export class SqlModelCardRepo implements ModelCardRepo {
     },
   ): Promise<{ items: ModelCardRow[]; hasMore: boolean }> {
     const sql =
-      `SELECT id, tenant_id, model_id, provider, display_name, base_url, ` +
+      `SELECT id, tenant_id, model_id, provider, model, base_url, ` +
       `custom_headers, api_key_preview, is_default, ` +
       `created_at, updated_at, archived_at FROM model_cards ` +
       `WHERE tenant_id = ? ${cursorWhereSql(opts.after)} ` +
@@ -129,7 +129,7 @@ export class SqlModelCardRepo implements ModelCardRepo {
   ): Promise<ModelCardRow | null> {
     const row = await this.db
       .prepare(
-        `SELECT id, tenant_id, model_id, provider, display_name, base_url,
+        `SELECT id, tenant_id, model_id, provider, model, base_url,
                 custom_headers, api_key_preview, is_default,
                 created_at, updated_at, archived_at
          FROM model_cards
@@ -144,7 +144,7 @@ export class SqlModelCardRepo implements ModelCardRepo {
   async getDefault(tenantId: string): Promise<ModelCardRow | null> {
     const row = await this.db
       .prepare(
-        `SELECT id, tenant_id, model_id, provider, display_name, base_url,
+        `SELECT id, tenant_id, model_id, provider, model, base_url,
                 custom_headers, api_key_preview, is_default,
                 created_at, updated_at, archived_at
          FROM model_cards
@@ -163,10 +163,6 @@ export class SqlModelCardRepo implements ModelCardRepo {
   ): Promise<ModelCardRow> {
     const sets: string[] = [];
     const binds: unknown[] = [];
-    if (update.displayName !== undefined) {
-      sets.push("display_name = ?");
-      binds.push(update.displayName);
-    }
     if (update.provider !== undefined) {
       sets.push("provider = ?");
       binds.push(update.provider);
@@ -174,6 +170,10 @@ export class SqlModelCardRepo implements ModelCardRepo {
     if (update.modelId !== undefined) {
       sets.push("model_id = ?");
       binds.push(update.modelId);
+    }
+    if (update.model !== undefined) {
+      sets.push("model = ?");
+      binds.push(update.model);
     }
     if (update.baseUrl !== undefined) {
       sets.push("base_url = ?");
@@ -306,7 +306,7 @@ interface DbModelCard {
   tenant_id: string;
   model_id: string;
   provider: string;
-  display_name: string;
+  model: string;
   base_url: string | null;
   custom_headers: string | null; // JSON
   api_key_preview: string;
@@ -321,8 +321,8 @@ function toRow(r: DbModelCard): ModelCardRow {
     id: r.id,
     tenant_id: r.tenant_id,
     model_id: r.model_id,
+    model: r.model,
     provider: r.provider,
-    display_name: r.display_name,
     base_url: r.base_url,
     custom_headers:
       r.custom_headers !== null

--- a/packages/model-cards-store/src/ports.ts
+++ b/packages/model-cards-store/src/ports.ts
@@ -20,9 +20,12 @@ import type { PageCursor } from "@open-managed-agents/shared";
 export interface NewModelCardInput {
   id: string;
   tenantId: string;
+  /** Tenant-unique handle. UNIQUE(tenant_id, model_id) enforced in DB. */
   modelId: string;
   provider: string;
-  displayName: string;
+  /** LLM string sent to the provider API. Defaults to modelId when callers
+   *  haven't customized — see ModelCardService.create. */
+  model: string;
   baseUrl: string | null;
   customHeaders: Record<string, string> | null;
   apiKeyCipher: string;
@@ -37,9 +40,10 @@ export interface NewModelCardInput {
 }
 
 export interface ModelCardUpdateFields {
-  displayName?: string;
   provider?: string;
   modelId?: string;
+  /** Update the wire-level LLM string. */
+  model?: string;
   baseUrl?: string | null;
   customHeaders?: Record<string, string> | null;
   /** New ciphertext when the api_key is rotated. Pair with `apiKeyPreview`. */

--- a/packages/model-cards-store/src/service.ts
+++ b/packages/model-cards-store/src/service.ts
@@ -69,9 +69,13 @@ export class ModelCardService {
 
   async create(opts: {
     tenantId: string;
+    /** Tenant-unique handle. UNIQUE(tenant_id, model_id) enforced in DB. */
     modelId: string;
     provider: string;
-    displayName: string;
+    /** Wire-level LLM model string sent to provider. Defaults to modelId
+     *  when omitted (so a new card with `model_id: "claude-sonnet-4-6"`
+     *  needs no extra config to do the obvious thing). */
+    model?: string;
     apiKey: string;
     baseUrl?: string | null;
     customHeaders?: Record<string, string> | null;
@@ -84,7 +88,7 @@ export class ModelCardService {
       tenantId: opts.tenantId,
       modelId: opts.modelId,
       provider: opts.provider,
-      displayName: opts.displayName,
+      model: opts.model ?? opts.modelId,
       baseUrl: opts.baseUrl ?? null,
       customHeaders: opts.customHeaders ?? null,
       apiKeyCipher,
@@ -97,9 +101,11 @@ export class ModelCardService {
   async update(opts: {
     tenantId: string;
     cardId: string;
-    displayName?: string;
     provider?: string;
+    /** Rename the handle. UNIQUE(tenant_id, model_id) still enforced. */
     modelId?: string;
+    /** Change the wire-level LLM string sent to the provider. */
+    model?: string;
     /** Pass `null` to clear the override and fall back to the provider default. */
     baseUrl?: string | null;
     /** Pass `null` to clear. Pass an object to replace. */
@@ -111,9 +117,9 @@ export class ModelCardService {
   }): Promise<ModelCardRow> {
     await this.requireCard(opts);
     const update: ModelCardUpdateFields = { updatedAt: this.clock.nowMs() };
-    if (opts.displayName !== undefined) update.displayName = opts.displayName;
     if (opts.provider !== undefined) update.provider = opts.provider;
     if (opts.modelId !== undefined) update.modelId = opts.modelId;
+    if (opts.model !== undefined) update.model = opts.model;
     if (opts.baseUrl !== undefined) update.baseUrl = opts.baseUrl;
     if (opts.customHeaders !== undefined) update.customHeaders = opts.customHeaders;
     if (opts.isDefault !== undefined) update.isDefault = opts.isDefault;

--- a/packages/model-cards-store/src/test-fakes.ts
+++ b/packages/model-cards-store/src/test-fakes.ts
@@ -24,7 +24,7 @@ interface InMemModelCard {
   tenant_id: string;
   model_id: string;
   provider: string;
-  display_name: string;
+  model: string;
   base_url: string | null;
   custom_headers: Record<string, string> | null;
   api_key_cipher: string;
@@ -58,7 +58,7 @@ export class InMemoryModelCardRepo implements ModelCardRepo {
       tenant_id: input.tenantId,
       model_id: input.modelId,
       provider: input.provider,
-      display_name: input.displayName,
+      model: input.model,
       base_url: input.baseUrl,
       custom_headers: input.customHeaders,
       api_key_cipher: input.apiKeyCipher,
@@ -163,9 +163,9 @@ export class InMemoryModelCardRepo implements ModelCardRepo {
       // is_default not in the patch — nothing to enforce.
     }
 
-    if (update.displayName !== undefined) row.display_name = update.displayName;
     if (update.provider !== undefined) row.provider = update.provider;
     if (update.modelId !== undefined) row.model_id = update.modelId;
+    if (update.model !== undefined) row.model = update.model;
     if (update.baseUrl !== undefined) row.base_url = update.baseUrl;
     if (update.customHeaders !== undefined) row.custom_headers = update.customHeaders;
     if (update.apiKeyCipher !== undefined) row.api_key_cipher = update.apiKeyCipher;
@@ -310,8 +310,8 @@ function toRow(c: InMemModelCard): ModelCardRow {
     id: c.id,
     tenant_id: c.tenant_id,
     model_id: c.model_id,
+    model: c.model,
     provider: c.provider,
-    display_name: c.display_name,
     base_url: c.base_url,
     custom_headers: c.custom_headers,
     api_key_preview: c.api_key_preview,

--- a/packages/model-cards-store/src/types.ts
+++ b/packages/model-cards-store/src/types.ts
@@ -25,11 +25,17 @@
 export interface ModelCardRow {
   id: string;
   tenant_id: string;
-  /** External-facing model identifier (e.g. "claude-sonnet-4-6", "gpt-4o"). */
+  /** Tenant-unique user-facing handle (e.g. "claude-prod", "bedrock-sonnet").
+   *  Agents reference cards via `agent.model = card.model_id`. UNIQUE per
+   *  tenant — same string can't pin two different credentials. */
   model_id: string;
+  /** Actual LLM model string sent to the provider's API on each turn
+   *  (e.g. "claude-sonnet-4-6", "gpt-4o"). No uniqueness constraint —
+   *  multiple cards may serve the same underlying LLM with different keys
+   *  / base_urls / providers. */
+  model: string;
   /** Provider tag — controls how the agent worker shapes outbound requests. */
   provider: string;
-  display_name: string;
   /** Optional override for the upstream API base URL. NULL = use provider default. */
   base_url: string | null;
   /** Optional extra HTTP headers (used by *-compatible providers). NULL when unset. */

--- a/test/integration/auth-tenant.test.ts
+++ b/test/integration/auth-tenant.test.ts
@@ -147,7 +147,6 @@ describe("model cards", () => {
       method: "POST",
       headers: HEADERS,
       body: JSON.stringify({
-        name: "Test Anthropic",
         provider: "ant",
         model_id: "claude-sonnet-4-6",
         api_key: "sk-ant-test-1234567890",
@@ -155,7 +154,9 @@ describe("model cards", () => {
     });
     expect(res.status).toBe(201);
     const body = await res.json();
-    expect(body.name).toBe("Test Anthropic");
+    expect(body.model_id).toBe("claude-sonnet-4-6");
+    // model defaults to model_id when not specified
+    expect(body.model).toBe("claude-sonnet-4-6");
     expect(body.provider).toBe("ant");
     expect(body.api_key_preview).toBe("7890");
     // Full key should NOT be in response
@@ -168,7 +169,6 @@ describe("model cards", () => {
       method: "POST",
       headers: HEADERS,
       body: JSON.stringify({
-        name: "Test Compatible",
         provider: "oai-compatible",
         model_id: "deepseek-chat",
         api_key: "sk-test-deepseek",
@@ -195,11 +195,11 @@ describe("model cards", () => {
     const res = await api(`/v1/model_cards/${cardId}`, {
       method: "POST",
       headers: HEADERS,
-      body: JSON.stringify({ name: "Updated Anthropic", is_default: true }),
+      body: JSON.stringify({ model: "claude-opus-4-7", is_default: true }),
     });
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.name).toBe("Updated Anthropic");
+    expect(body.model).toBe("claude-opus-4-7");
     expect(body.is_default).toBe(true);
   });
 

--- a/test/test-worker.ts
+++ b/test/test-worker.ts
@@ -61,6 +61,8 @@ import schema0012 from "../apps/main/migrations/0012_slack_per_channel.sql?raw";
 import schema0013 from "../apps/main/migrations/0013_cursor_pagination_indexes.sql?raw";
 // @ts-expect-error vitest resolves SQL via ?raw
 import schema0014 from "../apps/main/migrations/0014_session_turn_id.sql?raw";
+// @ts-expect-error vitest resolves SQL via ?raw
+import schema0015 from "../apps/main/migrations/0015_model_card_handle_rename.sql?raw";
 
 const MIGRATIONS_RAW: string[] = [
   schema0001 as string,
@@ -79,6 +81,7 @@ const MIGRATIONS_RAW: string[] = [
   schema0012 as string,
   schema0013 as string,
   schema0014 as string,
+  schema0015 as string,
 ];
 
 let migrationsApplied = false;

--- a/test/unit/model-cards-store-service.test.ts
+++ b/test/unit/model-cards-store-service.test.ts
@@ -33,7 +33,6 @@ describe("ModelCardService — create + read", () => {
       tenantId: TENANT,
       modelId: "claude-sonnet-4-6",
       provider: "ant",
-      displayName: "Anthropic Sonnet",
       apiKey: "sk-ant-supersecret-1234",
     });
     expect(card.id).toMatch(/^mdl-/);
@@ -46,7 +45,8 @@ describe("ModelCardService — create + read", () => {
     expect(card.custom_headers).toBeNull();
 
     const got = await service.get({ tenantId: TENANT, cardId: card.id });
-    expect(got?.display_name).toBe("Anthropic Sonnet");
+    // model defaults to model_id when not explicitly set on create.
+    expect(got?.model).toBe("claude-sonnet-4-6");
   });
 
   it("isolates cards by tenant", async () => {
@@ -55,7 +55,6 @@ describe("ModelCardService — create + read", () => {
       tenantId: "tn_a",
       modelId: "claude-sonnet-4-6",
       provider: "ant",
-      displayName: "A",
       apiKey: "sk-A-1234",
     });
     expect((await service.list({ tenantId: "tn_a" })).length).toBe(1);
@@ -75,7 +74,6 @@ describe("ModelCardService — create + read", () => {
       tenantId: TENANT,
       modelId: "gpt-4o",
       provider: "oai",
-      displayName: "OpenAI",
       apiKey: "sk-oai-abcdef-LAST",
     });
     // api_key is not on the row — neither cleartext nor cipher
@@ -94,7 +92,6 @@ describe("ModelCardService — UNIQUE(tenant_id, model_id)", () => {
       tenantId: TENANT,
       modelId: "claude-sonnet-4-6",
       provider: "ant",
-      displayName: "first",
       apiKey: "sk-ant-1111",
     });
     await expect(() =>
@@ -102,7 +99,6 @@ describe("ModelCardService — UNIQUE(tenant_id, model_id)", () => {
         tenantId: TENANT,
         modelId: "claude-sonnet-4-6",
         provider: "ant",
-        displayName: "second",
         apiKey: "sk-ant-2222",
       }),
     ).rejects.toBeInstanceOf(ModelCardDuplicateModelIdError);
@@ -114,14 +110,12 @@ describe("ModelCardService — UNIQUE(tenant_id, model_id)", () => {
       tenantId: "tn_a",
       modelId: "gpt-4o",
       provider: "oai",
-      displayName: "A",
       apiKey: "sk-A-1111",
     });
     const b = await service.create({
       tenantId: "tn_b",
       modelId: "gpt-4o",
       provider: "oai",
-      displayName: "B",
       apiKey: "sk-B-2222",
     });
     expect(b.tenant_id).toBe("tn_b");
@@ -133,14 +127,12 @@ describe("ModelCardService — UNIQUE(tenant_id, model_id)", () => {
       tenantId: TENANT,
       modelId: "claude-sonnet-4-6",
       provider: "ant",
-      displayName: "Sonnet",
       apiKey: "sk-1111",
     });
     const b = await service.create({
       tenantId: TENANT,
       modelId: "claude-haiku-4-6",
       provider: "ant",
-      displayName: "Haiku",
       apiKey: "sk-2222",
     });
     await expect(() =>
@@ -163,7 +155,6 @@ describe("ModelCardService — partial UNIQUE: default semantics", () => {
       tenantId: TENANT,
       modelId: "claude-sonnet-4-6",
       provider: "ant",
-      displayName: "Default",
       apiKey: "sk-ant-1111",
       makeDefault: true,
     });
@@ -179,7 +170,6 @@ describe("ModelCardService — partial UNIQUE: default semantics", () => {
       tenantId: TENANT,
       modelId: "claude-sonnet-4-6",
       provider: "ant",
-      displayName: "A",
       apiKey: "sk-A-1111",
       makeDefault: true,
     });
@@ -188,7 +178,6 @@ describe("ModelCardService — partial UNIQUE: default semantics", () => {
       tenantId: TENANT,
       modelId: "gpt-4o",
       provider: "oai",
-      displayName: "B",
       apiKey: "sk-B-2222",
     });
     clock.set(3000);
@@ -212,7 +201,6 @@ describe("ModelCardService — partial UNIQUE: default semantics", () => {
       tenantId: TENANT,
       modelId: "claude-sonnet-4-6",
       provider: "ant",
-      displayName: "A",
       apiKey: "sk-A-1111",
       makeDefault: true,
     });
@@ -220,7 +208,6 @@ describe("ModelCardService — partial UNIQUE: default semantics", () => {
       tenantId: TENANT,
       modelId: "gpt-4o",
       provider: "oai",
-      displayName: "B",
       apiKey: "sk-B-2222",
       makeDefault: true,
     });
@@ -237,7 +224,6 @@ describe("ModelCardService — partial UNIQUE: default semantics", () => {
       tenantId: TENANT,
       modelId: "claude-sonnet-4-6",
       provider: "ant",
-      displayName: "A",
       apiKey: "sk-A-1111",
       makeDefault: true,
     });
@@ -245,7 +231,6 @@ describe("ModelCardService — partial UNIQUE: default semantics", () => {
       tenantId: TENANT,
       modelId: "gpt-4o",
       provider: "oai",
-      displayName: "B",
       apiKey: "sk-B-2222",
     });
     const updated = await service.update({
@@ -269,7 +254,6 @@ describe("ModelCardService — partial UNIQUE: default semantics", () => {
       tenantId: TENANT,
       modelId: "claude-sonnet-4-6",
       provider: "ant",
-      displayName: "A",
       apiKey: "sk-A",
       makeDefault: true,
     });
@@ -277,7 +261,6 @@ describe("ModelCardService — partial UNIQUE: default semantics", () => {
       tenantId: TENANT,
       modelId: "gpt-4o",
       provider: "oai",
-      displayName: "B",
       apiKey: "sk-B",
       makeDefault: true,           // demotes a
     });
@@ -285,7 +268,6 @@ describe("ModelCardService — partial UNIQUE: default semantics", () => {
       tenantId: TENANT,
       modelId: "claude-haiku-4-6",
       provider: "ant",
-      displayName: "C",
       apiKey: "sk-C",
     });
     await service.setDefault({ tenantId: TENANT, cardId: c.id }); // demotes b
@@ -325,7 +307,6 @@ describe("ModelCardService — partial UNIQUE: default semantics", () => {
       tenantId: TENANT,
       modelId: "claude-sonnet-4-6",
       provider: "ant",
-      displayName: "A",
       apiKey: "sk-A-1111",
     });
     expect(await service.getDefault({ tenantId: TENANT })).toBeNull();
@@ -333,26 +314,25 @@ describe("ModelCardService — partial UNIQUE: default semantics", () => {
 });
 
 describe("ModelCardService — update", () => {
-  it("updates display_name + api_key + base_url + custom_headers", async () => {
+  it("updates model + api_key + base_url + custom_headers", async () => {
     const clock = new ManualClock(1000);
     const { service } = createInMemoryModelCardService({ clock });
     const card = await service.create({
       tenantId: TENANT,
       modelId: "claude-sonnet-4-6",
       provider: "ant",
-      displayName: "old",
       apiKey: "sk-ant-OLD0",
     });
     clock.set(2000);
     const updated = await service.update({
       tenantId: TENANT,
       cardId: card.id,
-      displayName: "new",
+      model: "claude-opus-4-7",
       apiKey: "sk-ant-NEW9",
       baseUrl: "https://my-proxy.example.com/v1",
       customHeaders: { "X-Custom": "value" },
     });
-    expect(updated.display_name).toBe("new");
+    expect(updated.model).toBe("claude-opus-4-7");
     expect(updated.api_key_preview).toBe("NEW9");
     expect(updated.base_url).toBe("https://my-proxy.example.com/v1");
     expect(updated.custom_headers).toEqual({ "X-Custom": "value" });
@@ -369,7 +349,6 @@ describe("ModelCardService — update", () => {
       tenantId: TENANT,
       modelId: "deepseek-chat",
       provider: "oai-compatible",
-      displayName: "DeepSeek",
       apiKey: "sk-ds-1111",
       baseUrl: "https://api.deepseek.com/v1",
       customHeaders: { "X-Tag": "live" },
@@ -390,7 +369,6 @@ describe("ModelCardService — update", () => {
       service.update({
         tenantId: TENANT,
         cardId: "missing",
-        displayName: "x",
       }),
     ).rejects.toBeInstanceOf(ModelCardNotFoundError);
   });
@@ -403,7 +381,6 @@ describe("ModelCardService — delete", () => {
       tenantId: TENANT,
       modelId: "claude-sonnet-4-6",
       provider: "ant",
-      displayName: "x",
       apiKey: "sk-ant-1111",
     });
     await service.delete({ tenantId: TENANT, cardId: card.id });
@@ -418,7 +395,6 @@ describe("ModelCardService — delete", () => {
       tenantId: TENANT,
       modelId: "claude-sonnet-4-6",
       provider: "ant",
-      displayName: "Default",
       apiKey: "sk-ant-1111",
       makeDefault: true,
     });
@@ -443,7 +419,6 @@ describe("ModelCardService — listing + lookups", () => {
       tenantId: TENANT,
       modelId: "claude-sonnet-4-6",
       provider: "ant",
-      displayName: "first",
       apiKey: "sk-1111",
     });
     clock.set(2000);
@@ -451,7 +426,6 @@ describe("ModelCardService — listing + lookups", () => {
       tenantId: TENANT,
       modelId: "gpt-4o",
       provider: "oai",
-      displayName: "second",
       apiKey: "sk-2222",
     });
     clock.set(3000);
@@ -459,11 +433,10 @@ describe("ModelCardService — listing + lookups", () => {
       tenantId: TENANT,
       modelId: "claude-haiku-4-6",
       provider: "ant",
-      displayName: "third",
       apiKey: "sk-3333",
     });
     const all = await service.list({ tenantId: TENANT });
-    expect(all.map((c) => c.display_name)).toEqual(["first", "second", "third"]);
+    expect(all.map((c) => c.model_id)).toEqual(["claude-sonnet-4-6", "gpt-4o", "claude-haiku-4-6"]);
   });
 
   it("findByModelId returns the matching card or null", async () => {
@@ -472,7 +445,6 @@ describe("ModelCardService — listing + lookups", () => {
       tenantId: TENANT,
       modelId: "claude-sonnet-4-6",
       provider: "ant",
-      displayName: "Sonnet",
       apiKey: "sk-1111",
     });
     expect(
@@ -504,7 +476,6 @@ describe("ModelCardService — api_key crypto boundary", () => {
       tenantId: TENANT,
       modelId: "claude-sonnet-4-6",
       provider: "ant",
-      displayName: "x",
       apiKey: "sk-ant-supersecret-PLAIN",
     });
     const key = await service.getApiKey({
@@ -522,7 +493,6 @@ describe("ModelCardService — api_key crypto boundary", () => {
       tenantId: TENANT,
       modelId: "claude-sonnet-4-6",
       provider: "ant",
-      displayName: "x",
       apiKey: "sk-ant-VISIBLE",
     });
     const cipher = await repo.getApiKeyCipher(TENANT, card.id);


### PR DESCRIPTION
## Summary

- **Schema rename** (additive migration `0015`): `model_id` becomes the tenant-unique user-facing handle (was the LLM string); a NEW `model` column holds the wire-level LLM string sent to the provider. `display_name` dropped. Existing rows backfill `model = model_id` so nothing breaks.
- **Agent create UI**: collapses dual *Model + Model Card* dropdowns into a single picker over model cards. Default card pre-selected via `is_default`. The dual selector was always solving a non-existent problem — DB has UNIQUE(tenant_id, model_id), so one handle ↔ one card.
- **Multi-provider same-model unblocked**: with `model_id` as a free-form handle and `model` as the wire string, you can now have e.g. `claude-prod` and `claude-dev` cards both wiring to `claude-sonnet-4-6` with different keys/base_urls.

## Why

Two tangled problems before:
1. **Confusing UX**: agent create form had Model + Model Card dropdowns + an "Auto-detect by model ID" middle state that did nothing (UNIQUE index made the disambiguation impossible).
2. **Schema lock-in**: `model_id` was both "the LLM API string" and "the unique key for credentials" — couldn't have two cards serving the same upstream model with different credentials.

Decoupling the handle from the wire model fixes both at once.

## Touched layers

- `apps/main/migrations/0015_model_card_handle_rename.sql` — additive ALTER + UPDATE + DROP, no data loss
- `packages/model-cards-store/` — types, ports, service, sql adapter, test-fakes all renamed `displayName` → `model`
- `packages/api-types/src/types.ts` — `ModelCard` interface drops `name`, adds `model`
- `apps/main/src/routes/model-cards.ts` — POST/UPDATE bodies; `toApiShape` drops name mapping
- `apps/main/src/routes/agents.ts` — `validateModel` comment clarifies handle semantic
- `apps/agent/src/runtime/session-do.ts` — `resolveModelCardCredentials` returns `model: card.model`; both call sites pass `creds.model` to `resolveModel` so wire model reaches the provider even when handle ≠ wire
- `apps/console/src/pages/ModelCardsList.tsx` — form has `Model ID` (handle) + `Wire Model` (optional, defaults to handle)
- `apps/console/src/pages/AgentsList.tsx` — single Model picker, `useEffect` pre-selects default card on form open
- `packages/cli/src/index.ts` — `oma models create --model-id <id> --api-key <key> [--model <wire>]`

## Test plan

- [x] `pnpm vitest run test/unit/model-cards-store-service.test.ts` — 25/25 pass
- [x] `pnpm vitest run test/unit/agents-store-service.test.ts` — 24/24 pass
- [x] `pnpm vitest run test/integration/auth-tenant.test.ts` — 28/28 pass against miniflare workerd + D1 (migration chain 0001 → 0015 applied end-to-end)
- [x] `tsc --noEmit` clean on: api-types, model-cards-store, services, cli, apps/main, apps/agent, apps/console (touched files)
- [x] **Real-LLM staging smoke** — deployed to staging via `deploy-staging.yml`, manually applied 0015 to staging D1, then:
  - PATCH on a card: changed `model` only, verified `model_id` unchanged
  - End-to-end session via existing MiniMax card (`ant` provider) — got "PONG" in 1958ms
  - End-to-end session via DeepSeek card (`oai-compatible` provider) — got "PONG" in 1177ms
  - All test resources cleaned up after

## Notes

- **deploy-staging.yml intentionally NOT modified.** Staging schema may shift independently — applying migrations manually for now. `deploy.yml` (prod) already runs `wrangler d1 migrations apply --remote` pre-deploy.
- **No users yet** — no backward-compat shims for `name` / `display_name`. New schema is the only schema.
- **Rollback**: there is none today. Reverting this PR + applying a hand-written `0016_revert_model_card_handle.sql` would be the path. We agreed to discuss the broader rollback story separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)