### PR TITLE
fix(shard): wire env.staging shard bindings (PR #58 squash slip)

### DIFF
--- a/apps/agent/wrangler.jsonc
+++ b/apps/agent/wrangler.jsonc
@@ -158,7 +158,12 @@
         { "binding": "CONFIG_KV", "id": "f91ddab8abe64941bd3ef398b0c187a7" }
       ],
       "d1_databases": [
-        { "binding": "AUTH_DB", "database_name": "openma-auth-staging", "database_id": "aff5dbb7-36f9-46b7-b82f-4513e5603ac6" }
+        { "binding": "AUTH_DB",    "database_name": "openma-auth-staging",          "database_id": "aff5dbb7-36f9-46b7-b82f-4513e5603ac6" },
+        { "binding": "ROUTER_DB",  "database_name": "openma-router-staging",        "database_id": "c238a338-9b6e-40c5-aaaa-48d4fe6dc63d" },
+        { "binding": "AUTH_DB_00", "database_name": "openma-auth-staging",          "database_id": "aff5dbb7-36f9-46b7-b82f-4513e5603ac6" },
+        { "binding": "AUTH_DB_01", "database_name": "openma-auth-shard-01-staging", "database_id": "fe6a34d1-cd8a-48a1-bff1-29032026d006" },
+        { "binding": "AUTH_DB_02", "database_name": "openma-auth-shard-02-staging", "database_id": "8636a018-8ac6-48c2-ae95-2f70919c8aab" },
+        { "binding": "AUTH_DB_03", "database_name": "openma-auth-shard-03-staging", "database_id": "8ce8f17d-7527-4a5a-b097-ce73251be55a" }
       ],
       "ai": { "binding": "AI" },
       "vectorize": [

--- a/apps/integrations/wrangler.jsonc
+++ b/apps/integrations/wrangler.jsonc
@@ -83,8 +83,13 @@
         { "pattern": "integrations.staging.openma.dev", "custom_domain": true }
       ],
       "d1_databases": [
-        { "binding": "AUTH_DB",         "database_name": "openma-auth-staging",         "database_id": "aff5dbb7-36f9-46b7-b82f-4513e5603ac6" },
-        { "binding": "INTEGRATIONS_DB", "database_name": "openma-integrations-staging", "database_id": "e7247e7e-e60c-4c8e-ac1c-5eff7ad8cb95" }
+        { "binding": "AUTH_DB",         "database_name": "openma-auth-staging",          "database_id": "aff5dbb7-36f9-46b7-b82f-4513e5603ac6" },
+        { "binding": "ROUTER_DB",       "database_name": "openma-router-staging",        "database_id": "c238a338-9b6e-40c5-aaaa-48d4fe6dc63d" },
+        { "binding": "AUTH_DB_00",      "database_name": "openma-auth-staging",          "database_id": "aff5dbb7-36f9-46b7-b82f-4513e5603ac6" },
+        { "binding": "AUTH_DB_01",      "database_name": "openma-auth-shard-01-staging", "database_id": "fe6a34d1-cd8a-48a1-bff1-29032026d006" },
+        { "binding": "AUTH_DB_02",      "database_name": "openma-auth-shard-02-staging", "database_id": "8636a018-8ac6-48c2-ae95-2f70919c8aab" },
+        { "binding": "AUTH_DB_03",      "database_name": "openma-auth-shard-03-staging", "database_id": "8ce8f17d-7527-4a5a-b097-ce73251be55a" },
+        { "binding": "INTEGRATIONS_DB", "database_name": "openma-integrations-staging",  "database_id": "e7247e7e-e60c-4c8e-ac1c-5eff7ad8cb95" }
       ],
       "services": [
         { "binding": "MAIN", "service": "managed-agents-staging" }

--- a/apps/main/wrangler.jsonc
+++ b/apps/main/wrangler.jsonc
@@ -189,8 +189,13 @@
         { "binding": "CONFIG_KV", "id": "f91ddab8abe64941bd3ef398b0c187a7" }
       ],
       "d1_databases": [
-        { "binding": "AUTH_DB",         "database_name": "openma-auth-staging",         "database_id": "aff5dbb7-36f9-46b7-b82f-4513e5603ac6" },
-        { "binding": "INTEGRATIONS_DB", "database_name": "openma-integrations-staging", "database_id": "e7247e7e-e60c-4c8e-ac1c-5eff7ad8cb95" }
+        { "binding": "AUTH_DB",         "database_name": "openma-auth-staging",          "database_id": "aff5dbb7-36f9-46b7-b82f-4513e5603ac6", "migrations_dir": "migrations" },
+        { "binding": "ROUTER_DB",       "database_name": "openma-router-staging",        "database_id": "c238a338-9b6e-40c5-aaaa-48d4fe6dc63d", "migrations_dir": "migrations-router" },
+        { "binding": "AUTH_DB_00",      "database_name": "openma-auth-staging",          "database_id": "aff5dbb7-36f9-46b7-b82f-4513e5603ac6", "migrations_dir": "migrations" },
+        { "binding": "AUTH_DB_01",      "database_name": "openma-auth-shard-01-staging", "database_id": "fe6a34d1-cd8a-48a1-bff1-29032026d006", "migrations_dir": "migrations" },
+        { "binding": "AUTH_DB_02",      "database_name": "openma-auth-shard-02-staging", "database_id": "8636a018-8ac6-48c2-ae95-2f70919c8aab", "migrations_dir": "migrations" },
+        { "binding": "AUTH_DB_03",      "database_name": "openma-auth-shard-03-staging", "database_id": "8ce8f17d-7527-4a5a-b097-ce73251be55a", "migrations_dir": "migrations" },
+        { "binding": "INTEGRATIONS_DB", "database_name": "openma-integrations-staging",  "database_id": "e7247e7e-e60c-4c8e-ac1c-5eff7ad8cb95", "migrations_dir": "migrations-integrations" }
       ],
       "r2_buckets": [
         { "binding": "FILES_BUCKET", "bucket_name": "managed-agents-files" },

--- a/scripts/migrate-all-shards.sh
+++ b/scripts/migrate-all-shards.sh
@@ -10,18 +10,23 @@
 # d1_migrations and skips anything already done.
 #
 # Usage:
-#   scripts/migrate-all-shards.sh            # remote (prod)
-#   scripts/migrate-all-shards.sh --local    # local dev
+#   scripts/migrate-all-shards.sh                # remote prod
+#   scripts/migrate-all-shards.sh --staging      # remote staging (env.staging block)
+#   scripts/migrate-all-shards.sh --local        # local dev
 #
 # Pre-req: cwd = repo root, apps/main installed (wrangler available).
 set -euo pipefail
 
 LOCAL_FLAG=""
 REMOTE_FLAG="--remote"
-if [ "${1:-}" = "--local" ]; then
-  REMOTE_FLAG=""
-  LOCAL_FLAG="--local"
-fi
+ENV_FLAG=""
+for arg in "$@"; do
+  case "$arg" in
+    --local) REMOTE_FLAG=""; LOCAL_FLAG="--local" ;;
+    --staging) ENV_FLAG="--env staging" ;;
+    --env=*) ENV_FLAG="--env ${arg#--env=}" ;;
+  esac
+done
 
 cd "$(dirname "$0")/.."
 cd apps/main
@@ -29,12 +34,12 @@ cd apps/main
 run_apply() {
   local binding="$1"
   echo ""
-  echo "─── $binding ────────────────────────────────"
+  echo "─── $binding ${ENV_FLAG:+($ENV_FLAG)} ────────────────────────"
   if [ -n "$LOCAL_FLAG" ]; then
-    npx wrangler d1 migrations apply "$binding" --local --persist-to ../../.wrangler/state \
+    npx wrangler d1 migrations apply "$binding" --local --persist-to ../../.wrangler/state $ENV_FLAG \
       || echo "  (continuing — check error above)"
   else
-    npx wrangler d1 migrations apply "$binding" --remote \
+    npx wrangler d1 migrations apply "$binding" --remote $ENV_FLAG \
       || echo "  (continuing — check error above)"
   fi
 }


### PR DESCRIPTION
Re-applies the env.staging shard wiring + --staging flag for migrate-all-shards.sh that didn't make it into the PR #58 squash. See commit message.