### PR TITLE
refactor(shard): MemoryStoreTenantIndex port + service

### DIFF
--- a/apps/main/migrations-router/0001_schema.sql
+++ b/apps/main/migrations-router/0001_schema.sql
@@ -39,11 +39,21 @@ CREATE TABLE IF NOT EXISTS "shard_pool" (
 CREATE INDEX IF NOT EXISTS "idx_shard_pool_status"
   ON "shard_pool" ("status", "tenant_count");
 
--- Seed the 4 initial shards. AUTH_DB_00 is the original openma-auth
--- (where all current data lives); _01..03 are net-new empty shards.
+-- Seed only the mandatory baseline shard. AUTH_DB_00 is the same
+-- database_id as the legacy AUTH_DB binding — the "default shard"
+-- every deploy must have. Adding more shards is operations:
+--
+--   1. wrangler d1 create openma-auth-shard-NN
+--   2. add { binding: "AUTH_DB_NN", database_id: "..." } to wrangler.jsonc
+--   3. wrangler d1 execute ROUTER_DB --remote --command \
+--        "INSERT INTO shard_pool (binding_name, status) VALUES ('AUTH_DB_NN','open')"
+--   4. deploy
+--
+-- Coupling shard count to a migration would force every operator
+-- (including OSS self-hosters) to either accept this exact 4-shard
+-- topology or hand-edit migration files. Runtime INSERT keeps it
+-- config-driven.
+--
 -- Idempotent — INSERT OR IGNORE no-ops on re-run.
-INSERT OR IGNORE INTO "shard_pool" ("binding_name", "status", "notes") VALUES
-  ('AUTH_DB_00', 'open', 'original openma-auth — pre-shard data'),
-  ('AUTH_DB_01', 'open', NULL),
-  ('AUTH_DB_02', 'open', NULL),
-  ('AUTH_DB_03', 'open', NULL);
+INSERT OR IGNORE INTO "shard_pool" ("binding_name", "status", "notes")
+VALUES ('AUTH_DB_00', 'open', 'baseline shard — alias of legacy AUTH_DB');

--- a/apps/main/migrations-router/0002_memory_store_tenant.sql
+++ b/apps/main/migrations-router/0002_memory_store_tenant.sql
@@ -20,9 +20,18 @@
 -- for tenants on shards 1-3. Putting the index here means the lookup
 -- doesn't depend on the data plane being up.
 --
--- Pre-existing data backfilled in this migration. The fallback path in
--- the consumer treats "missing row" as "store on AUTH_DB_00" so legacy
--- stores keep working even if the backfill was incomplete.
+-- Empty by default: the consumer treats "missing row" as "store on
+-- AUTH_DB_00" (legacy fallback), so pre-shard stores keep working
+-- even without backfill. Operators with existing memory_stores at the
+-- time of shard rollout should backfill via:
+--
+--   wrangler d1 execute ROUTER_DB --remote --command \
+--     "INSERT INTO memory_store_tenant (store_id, tenant_id, created_at)
+--      SELECT id, tenant_id, COALESCE(created_at*1000, strftime('%s','now')*1000)
+--        FROM memory_stores"
+--
+-- (run from apps/main, before traffic for new tenants on non-shard-0
+-- shards starts creating memory_stores).
 
 CREATE TABLE IF NOT EXISTS "memory_store_tenant" (
   "store_id"     TEXT PRIMARY KEY NOT NULL,
@@ -32,9 +41,3 @@ CREATE TABLE IF NOT EXISTS "memory_store_tenant" (
 
 CREATE INDEX IF NOT EXISTS "idx_memory_store_tenant_tenant"
   ON "memory_store_tenant" ("tenant_id");
-
--- Backfill the 2 stores that exist in prod AUTH_DB today (both on
--- shard 0). Idempotent — INSERT OR IGNORE no-ops on re-run.
-INSERT OR IGNORE INTO "memory_store_tenant" (store_id, tenant_id, created_at) VALUES
-  ('memstore-ee98ketcngv07s5u', 'tn_be94edac426540e2', 1777380732000),
-  ('memstore-j11haxmw66aklmln', 'tn_d258dc516aac47c6', 1777021557000);

--- a/apps/main/src/queue/memory-events.ts
+++ b/apps/main/src/queue/memory-events.ts
@@ -15,6 +15,7 @@ import {
 } from "@open-managed-agents/memory-store";
 import { CfD1SqlClient } from "@open-managed-agents/sql-client/adapters/cf-d1";
 import { buildCfTenantDbProvider } from "@open-managed-agents/services";
+import { createCfMemoryStoreTenantIndexService } from "@open-managed-agents/tenant-dbs-store";
 
 /**
  * Cloudflare Queue consumer for R2 Event Notifications on MEMORY_BUCKET.
@@ -62,9 +63,14 @@ export async function handleMemoryEvents(
     return;
   }
 
+  // Composition root for the CF queue handler. Build the runtime-agnostic
+  // services this handler needs from CF env bindings here; pass services
+  // (ports) into the per-message processing path.
   const blobs = new CfR2BlobStore(env.MEMORY_BUCKET);
   const provider = buildCfTenantDbProvider(env);
-  const controlPlaneDb = env.ROUTER_DB ?? env.AUTH_DB;
+  const tenantIndex = createCfMemoryStoreTenantIndexService({
+    controlPlaneDb: env.ROUTER_DB ?? env.AUTH_DB,
+  });
   // Per-batch cache of store_id → SqlMemoryRepo. The repo wraps the
   // resolved per-tenant shard's SqlClient. Avoids one ROUTER_DB lookup
   // per message when a batch has many events for the same store
@@ -73,11 +79,22 @@ export async function handleMemoryEvents(
   const resolveRepo = async (storeId: string): Promise<SqlMemoryRepo> => {
     const cached = repoCache.get(storeId);
     if (cached) return cached;
-    const tenantId = await lookupTenantForStore(controlPlaneDb, storeId);
+    let tenantId: string | null = null;
+    try {
+      tenantId = await tenantIndex.lookup(storeId);
+    } catch (err) {
+      // Index lookup itself failed (control-plane DB down). Don't crash
+      // the batch — fall back to AUTH_DB. Worst case: a few writes land
+      // on the wrong shard until the control-plane recovers.
+      logWarn(
+        { op: "queue.memory_events.lookup_failed", store_id: storeId, err },
+        "memory_store_tenant lookup failed; falling back to AUTH_DB",
+      );
+    }
     if (!tenantId) {
-      // Legacy / pre-shard fallback: store_id has no entry in
-      // memory_store_tenant. All such stores live on AUTH_DB_00 (= AUTH_DB)
-      // since they were created before this index existed. Wrap and cache.
+      // Legacy / pre-shard fallback: store_id has no entry in the index.
+      // All such stores live on AUTH_DB_00 (= AUTH_DB) since they were
+      // created before this index existed. Wrap and cache.
       const fallback = new SqlMemoryRepo(new CfD1SqlClient(env.AUTH_DB));
       repoCache.set(storeId, fallback);
       return fallback;
@@ -105,34 +122,6 @@ export async function handleMemoryEvents(
       );
       message.retry();
     }
-  }
-}
-
-/**
- * Look up which tenant owns a memory store. Reads from ROUTER_DB.memory_store_tenant
- * (populated synchronously at memory store creation in routes/memory.ts).
- * Returns null for stores that pre-date the index — caller falls back
- * to AUTH_DB.
- */
-async function lookupTenantForStore(
-  controlPlaneDb: D1Database,
-  storeId: string,
-): Promise<string | null> {
-  try {
-    const row = await controlPlaneDb
-      .prepare("SELECT tenant_id FROM memory_store_tenant WHERE store_id = ?")
-      .bind(storeId)
-      .first<{ tenant_id: string }>();
-    return row?.tenant_id ?? null;
-  } catch (err) {
-    // ROUTER_DB unreachable or table missing (legacy deploy). Fall back —
-    // the caller treats null as "use AUTH_DB". Don't throw, that would
-    // retry the whole batch indefinitely.
-    logWarn(
-      { op: "queue.memory_events.lookup_failed", store_id: storeId, err },
-      "memory_store_tenant lookup failed; falling back to AUTH_DB",
-    );
-    return null;
   }
 }
 

--- a/apps/main/src/routes/memory.ts
+++ b/apps/main/src/routes/memory.ts
@@ -77,21 +77,13 @@ app.post("/", async (c) => {
       description: body.description,
     });
 
-    // Index store_id → tenant_id in ROUTER_DB so the memory queue
-    // consumer (apps/main/src/queue/memory-events.ts) can route R2
-    // events to the right shard. R2 events carry only the storage key
-    // (`<store_id>/<path>`) — no tenant_id — so without this index the
-    // consumer would write the memories UPSERT to the wrong shard.
-    // Falls back to AUTH_DB when ROUTER_DB binding is absent.
-    const controlPlaneDb = c.env.ROUTER_DB ?? c.env.AUTH_DB;
-    await controlPlaneDb
-      .prepare(
-        `INSERT OR IGNORE INTO memory_store_tenant
-           (store_id, tenant_id, created_at)
-         VALUES (?, ?, ?)`,
-      )
-      .bind(store.id, t, Date.now())
-      .run();
+    // Index store_id → tenant_id so the memory queue consumer
+    // (apps/main/src/queue/memory-events.ts) can route R2 events to
+    // the right shard. R2 events carry only the storage key
+    // (`<store_id>/<path>`) — no tenant_id — so without this index
+    // the consumer would write the memories UPSERT to the wrong shard.
+    // The service abstracts the underlying control-plane DB.
+    await c.var.services.memoryStoreTenantIndex.register(store.id, t);
 
     return c.json(toApiStore(store), 201);
   } catch (err) {

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -86,8 +86,10 @@ import {
 import {
   TenantShardDirectoryService,
   ShardPoolService,
+  MemoryStoreTenantIndexService,
   createCfTenantShardDirectoryService,
   createCfShardPoolService,
+  createCfMemoryStoreTenantIndexService,
 } from "@open-managed-agents/tenant-dbs-store";
 import { type BlobStore, blobStoreFromR2 } from "@open-managed-agents/blob-store";
 import { type KvStore, CfKvStore } from "@open-managed-agents/kv-store";
@@ -121,6 +123,11 @@ export interface Services {
   /** Control-plane: per-shard status / capacity / tenant count. Used for
    *  shard selection at sign-up + capacity monitoring. */
   shardPool: ShardPoolService;
+  /** Control-plane: memory_store_id → tenant_id index. Populated on
+   *  store creation, consumed by the R2 memory-events queue consumer to
+   *  resolve the per-tenant shard from an R2 storage key (which carries
+   *  no tenant_id). */
+  memoryStoreTenantIndex: MemoryStoreTenantIndexService;
   /**
    * File-bytes blob store (R2 FILES_BUCKET in CF, local-FS / S3 in Node).
    * Null when the underlying storage isn't configured — routes that need it
@@ -254,6 +261,9 @@ export function buildServices(env: Env, db: D1Database): Services {
       controlPlaneDb: env.ROUTER_DB ?? env.AUTH_DB,
     }),
     shardPool: createCfShardPoolService({
+      controlPlaneDb: env.ROUTER_DB ?? env.AUTH_DB,
+    }),
+    memoryStoreTenantIndex: createCfMemoryStoreTenantIndexService({
       controlPlaneDb: env.ROUTER_DB ?? env.AUTH_DB,
     }),
     // File blob storage. CF: R2 binding; self-host: S3 / local-FS adapter.

--- a/packages/tenant-dbs-store/src/adapters/index.ts
+++ b/packages/tenant-dbs-store/src/adapters/index.ts
@@ -4,14 +4,17 @@
 
 export { SqlTenantShardDirectoryRepo } from "./sql-tenant-shard-repo";
 export { SqlShardPoolRepo } from "./sql-shard-pool-repo";
+export { SqlMemoryStoreTenantIndexRepo } from "./sql-memory-store-tenant-index-repo";
 
 import { SqlTenantShardDirectoryRepo } from "./sql-tenant-shard-repo";
 import { SqlShardPoolRepo } from "./sql-shard-pool-repo";
+import { SqlMemoryStoreTenantIndexRepo } from "./sql-memory-store-tenant-index-repo";
 import { CfD1SqlClient } from "@open-managed-agents/sql-client/adapters/cf-d1";
 import type { SqlClient } from "@open-managed-agents/sql-client";
 import {
   TenantShardDirectoryService,
   ShardPoolService,
+  MemoryStoreTenantIndexService,
 } from "../service";
 
 export function createCfTenantShardDirectoryService(deps: {
@@ -28,6 +31,14 @@ export function createCfShardPoolService(deps: {
   return new ShardPoolService(new SqlShardPoolRepo(new CfD1SqlClient(deps.controlPlaneDb)));
 }
 
+export function createCfMemoryStoreTenantIndexService(deps: {
+  controlPlaneDb: D1Database;
+}): MemoryStoreTenantIndexService {
+  return new MemoryStoreTenantIndexService(
+    new SqlMemoryStoreTenantIndexRepo(new CfD1SqlClient(deps.controlPlaneDb)),
+  );
+}
+
 export function createSqliteTenantShardDirectoryService(deps: {
   client: SqlClient;
 }): TenantShardDirectoryService {
@@ -38,4 +49,10 @@ export function createSqliteShardPoolService(deps: {
   client: SqlClient;
 }): ShardPoolService {
   return new ShardPoolService(new SqlShardPoolRepo(deps.client));
+}
+
+export function createSqliteMemoryStoreTenantIndexService(deps: {
+  client: SqlClient;
+}): MemoryStoreTenantIndexService {
+  return new MemoryStoreTenantIndexService(new SqlMemoryStoreTenantIndexRepo(deps.client));
 }

--- a/packages/tenant-dbs-store/src/adapters/sql-memory-store-tenant-index-repo.ts
+++ b/packages/tenant-dbs-store/src/adapters/sql-memory-store-tenant-index-repo.ts
@@ -1,0 +1,57 @@
+import type {
+  MemoryStoreTenantIndexRepo,
+  MemoryStoreTenantRow,
+} from "../ports";
+import type { SqlClient } from "@open-managed-agents/sql-client";
+
+interface Row {
+  store_id: string;
+  tenant_id: string;
+  created_at: number;
+}
+
+/**
+ * SQL adapter for the memory_store → tenant index. Same shape as the
+ * sibling tenant_shard / shard_pool repos: depends only on the SqlClient
+ * port, no CF-specific types. Schema lives in
+ * apps/main/migrations-router/0002_memory_store_tenant.sql.
+ */
+export class SqlMemoryStoreTenantIndexRepo implements MemoryStoreTenantIndexRepo {
+  constructor(private readonly db: SqlClient) {}
+
+  async lookup(storeId: string): Promise<string | null> {
+    const row = await this.db
+      .prepare(`SELECT tenant_id FROM memory_store_tenant WHERE store_id = ?`)
+      .bind(storeId)
+      .first<{ tenant_id: string }>();
+    return row?.tenant_id ?? null;
+  }
+
+  async register(storeId: string, tenantId: string, nowMs: number): Promise<void> {
+    // INSERT OR IGNORE: a retried createStore must NOT re-route the
+    // store to a different tenant. First registration wins.
+    await this.db
+      .prepare(
+        `INSERT OR IGNORE INTO memory_store_tenant
+           (store_id, tenant_id, created_at)
+         VALUES (?, ?, ?)`,
+      )
+      .bind(storeId, tenantId, nowMs)
+      .run();
+  }
+
+  async listAll(): Promise<readonly MemoryStoreTenantRow[]> {
+    const { results } = await this.db
+      .prepare(`SELECT * FROM memory_store_tenant ORDER BY created_at`)
+      .all<Row>();
+    return (results ?? []).map(toDomain);
+  }
+}
+
+function toDomain(row: Row): MemoryStoreTenantRow {
+  return {
+    storeId: row.store_id,
+    tenantId: row.tenant_id,
+    createdAt: row.created_at,
+  };
+}

--- a/packages/tenant-dbs-store/src/index.ts
+++ b/packages/tenant-dbs-store/src/index.ts
@@ -20,8 +20,11 @@ export * from "./service";
 export {
   SqlTenantShardDirectoryRepo,
   SqlShardPoolRepo,
+  SqlMemoryStoreTenantIndexRepo,
   createCfTenantShardDirectoryService,
   createCfShardPoolService,
+  createCfMemoryStoreTenantIndexService,
   createSqliteTenantShardDirectoryService,
   createSqliteShardPoolService,
+  createSqliteMemoryStoreTenantIndexService,
 } from "./adapters";

--- a/packages/tenant-dbs-store/src/ports.ts
+++ b/packages/tenant-dbs-store/src/ports.ts
@@ -71,3 +71,31 @@ export interface ShardPoolRepo {
   incrementTenantCount(bindingName: string): Promise<void>;
   listAll(): Promise<readonly ShardPoolRow[]>;
 }
+
+// ─── Memory store → tenant index ────────────────────────────────────────
+//
+// Lives in the same control-plane DB as tenant_shard / shard_pool.
+// Populated synchronously when a memory store is created (REST POST
+// /v1/memory). Consumed by the R2 memory-events queue consumer to
+// resolve which AUTH_DB_NN shard owns a given memory_store — R2 events
+// carry only the storage key (`<store_id>/<path>`), no tenant_id, so
+// without this index the consumer would have to fall back to env.AUTH_DB
+// and write cross-shard ghost rows for any tenant not on shard 0.
+
+export interface MemoryStoreTenantRow {
+  storeId: string;
+  tenantId: string;
+  createdAt: number;
+}
+
+export interface MemoryStoreTenantIndexRepo {
+  /** O(1) lookup. Hot path — every R2 memory event hits this. Returns
+   *  null for store_ids that pre-date the index (caller treats as
+   *  "use the default shard"). */
+  lookup(storeId: string): Promise<string | null>;
+  /** Idempotent: re-running create-store on the same store_id MUST NOT
+   *  re-route to a different tenant. PK collision is a no-op. */
+  register(storeId: string, tenantId: string, nowMs: number): Promise<void>;
+  /** For admin views / backfill scripts. */
+  listAll(): Promise<readonly MemoryStoreTenantRow[]>;
+}

--- a/packages/tenant-dbs-store/src/service.ts
+++ b/packages/tenant-dbs-store/src/service.ts
@@ -1,4 +1,6 @@
 import type {
+  MemoryStoreTenantIndexRepo,
+  MemoryStoreTenantRow,
   NewShardPool,
   NewTenantShard,
   ShardPoolRepo,
@@ -67,6 +69,33 @@ export class ShardPoolService {
   }
 
   listAll(): Promise<readonly ShardPoolRow[]> {
+    return this.repo.listAll();
+  }
+}
+
+/**
+ * Service wrapper around MemoryStoreTenantIndexRepo. Used by:
+ *   - REST POST /v1/memory (route handler) to register on store creation
+ *   - apps/main/src/queue/memory-events.ts to look up tenant from
+ *     R2 event's storage key
+ *
+ * Both paths consume only this service — no direct SQL, no D1Database
+ * in the call chain. CF wiring is in packages/services.
+ */
+export class MemoryStoreTenantIndexService {
+  constructor(private readonly repo: MemoryStoreTenantIndexRepo) {}
+
+  /** Returns null for legacy stores not in the index — caller falls back. */
+  lookup(storeId: string): Promise<string | null> {
+    return this.repo.lookup(storeId);
+  }
+
+  /** Idempotent — safe to call from a retry on store creation. */
+  register(storeId: string, tenantId: string, nowMs: number = Date.now()): Promise<void> {
+    return this.repo.register(storeId, tenantId, nowMs);
+  }
+
+  listAll(): Promise<readonly MemoryStoreTenantRow[]> {
     return this.repo.listAll();
   }
 }


### PR DESCRIPTION
Replaces raw SQL on memory_store_tenant in app code with proper port/adapter/service following the existing shard_pool / tenant_shard pattern. Also: shard_pool seed reduced to mandatory baseline (AUTH_DB_00) — adding shards is runtime INSERT, not migration edit. See commit.