### PR TITLE
feat(github): network-layer credential proxy + dynamic session resources UI

### DIFF
--- a/apps/agent/src/oma-sandbox.ts
+++ b/apps/agent/src/oma-sandbox.ts
@@ -307,8 +307,92 @@ const r2OutboundPassthrough = async (request: Request): Promise<Response> => {
   );
 };
 
+// Per-host network-layer GitHub credential injection (γ proxy).
+//
+// Sandbox containers fire plain HTTPS at github.com (smart-HTTP git
+// protocol) and api.github.com (REST/GraphQL) with no Authorization
+// header — neither ~/.git-credentials nor GITHUB_TOKEN env exists in the
+// sandbox by design. We resolve the right token via main worker RPC
+// (per-session, per-repo path matching with first-resource fallback),
+// inject Authorization with the host-appropriate scheme, and forward.
+//
+// Auth scheme is host-specific:
+//   - github.com   → Basic base64("x-access-token:<token>") (smart-HTTP)
+//   - api.github.com → Bearer <token> (REST/GraphQL)
+//
+// Pass-through (no auth header added) when:
+//   - the session has no github_repository resources
+//   - the per-session credential lookup fails
+//
+// Multi-repo fallback: if the request URL doesn't match any mounted
+// repo's owner/repo slug, we use the first declared repo's token.
+// Known limitation: cross-token mutations (graphql to repo B with token
+// A's scope) return GitHub's standard error envelope; we don't retry.
+const githubAuthHandler = async (
+  request: Request,
+  env: unknown,
+  ctx: SdkContext<OutboundContextParams>,
+): Promise<Response> => {
+  const url = new URL(request.url);
+  const params = ctx.params ?? {};
+  const e = env as Env;
+
+  let cred: { scheme: "Basic" | "Bearer"; token: string; slug: string } | null = null;
+  if (params.tenantId && params.sessionId && e.MAIN_MCP) {
+    try {
+      cred = await e.MAIN_MCP.lookupGithubCredential({
+        tenantId: params.tenantId,
+        sessionId: params.sessionId,
+        hostname: url.hostname,
+        pathname: url.pathname,
+      });
+    } catch (err) {
+      console.error(
+        `[oma-sandbox] lookupGithubCredential threw host=${url.hostname}: ${(err as Error)?.message ?? err}`,
+      );
+      // Fall through unauthenticated — same as legacy behaviour for
+      // RPC failure; agent sees 401, can retry.
+    }
+  }
+
+  const outHeaders = new Headers(request.headers);
+  for (const h of HOP_BY_HOP_OR_CF_HEADERS) outHeaders.delete(h);
+  if (cred) {
+    const value = cred.scheme === "Basic"
+      ? `Basic ${btoa(`x-access-token:${cred.token}`)}`
+      : `Bearer ${cred.token}`;
+    outHeaders.set("authorization", value);
+  }
+
+  let upstreamReq: Request;
+  if (request.method === "GET" || request.method === "HEAD") {
+    upstreamReq = new Request(request.url, {
+      method: request.method,
+      headers: outHeaders,
+      redirect: "manual",
+    });
+  } else {
+    // Materialize body — Workers needs known-length to set Content-Length
+    // (same constraint as injectVaultCredsHandler / r2OutboundPassthrough).
+    const bodyBytes = await request.arrayBuffer();
+    upstreamReq = new Request(request.url, {
+      method: request.method,
+      headers: outHeaders,
+      body: bodyBytes,
+      redirect: "manual",
+    });
+  }
+
+  console.log(
+    `[oma-sandbox] github host=${url.hostname} method=${request.method} cred=${cred ? cred.slug : "none"}`,
+  );
+  return fetch(upstreamReq);
+};
+
 (OmaSandbox as unknown as {
-  outboundByHost: Record<string, (req: Request) => Promise<Response>>;
+  outboundByHost: Record<string, (req: Request, env: unknown, ctx: SdkContext<OutboundContextParams>) => Promise<Response>>;
 }).outboundByHost = {
   "*.r2.cloudflarestorage.com": r2OutboundPassthrough,
+  "github.com": githubAuthHandler,
+  "api.github.com": githubAuthHandler,
 };

--- a/apps/agent/src/runtime/resource-mounter.ts
+++ b/apps/agent/src/runtime/resource-mounter.ts
@@ -31,7 +31,6 @@ export async function mountResources(
   memoryStoreLookup?: (storeId: string) => Promise<{ name: string } | null>,
 ): Promise<void> {
   let hasGitRepo = false;
-  let lastGitToken: string | null = null;
   // Buffer env vars across the loop so we make a single setEnvVars call
   // at the end. setEnvVars on most sandbox implementations is a network
   // round-trip per call; one batched call beats one-per-resource.
@@ -46,10 +45,12 @@ export async function mountResources(
         case "github_repository":
         case "github_repo": {
           hasGitRepo = true;
-          const resId = res.id as string;
-          const token = resId ? secretStore?.get(resId) || null : null;
-          if (token) lastGitToken = token;
-          await mountGitRepo(sandbox, res, token);
+          // Token is no longer pulled into the sandbox — the agent worker's
+          // outbound proxy injects Authorization on every github.com /
+          // api.github.com call by RPC-ing main per request. mountGitRepo
+          // therefore clones / fetches with no auth surface inside the
+          // container; the proxy makes those calls succeed.
+          await mountGitRepo(sandbox, res);
           break;
         }
         case "memory_store":
@@ -79,11 +80,6 @@ export async function mountResources(
 
   // kv reserved for future use (memory_store, etc.); intentionally unused for files now.
   void kv;
-
-  // Register last token for gh CLI (gh only supports one GH_TOKEN)
-  if (lastGitToken && sandbox.registerCommandSecrets) {
-    sandbox.registerCommandSecrets("gh", { GITHUB_TOKEN: lastGitToken, GH_TOKEN: lastGitToken });
-  }
 
   // Apply collected env vars in a single call. setEnvVars is optional on
   // SandboxExecutor (some test fakes omit it) — silently skip when
@@ -190,37 +186,34 @@ async function mountMemoryStore(
 async function mountGitRepo(
   sandbox: SandboxExecutor,
   res: Record<string, unknown>,
-  token: string | null,
 ): Promise<void> {
   const repoUrl = res.url as string || res.repo_url as string;
   if (!repoUrl) return;
 
   const targetDir = (res.mount_path as string) || "/workspace";
 
-  // Store credential BEFORE clone so git can auth automatically
-  if (token) {
-    // Write credential to .git-credentials (per-repo, per-host)
-    // Format: https://user:token@host/path.git (one per line)
-    try {
-      const url = new URL(repoUrl);
-      const credLine = `https://x-access-token:${token}@${url.hostname}${url.pathname}`;
-      await sandbox.exec(`git config --global credential.helper store`, 5000);
-      const writeResult = await sandbox.exec(`echo '${credLine.replace(/'/g, "'\\''")}' >> $HOME/.git-credentials && chmod 600 $HOME/.git-credentials && echo CRED_OK`, 5000);
-      if (!writeResult.includes("CRED_OK")) {
-        console.error("[resource-mounter] credential write failed:", writeResult);
-      }
-    } catch (err) {
-      console.error("[resource-mounter] credential setup error:", err);
-    }
-  }
+  // Disable interactive credential prompting BEFORE any git network call.
+  // The network-layer proxy (apps/agent/src/oma-sandbox.ts githubAuthHandler)
+  // injects Authorization on every github.com / api.github.com request, so
+  // the happy path never sees a 401 inside git. If the proxy fails to
+  // resolve a token (no github_repository resource matched, RPC error, …),
+  // git would otherwise hang waiting for stdin or invoke a GUI askpass —
+  // /bin/true returns immediately so git fails fast and surfaces an error
+  // to the agent. No credential helper is configured at all on purpose:
+  // ~/.git-credentials and credential.helper are intentionally unset so
+  // the only auth path is the worker proxy.
+  await sandbox.exec(
+    `git config --global core.askpass /bin/true && ` +
+    `git config --global credential.helper "" && ` +
+    `git config --global --unset-all credential.helper 2>/dev/null; true`,
+    5000,
+  );
 
-  // Clone repo
+  // Clone the repo's default branch first. Branch checkout is handled
+  // separately below so we can fall back to creating a new local branch
+  // when the requested name doesn't exist on the remote.
   if (sandbox.gitCheckout) {
-    const checkout = res.checkout as { type?: string; name?: string; sha?: string } | undefined;
-    await sandbox.gitCheckout(repoUrl, {
-      branch: checkout?.type === "branch" ? checkout.name : undefined,
-      targetDir,
-    });
+    await sandbox.gitCheckout(repoUrl, { targetDir });
   } else {
     await sandbox.exec(`git clone ${repoUrl} ${targetDir} 2>&1`, 120000);
   }
@@ -231,9 +224,20 @@ async function mountGitRepo(
     10000
   );
 
-  // Handle checkout (commit SHA)
   const checkout = res.checkout as { type?: string; name?: string; sha?: string } | undefined;
-  if (checkout?.type === "commit" && checkout.sha) {
+  if (checkout?.type === "branch" && checkout.name) {
+    // Try fetch + checkout (DWIM creates a local tracking branch when
+    // origin/<name> exists). If the remote doesn't have the branch,
+    // create it locally off the just-cloned default HEAD instead of
+    // failing the whole mount.
+    const branch = checkout.name.replace(/[^A-Za-z0-9._/-]/g, "");
+    if (branch) {
+      await sandbox.exec(
+        `cd ${targetDir} && (git fetch origin ${branch}:refs/remotes/origin/${branch} 2>/dev/null && git checkout ${branch}) || git checkout -b ${branch}`,
+        60000,
+      );
+    }
+  } else if (checkout?.type === "commit" && checkout.sha) {
     await sandbox.exec(`cd ${targetDir} && git checkout ${checkout.sha}`, 30000);
   }
 }

--- a/apps/console/package.json
+++ b/apps/console/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "dev:staging": "VITE_API_TARGET=https://app.staging.openma.dev vite",
     "build": "vite build",
     "preview": "vite preview"
   },

--- a/apps/console/src/components/Layout.tsx
+++ b/apps/console/src/components/Layout.tsx
@@ -12,6 +12,7 @@ import {
   ChevronDownIcon,
   DashboardIcon,
   EnvIcon,
+  FilesIcon,
   GitHubIcon,
   LinearIcon,
   MemoryIcon,
@@ -48,6 +49,7 @@ const navGroups: NavGroup[] = [
     items: [
       { to: "/agents", label: "Agents", icon: AgentIcon },
       { to: "/sessions", label: "Sessions", icon: SessionsIcon },
+      { to: "/files", label: "Files", icon: FilesIcon },
       { to: "/evals", label: "Eval Runs", icon: SessionsIcon },
     ],
   },

--- a/apps/console/src/components/icons.tsx
+++ b/apps/console/src/components/icons.tsx
@@ -87,6 +87,10 @@ export function RuntimesIcon({ className }: IconProps) {
   return <StrokeIcon className={className} d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />;
 }
 
+export function FilesIcon({ className }: IconProps) {
+  return <StrokeIcon className={className} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />;
+}
+
 // ─── Brand marks (simple-icons paths, full 0..24 coverage, fill-rendered) ─
 
 export function LinearIcon({ className }: IconProps) {

--- a/apps/console/src/main.tsx
+++ b/apps/console/src/main.tsx
@@ -11,6 +11,7 @@ import { AgentsList } from "./pages/AgentsList";
 import { AgentDetail } from "./pages/AgentDetail";
 import { SessionsList } from "./pages/SessionsList";
 import { SessionDetail } from "./pages/SessionDetail";
+import { FilesList } from "./pages/FilesList";
 import { EnvironmentsList } from "./pages/EnvironmentsList";
 import { EnvironmentDetail } from "./pages/EnvironmentDetail";
 import { VaultsList } from "./pages/VaultsList";
@@ -57,6 +58,7 @@ createRoot(document.getElementById("root")!).render(
             <Route path="agents/:id" element={<AgentDetail />} />
             <Route path="sessions" element={<SessionsList />} />
             <Route path="sessions/:id" element={<SessionDetail />} />
+            <Route path="files" element={<FilesList />} />
             <Route path="evals" element={<EvalRunsList />} />
             <Route path="evals/:id" element={<EvalRunDetail />} />
             <Route path="environments" element={<EnvironmentsList />} />

--- a/apps/console/src/pages/FilesList.tsx
+++ b/apps/console/src/pages/FilesList.tsx
@@ -1,0 +1,239 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router";
+import { useApi, getActiveTenantId } from "../lib/api";
+import { useToast } from "../components/Toast";
+import { ListPage } from "../components/ListPage";
+
+interface FileRecord {
+  id: string;
+  type?: "file";
+  filename: string;
+  media_type: string;
+  size_bytes: number;
+  scope_id?: string;
+  downloadable?: boolean;
+  created_at: string;
+}
+
+interface ListResponse {
+  data: FileRecord[];
+  has_more?: boolean;
+  first_id?: string;
+  last_id?: string;
+}
+
+const PAGE_SIZE = 50;
+
+export function FilesList() {
+  const { api } = useApi();
+  const { toast } = useToast();
+  const [items, setItems] = useState<FileRecord[]>([]);
+  const [hasMore, setHasMore] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [scopeFilter, setScopeFilter] = useState("");
+  const [search, setSearch] = useState("");
+
+  const buildUrl = (beforeId?: string) => {
+    const sp = new URLSearchParams();
+    sp.set("limit", String(PAGE_SIZE));
+    if (scopeFilter) sp.set("scope_id", scopeFilter);
+    if (beforeId) sp.set("before_id", beforeId);
+    return `/v1/files?${sp.toString()}`;
+  };
+
+  const refresh = async () => {
+    setLoading(true);
+    try {
+      const res = await api<ListResponse>(buildUrl());
+      setItems(res.data);
+      setHasMore(!!res.has_more);
+    } catch {
+      // api() already toasted; empty list communicates the failure.
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const loadMore = async () => {
+    const lastId = items[items.length - 1]?.id;
+    if (!lastId || loadingMore) return;
+    setLoadingMore(true);
+    try {
+      const res = await api<ListResponse>(buildUrl(lastId));
+      setItems((prev) => [...prev, ...res.data]);
+      setHasMore(!!res.has_more);
+    } catch {
+      // toasted by api()
+    } finally {
+      setLoadingMore(false);
+    }
+  };
+
+  useEffect(() => {
+    void refresh();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [scopeFilter]);
+
+  // Direct fetch for binary download — api() always parses JSON, and we need
+  // the raw blob. Mirror its tenant-pin header so downloads honor the active
+  // workspace, not the user's default tenant.
+  const download = async (f: FileRecord) => {
+    try {
+      const activeTenant = getActiveTenantId();
+      const res = await fetch(`/v1/files/${f.id}/content`, {
+        credentials: "include",
+        headers: activeTenant ? { "x-active-tenant": activeTenant } : {},
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        const message = (body as { error?: string }).error || `HTTP ${res.status}`;
+        toast(`Download failed: ${message}`, "error");
+        return;
+      }
+      const blob = await res.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = f.filename;
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch (e) {
+      toast(`Download failed: ${e instanceof Error ? e.message : "network error"}`, "error");
+    }
+  };
+
+  const remove = async (f: FileRecord) => {
+    if (!confirm(`Delete "${f.filename}"? The R2 object and metadata both go. This cannot be undone.`)) return;
+    try {
+      await api(`/v1/files/${f.id}`, { method: "DELETE" });
+      setItems((prev) => prev.filter((x) => x.id !== f.id));
+    } catch {
+      // toasted
+    }
+  };
+
+  // Search is client-side over the loaded page — backend doesn't index by
+  // filename and the upload API has no name filter. Operators who need a
+  // file from the long tail filter by scope_id (server-side) first.
+  const filtered = search
+    ? items.filter((f) => f.filename.toLowerCase().includes(search.toLowerCase()))
+    : items;
+
+  return (
+    <ListPage<FileRecord>
+      title="Files"
+      subtitle={
+        <>
+          Tenant-scoped file storage (<code className="text-xs">/v1/files</code>). Used by agents for inputs, attachments, and session outputs.
+        </>
+      }
+      searchPlaceholder="Filter loaded files by name…"
+      searchValue={search}
+      onSearchChange={setSearch}
+      filters={
+        <input
+          type="text"
+          value={scopeFilter}
+          onChange={(e) => setScopeFilter(e.target.value)}
+          placeholder="Filter by scope (session ID)…"
+          className="border border-border rounded-md px-3 py-1.5 text-sm bg-bg text-fg placeholder:text-fg-subtle focus:border-brand focus:outline-none transition-colors w-full sm:w-72"
+        />
+      }
+      data={filtered}
+      loading={loading}
+      hasMore={hasMore && !search}
+      onLoadMore={loadMore}
+      loadingMore={loadingMore}
+      getRowKey={(f) => f.id}
+      emptyTitle={scopeFilter ? "No files in this scope" : "No files yet"}
+      emptySubtitle={
+        scopeFilter
+          ? "Try clearing the scope filter, or check the session id."
+          : <>Upload via <code className="text-xs">POST /v1/files</code> or the AMA SDK <code className="text-xs">client.beta.files.create()</code>.</>
+      }
+      columns={[
+        {
+          key: "filename",
+          label: "Filename",
+          className: "font-medium",
+          render: (f) => (
+            <span title={f.filename} className="truncate inline-block max-w-[280px] align-bottom">
+              {f.filename}
+            </span>
+          ),
+        },
+        {
+          key: "id",
+          label: "ID",
+          className: "font-mono text-xs text-fg-muted truncate max-w-[160px]",
+          render: (f) => <span title={f.id}>{f.id}</span>,
+        },
+        {
+          key: "media_type",
+          label: "Type",
+          className: "text-fg-muted text-xs",
+        },
+        {
+          key: "size_bytes",
+          label: "Size",
+          className: "text-fg-muted text-xs tabular-nums",
+          render: (f) => formatBytes(f.size_bytes),
+        },
+        {
+          key: "scope",
+          label: "Scope",
+          className: "text-fg-muted text-xs font-mono",
+          render: (f) =>
+            f.scope_id ? (
+              <Link
+                to={`/sessions/${f.scope_id}`}
+                onClick={(e) => e.stopPropagation()}
+                className="text-brand hover:underline"
+              >
+                {f.scope_id}
+              </Link>
+            ) : (
+              <span className="text-fg-subtle">—</span>
+            ),
+        },
+        {
+          key: "created",
+          label: "Created",
+          className: "text-fg-muted text-xs whitespace-nowrap",
+          render: (f) => new Date(f.created_at).toLocaleString(),
+        },
+        {
+          key: "actions",
+          label: "",
+          className: "text-right whitespace-nowrap",
+          render: (f) => (
+            <>
+              {f.downloadable && (
+                <button
+                  onClick={(e) => { e.stopPropagation(); void download(f); }}
+                  className="text-xs text-fg-muted hover:text-fg mr-3"
+                >
+                  Download
+                </button>
+              )}
+              <button
+                onClick={(e) => { e.stopPropagation(); void remove(f); }}
+                className="text-xs text-danger hover:text-danger/80"
+              >
+                Delete
+              </button>
+            </>
+          ),
+        },
+      ]}
+    />
+  );
+}
+
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  if (n < 1024 * 1024 * 1024) return `${(n / 1024 / 1024).toFixed(1)} MB`;
+  return `${(n / 1024 / 1024 / 1024).toFixed(2)} GB`;
+}

--- a/apps/console/src/pages/SessionsList.tsx
+++ b/apps/console/src/pages/SessionsList.tsx
@@ -15,6 +15,62 @@ interface Session {
   metadata?: Record<string, unknown>;
 }
 interface Vault { id: string; name: string; }
+interface FilePick { id: string; filename: string; size_bytes: number; }
+interface MemoryStorePick { id: string; name: string; }
+
+/** Discriminated union for one row in the dynamic Resources list. Mapped
+ *  to the wire `{type, ...}` resource object at submit time (see `create`). */
+type ResourceRow =
+  | { kind: "github"; url: string; token: string; checkout_type: "none" | "branch" | "commit"; checkout_name: string; mount_path: string }
+  | { kind: "file"; file_id: string; mount_path: string }
+  | { kind: "memory_store"; memory_store_id: string; mount_path: string; access: "read_write" | "read_only" }
+  | { kind: "env"; name: string; value: string };
+
+function blankResource(kind: ResourceRow["kind"]): ResourceRow {
+  switch (kind) {
+    case "github": return { kind, url: "", token: "", checkout_type: "none", checkout_name: "", mount_path: "" };
+    case "file": return { kind, file_id: "", mount_path: "" };
+    case "memory_store": return { kind, memory_store_id: "", mount_path: "", access: "read_write" };
+    case "env": return { kind, name: "", value: "" };
+  }
+}
+
+function kindLabel(kind: ResourceRow["kind"]): string {
+  switch (kind) {
+    case "github": return "GitHub repository";
+    case "file": return "File";
+    case "memory_store": return "Memory store";
+    case "env": return "Environment variable";
+  }
+}
+
+/** Best-effort `<repo-name>` extraction from GitHub URL forms. Used to
+ *  derive the default mount path /workspace/<repo-name>. Returns null when
+ *  the URL doesn't look like GitHub (caller falls back to /workspace). */
+function parseGitHubRepoName(url: string): string | null {
+  const trimmed = url.trim().replace(/\.git$/, "");
+  if (!trimmed) return null;
+  // Full URL: https://github.com/owner/repo
+  try {
+    const u = new URL(trimmed);
+    if (u.hostname !== "github.com" && u.hostname !== "www.github.com") return null;
+    const parts = u.pathname.replace(/^\/+/, "").split("/").filter(Boolean);
+    return parts[1] || null;
+  } catch {
+    // SSH: git@github.com:owner/repo
+    const ssh = trimmed.match(/^git@github\.com:[^/]+\/([^/]+)$/);
+    if (ssh) return ssh[1];
+    // Bare: owner/repo
+    const bare = trimmed.match(/^[^/]+\/([^/]+)$/);
+    if (bare) return bare[1];
+    return null;
+  }
+}
+
+function defaultMountPath(githubUrl: string): string {
+  const name = parseGitHubRepoName(githubUrl);
+  return name ? `/workspace/${name}` : "/workspace";
+}
 
 /** Tiny "🔗 Linear" pill shown when a session was triggered by a Linear webhook. */
 function LinearBadge({ metadata }: { metadata?: Record<string, unknown> }) {
@@ -91,24 +147,23 @@ export function SessionsList() {
   } | null>(null);
   const [envs, setEnvs] = useState<Array<{ id: string; name: string }>>([]);
   const [vaults, setVaults] = useState<Vault[]>([]);
+  const [files, setFiles] = useState<FilePick[]>([]);
+  const [memoryStores, setMemoryStores] = useState<MemoryStorePick[]>([]);
   const [, setAuxLoading] = useState(true);
   const [showCreate, setShowCreate] = useState(false);
   const [form, setForm] = useState({
     agent: "", environment_id: "", title: "",
     vault_ids: [] as string[],
-    github_url: "", github_token: "", github_branch: "",
-    env_vars: [{ name: "", value: "" }],
+    resources: [] as ResourceRow[],
   });
-  // Per-row toggle for masking the env value input. Default: masked. We
-  // intentionally use a text input + a visual mask via the toggle (rather
-  // than type="password") so the UI stops implying that the value is
-  // encrypted at rest — env values are stored alongside other session
-  // resources without app-level encryption today (see the "env" type
-  // rename in api-types/types.ts:801 for the matching back-end change).
-  const [revealedEnvIdx, setRevealedEnvIdx] = useState<Set<number>>(new Set());
-  const toggleEnvReveal = (idx: number) => setRevealedEnvIdx((prev) => {
+  // Per-field reveal toggle for any masked input (env value, github token).
+  // Keyed by `${idx}:${field}`. We intentionally don't try to keep stale
+  // entries valid across resource list mutations — adding/removing a row
+  // just clears the set, which costs at worst one re-click.
+  const [revealedSecrets, setRevealedSecrets] = useState<Set<string>>(new Set());
+  const toggleReveal = (key: string) => setRevealedSecrets((prev) => {
     const next = new Set(prev);
-    if (next.has(idx)) next.delete(idx); else next.add(idx);
+    if (next.has(key)) next.delete(key); else next.add(key);
     return next;
   });
 
@@ -136,14 +191,18 @@ export function SessionsList() {
   const loadAux = async () => {
     setAuxLoading(true);
     try {
-      const [a, e, v] = await Promise.all([
+      const [a, e, v, f, m] = await Promise.all([
         api<{ data: Array<{ id: string; name: string }> }>("/v1/agents?limit=200"),
         api<{ data: Array<{ id: string; name: string }> }>("/v1/environments?limit=200"),
         api<{ data: Vault[] }>("/v1/vaults?limit=200").catch(() => ({ data: [] })),
+        api<{ data: FilePick[] }>("/v1/files?limit=200").catch(() => ({ data: [] })),
+        api<{ data: MemoryStorePick[] }>("/v1/memory_stores").catch(() => ({ data: [] })),
       ]);
       setAgents(a.data);
       setEnvs(e.data);
       setVaults(v.data);
+      setFiles(f.data);
+      setMemoryStores(m.data);
     } catch {}
     setAuxLoading(false);
   };
@@ -160,23 +219,57 @@ export function SessionsList() {
     selectedAgentDetail ?? agents.find((a) => a.id === form.agent);
   const isLocalRuntime = !!selectedAgent?.runtime_binding;
 
+  // Per-row validation for the Create button. Only github currently has
+  // hard-required fields beyond the type picker (URL + token); the other
+  // kinds are skip-on-incomplete during submit.
+  const resourcesValid = form.resources.every((r) => {
+    if (r.kind === "github") return !!r.url && !!r.token;
+    return true;
+  });
+
   const create = async () => {
     try {
       const resources: Array<Record<string, unknown>> = [];
-
-      if (form.github_url) {
-        const res: Record<string, unknown> = { type: "github_repository", url: form.github_url };
-        if (form.github_token) res.authorization_token = form.github_token;
-        if (form.github_branch) res.checkout = { type: "branch", name: form.github_branch };
-        resources.push(res);
-      }
-
-      for (const s of form.env_vars) {
-        if (s.name && s.value) {
+      for (const r of form.resources) {
+        if (r.kind === "github") {
+          // Token is required — UI gates the Create button on this, but we
+          // double-check so a stale row from a previous validation pass
+          // can't slip through.
+          if (!r.url || !r.token) continue;
+          const res: Record<string, unknown> = {
+            type: "github_repository",
+            url: r.url,
+            authorization_token: r.token,
+            // Always send mount_path: derive /workspace/<repo-name> from the
+            // URL when the user left it blank. Mirrors the in-form preview.
+            mount_path: r.mount_path || defaultMountPath(r.url),
+          };
+          if (r.checkout_type === "branch" && r.checkout_name) {
+            res.checkout = { type: "branch", name: r.checkout_name };
+          } else if (r.checkout_type === "commit" && r.checkout_name) {
+            res.checkout = { type: "commit", sha: r.checkout_name };
+          }
+          resources.push(res);
+        } else if (r.kind === "file") {
+          if (!r.file_id) continue;
+          const res: Record<string, unknown> = { type: "file", file_id: r.file_id };
+          if (r.mount_path) res.mount_path = r.mount_path;
+          resources.push(res);
+        } else if (r.kind === "memory_store") {
+          if (!r.memory_store_id) continue;
+          const res: Record<string, unknown> = {
+            type: "memory_store",
+            memory_store_id: r.memory_store_id,
+            access: r.access,
+          };
+          if (r.mount_path) res.mount_path = r.mount_path;
+          resources.push(res);
+        } else if (r.kind === "env") {
+          if (!r.name || !r.value) continue;
           // type=env (was env_secret pre-rename). Server still accepts the
           // legacy alias so older console builds keep working — see
           // sessions.ts:262.
-          resources.push({ type: "env", name: s.name, value: s.value });
+          resources.push({ type: "env", name: r.name, value: r.value });
         }
       }
 
@@ -217,28 +310,25 @@ export function SessionsList() {
     }));
   };
 
-  const updateEnvVar = (idx: number, field: "name" | "value", val: string) => {
-    setForm(f => {
-      const vars = [...f.env_vars];
-      vars[idx] = { ...vars[idx], [field]: val };
-      return { ...f, env_vars: vars };
+  const updateResource = <K extends ResourceRow["kind"]>(
+    idx: number,
+    patch: Partial<Extract<ResourceRow, { kind: K }>>,
+  ) => {
+    setForm((f) => {
+      const next = [...f.resources];
+      next[idx] = { ...next[idx], ...patch } as ResourceRow;
+      return { ...f, resources: next };
     });
   };
 
-  const addEnvVar = () => {
-    setForm(f => ({ ...f, env_vars: [...f.env_vars, { name: "", value: "" }] }));
+  const addResource = (kind: ResourceRow["kind"]) => {
+    setForm((f) => ({ ...f, resources: [...f.resources, blankResource(kind)] }));
+    setRevealedSecrets(new Set());
   };
 
-  const removeEnvVar = (idx: number) => {
-    setForm(f => ({ ...f, env_vars: f.env_vars.filter((_, i) => i !== idx) }));
-    setRevealedEnvIdx((prev) => {
-      const next = new Set<number>();
-      for (const i of prev) {
-        if (i < idx) next.add(i);
-        else if (i > idx) next.add(i - 1);
-      }
-      return next;
-    });
+  const removeResource = (idx: number) => {
+    setForm((f) => ({ ...f, resources: f.resources.filter((_, i) => i !== idx) }));
+    setRevealedSecrets(new Set());
   };
 
   const statusCls = (status?: string) => {
@@ -362,10 +452,11 @@ export function SessionsList() {
         onClose={() => setShowCreate(false)}
         title="New Session"
         subtitle="Start a conversation with an agent."
+        maxWidth="max-w-2xl"
         footer={
           <>
             <Button variant="ghost" onClick={() => setShowCreate(false)}>Cancel</Button>
-            <Button onClick={create} disabled={!form.agent || (!isLocalRuntime && !form.environment_id)}>Create</Button>
+            <Button onClick={create} disabled={!form.agent || (!isLocalRuntime && !form.environment_id) || !resourcesValid}>Create</Button>
           </>
         }
       >
@@ -460,63 +551,252 @@ export function SessionsList() {
             </div>
           )}
 
-          <details className="group">
-            <summary className="text-sm font-medium text-fg cursor-pointer hover:text-brand">GitHub Repository <span className="text-fg-subtle font-normal">(optional)</span></summary>
-            <div className="mt-2 space-y-2 pl-1">
-              <div>
-                <label className="text-xs text-fg-muted block mb-0.5">Repository URL</label>
-                <input value={form.github_url} onChange={(e) => setForm({ ...form, github_url: e.target.value })} className={inputCls} placeholder="https://github.com/owner/repo" />
-              </div>
-              <div>
-                <label className="text-xs text-fg-muted block mb-0.5">Access Token <span className="text-fg-subtle">(write-only, never returned)</span></label>
-                <input type="password" value={form.github_token} onChange={(e) => setForm({ ...form, github_token: e.target.value })} className={inputCls} placeholder="ghp_..." />
-              </div>
-              <div>
-                <label className="text-xs text-fg-muted block mb-0.5">Branch <span className="text-fg-subtle">(optional)</span></label>
-                <input value={form.github_branch} onChange={(e) => setForm({ ...form, github_branch: e.target.value })} className={inputCls} placeholder="main" />
-              </div>
+          <div>
+            <div className="flex items-center justify-between mb-1">
+              <label className="text-sm text-fg-muted">Resources <span className="text-fg-subtle">(optional)</span></label>
             </div>
-          </details>
-
-          <details className="group">
-            <summary className="text-sm font-medium text-fg cursor-pointer hover:text-brand">Environment Variables <span className="text-fg-subtle font-normal">(optional)</span></summary>
-            <div className="mt-2 space-y-2 pl-1">
-              <p className="text-xs text-fg-subtle">
-                Plain environment variables passed to the agent. For tokens that need encryption, use credential vaults instead.
-              </p>
-              {form.env_vars.map((s, i) => {
-                const revealed = revealedEnvIdx.has(i);
-                return (
-                  <div key={i} className="flex gap-2 items-start">
-                    <div className="flex-1">
-                      <input value={s.name} onChange={(e) => updateEnvVar(i, "name", e.target.value)} className={inputCls} placeholder="ENV_VAR_NAME" />
-                    </div>
-                    <div className="flex-1 relative">
-                      <input
-                        type={revealed ? "text" : "password"}
-                        value={s.value}
-                        onChange={(e) => updateEnvVar(i, "value", e.target.value)}
-                        className={`${inputCls} pr-12`}
-                        placeholder="value"
-                      />
+            <p className="text-xs text-fg-subtle mb-2">
+              Mount files, GitHub repositories, memory stores, or pass environment variables into the session.
+            </p>
+            {form.resources.length === 0 ? (
+              <div className="text-xs text-fg-subtle border border-dashed border-border rounded-lg px-3 py-3 text-center">
+                No resources added.
+              </div>
+            ) : (
+              <div className="space-y-2">
+                {(() => {
+                  // Compute the first github row index + total count once so
+                  // we can mark it "primary" inline. The proxy resolver uses
+                  // the first declared github_repository's token for any
+                  // request whose URL doesn't carry an owner/repo slug
+                  // (graphql, /user, /search, …). Only show the hint when
+                  // there are 2+ github resources — for a single repo the
+                  // "first" semantics aren't meaningful.
+                  const githubIdxs = form.resources
+                    .map((r, i) => (r.kind === "github" ? i : -1))
+                    .filter((i) => i >= 0);
+                  const firstGithubIdx = githubIdxs[0] ?? -1;
+                  const showPrimaryHint = githubIdxs.length > 1;
+                  return form.resources.map((r, i) => (
+                  <div key={i} className="border border-border rounded-lg bg-bg-surface p-3">
+                    <div className="flex items-center justify-between mb-2">
+                      <span className="text-xs font-medium text-fg inline-flex items-center gap-2">
+                        {kindLabel(r.kind)}
+                        {showPrimaryHint && r.kind === "github" && i === firstGithubIdx && (
+                          <span
+                            className="text-[10px] font-medium px-1.5 py-0.5 rounded bg-brand/10 border border-brand/30 text-brand"
+                            title="This repo's token is used for GitHub API calls that don't target a specific repo (GraphQL, Search, /user, …)"
+                          >
+                            primary
+                          </span>
+                        )}
+                      </span>
                       <button
                         type="button"
-                        onClick={() => toggleEnvReveal(i)}
-                        className="absolute right-2 top-1/2 -translate-y-1/2 text-xs text-fg-subtle hover:text-fg"
-                        aria-label={revealed ? "Hide value" : "Show value"}
+                        onClick={() => removeResource(i)}
+                        className="text-fg-subtle hover:text-danger text-xs"
+                        aria-label="Remove resource"
                       >
-                        {revealed ? "hide" : "show"}
+                        Remove
                       </button>
                     </div>
-                    {form.env_vars.length > 1 && (
-                      <button onClick={() => removeEnvVar(i)} className="text-fg-subtle hover:text-danger text-xs mt-2">Remove</button>
+                    {r.kind === "github" && (
+                      <div className="space-y-2">
+                        <div>
+                          <label className="text-xs text-fg-muted block mb-0.5">Repository URL <span className="text-danger">*</span></label>
+                          <input
+                            value={r.url}
+                            onChange={(e) => updateResource<"github">(i, { url: e.target.value })}
+                            className={inputCls}
+                            placeholder="https://github.com/owner/repo"
+                          />
+                        </div>
+                        <div>
+                          <label className="text-xs text-fg-muted block mb-0.5">
+                            Authorization Token <span className="text-danger">*</span>
+                          </label>
+                          <div className="relative">
+                            <input
+                              type={revealedSecrets.has(`${i}:token`) ? "text" : "password"}
+                              value={r.token}
+                              onChange={(e) => updateResource<"github">(i, { token: e.target.value })}
+                              className={`${inputCls} pr-12`}
+                              placeholder="ghp_xxxxxxxxxxxxxxxxxxxx"
+                            />
+                            {r.token && (
+                              <button
+                                type="button"
+                                onClick={() => toggleReveal(`${i}:token`)}
+                                className="absolute right-2 top-1/2 -translate-y-1/2 text-xs text-fg-subtle hover:text-fg"
+                                aria-label="Toggle token visibility"
+                              >
+                                {revealedSecrets.has(`${i}:token`) ? "hide" : "show"}
+                              </button>
+                            )}
+                          </div>
+                        </div>
+                        <div className="grid grid-cols-2 gap-2">
+                          <div>
+                            <label className="text-xs text-fg-muted block mb-0.5">Checkout</label>
+                            <select
+                              value={r.checkout_type}
+                              onChange={(e) => updateResource<"github">(i, { checkout_type: e.target.value as "none" | "branch" | "commit", checkout_name: "" })}
+                              className={inputCls}
+                            >
+                              <option value="none">None</option>
+                              <option value="branch">Branch</option>
+                              <option value="commit">Commit</option>
+                            </select>
+                          </div>
+                          <div>
+                            <label className="text-xs text-fg-muted block mb-0.5">
+                              {r.checkout_type === "commit" ? "Commit SHA" : "Name"}
+                            </label>
+                            <input
+                              value={r.checkout_name}
+                              onChange={(e) => updateResource<"github">(i, { checkout_name: e.target.value })}
+                              className={inputCls}
+                              disabled={r.checkout_type === "none"}
+                              placeholder={r.checkout_type === "commit" ? "abc123..." : "main"}
+                            />
+                          </div>
+                        </div>
+                        <div>
+                          <label className="text-xs text-fg-muted block mb-0.5">Mount Path <span className="text-fg-subtle">(optional)</span></label>
+                          <input
+                            value={r.mount_path}
+                            onChange={(e) => updateResource<"github">(i, { mount_path: e.target.value })}
+                            className={inputCls}
+                            placeholder={`${defaultMountPath(r.url)} (default)`}
+                          />
+                        </div>
+                      </div>
+                    )}
+                    {r.kind === "file" && (
+                      <div className="space-y-2">
+                        <div>
+                          <div className="flex items-center justify-between mb-0.5">
+                            <label className="text-xs text-fg-muted">File <span className="text-danger">*</span></label>
+                            <a href="/files" className="text-xs text-brand hover:underline">Manage files →</a>
+                          </div>
+                          <select
+                            value={r.file_id}
+                            onChange={(e) => updateResource<"file">(i, { file_id: e.target.value })}
+                            className={inputCls}
+                          >
+                            <option value="">Select file...</option>
+                            {files.map((f) => (
+                              <option key={f.id} value={f.id}>
+                                {f.filename} ({f.id})
+                              </option>
+                            ))}
+                          </select>
+                          {files.length === 0 && (
+                            <p className="text-xs text-fg-subtle mt-1">No files yet — upload via the AMA SDK or POST /v1/files.</p>
+                          )}
+                        </div>
+                        <div>
+                          <label className="text-xs text-fg-muted block mb-0.5">Mount Path <span className="text-fg-subtle">(optional)</span></label>
+                          <input
+                            value={r.mount_path}
+                            onChange={(e) => updateResource<"file">(i, { mount_path: e.target.value })}
+                            className={inputCls}
+                            placeholder="/mnt/session/uploads/<file_id> (default)"
+                          />
+                        </div>
+                      </div>
+                    )}
+                    {r.kind === "memory_store" && (
+                      <div className="space-y-2">
+                        <div>
+                          <div className="flex items-center justify-between mb-0.5">
+                            <label className="text-xs text-fg-muted">Store <span className="text-danger">*</span></label>
+                            <a href="/memory" className="text-xs text-brand hover:underline">Manage stores →</a>
+                          </div>
+                          <select
+                            value={r.memory_store_id}
+                            onChange={(e) => updateResource<"memory_store">(i, { memory_store_id: e.target.value })}
+                            className={inputCls}
+                          >
+                            <option value="">Select store...</option>
+                            {memoryStores.map((m) => (
+                              <option key={m.id} value={m.id}>
+                                {m.name} ({m.id})
+                              </option>
+                            ))}
+                          </select>
+                        </div>
+                        <div className="grid grid-cols-2 gap-2">
+                          <div>
+                            <label className="text-xs text-fg-muted block mb-0.5">Access</label>
+                            <select
+                              value={r.access}
+                              onChange={(e) => updateResource<"memory_store">(i, { access: e.target.value as "read_write" | "read_only" })}
+                              className={inputCls}
+                            >
+                              <option value="read_write">Read / Write</option>
+                              <option value="read_only">Read only</option>
+                            </select>
+                          </div>
+                          <div>
+                            <label className="text-xs text-fg-muted block mb-0.5">Mount Path <span className="text-fg-subtle">(optional)</span></label>
+                            <input
+                              value={r.mount_path}
+                              onChange={(e) => updateResource<"memory_store">(i, { mount_path: e.target.value })}
+                              className={inputCls}
+                              placeholder="/mnt/memory/<name>/ (default)"
+                            />
+                          </div>
+                        </div>
+                      </div>
+                    )}
+                    {r.kind === "env" && (
+                      <div className="grid grid-cols-2 gap-2">
+                        <div>
+                          <label className="text-xs text-fg-muted block mb-0.5">Name <span className="text-danger">*</span></label>
+                          <input
+                            value={r.name}
+                            onChange={(e) => updateResource<"env">(i, { name: e.target.value })}
+                            className={inputCls}
+                            placeholder="ENV_VAR_NAME"
+                          />
+                        </div>
+                        <div>
+                          <label className="text-xs text-fg-muted block mb-0.5">Value <span className="text-danger">*</span></label>
+                          <div className="relative">
+                            <input
+                              type={revealedSecrets.has(`${i}:value`) ? "text" : "password"}
+                              value={r.value}
+                              onChange={(e) => updateResource<"env">(i, { value: e.target.value })}
+                              className={`${inputCls} pr-12`}
+                              placeholder="value"
+                            />
+                            {r.value && (
+                              <button
+                                type="button"
+                                onClick={() => toggleReveal(`${i}:value`)}
+                                className="absolute right-2 top-1/2 -translate-y-1/2 text-xs text-fg-subtle hover:text-fg"
+                                aria-label="Toggle value visibility"
+                              >
+                                {revealedSecrets.has(`${i}:value`) ? "hide" : "show"}
+                              </button>
+                            )}
+                          </div>
+                        </div>
+                      </div>
                     )}
                   </div>
-                );
-              })}
-              <button onClick={addEnvVar} className="text-xs text-fg-muted hover:text-fg">+ Add variable</button>
+                ));
+                })()}
+              </div>
+            )}
+            <div className="flex flex-wrap gap-2 mt-2">
+              <button type="button" onClick={() => addResource("github")} className="text-xs px-2.5 py-1.5 border border-border rounded-md hover:bg-bg-surface text-fg-muted hover:text-fg">+ GitHub repo</button>
+              <button type="button" onClick={() => addResource("file")} className="text-xs px-2.5 py-1.5 border border-border rounded-md hover:bg-bg-surface text-fg-muted hover:text-fg">+ File</button>
+              <button type="button" onClick={() => addResource("memory_store")} className="text-xs px-2.5 py-1.5 border border-border rounded-md hover:bg-bg-surface text-fg-muted hover:text-fg">+ Memory store</button>
+              <button type="button" onClick={() => addResource("env")} className="text-xs px-2.5 py-1.5 border border-border rounded-md hover:bg-bg-surface text-fg-muted hover:text-fg">+ Env var</button>
             </div>
-          </details>
+          </div>
         </div>
       </Modal>
     </ListPage>

--- a/apps/console/vite.config.ts
+++ b/apps/console/vite.config.ts
@@ -4,6 +4,16 @@ import tailwindcss from "@tailwindcss/vite";
 
 const API_TARGET = process.env.VITE_API_TARGET || "http://localhost:8787";
 
+// Shared proxy config. cookieDomainRewrite makes Set-Cookie headers from
+// any non-localhost API target (staging / prod) land on localhost so
+// browser-side auth works through the dev proxy.
+const proxyOpts = {
+  target: API_TARGET,
+  changeOrigin: true,
+  secure: true,
+  cookieDomainRewrite: "localhost",
+};
+
 export default defineConfig({
   plugins: [react(), tailwindcss()],
   build: {
@@ -12,14 +22,14 @@ export default defineConfig({
   },
   server: {
     proxy: {
-      "/v1":         { target: API_TARGET, changeOrigin: true, secure: true },
-      "/auth":       { target: API_TARGET, changeOrigin: true, secure: true },
-      "/auth-info":  { target: API_TARGET, changeOrigin: true, secure: true },
-      "/health":     { target: API_TARGET, changeOrigin: true, secure: true },
-      "/linear":     { target: API_TARGET, changeOrigin: true, secure: true },
-      "/linear-setup": { target: API_TARGET, changeOrigin: true, secure: true },
-      "/github":     { target: API_TARGET, changeOrigin: true, secure: true },
-      "/github-setup": { target: API_TARGET, changeOrigin: true, secure: true },
+      "/v1": proxyOpts,
+      "/auth": proxyOpts,
+      "/auth-info": proxyOpts,
+      "/health": proxyOpts,
+      "/linear": proxyOpts,
+      "/linear-setup": proxyOpts,
+      "/github": proxyOpts,
+      "/github-setup": proxyOpts,
     },
   },
 });

--- a/apps/main/src/index.ts
+++ b/apps/main/src/index.ts
@@ -29,6 +29,7 @@ import mcpProxyRoutes, {
   resolveOutboundCredentialByHost,
   forwardWithRefresh,
 } from "./routes/mcp-proxy";
+import { resolveGithubCredentials } from "./lib/github-creds";
 import { tickEvalRuns } from "./eval-runner";
 import { handleMemoryEvents } from "./queue/memory-events";
 import { handleMemoryEventsDlq } from "./queue/memory-events-dlq";
@@ -427,6 +428,36 @@ export class McpProxyRpc extends WorkerEntrypoint<Env> {
     );
     if (!cred) return null;
     return { type: "bearer", token: cred.upstreamToken };
+  }
+
+  /**
+   * Per-repo GitHub credential lookup for the network-layer proxy.
+   *
+   * Returns:
+   *   - null  → no credential available (caller passes through unauth'd):
+   *             host isn't a GitHub host we route, OR session is gone /
+   *             archived, OR session has no github_repository resources
+   *   - {...} → the chosen token + scheme + owner/repo slug. Slug is for
+   *             log correlation; the token never lands in any log.
+   *
+   * Pick rule: path-matched resource if the request URL has owner/repo
+   * AND it matches a resource; otherwise the first declared resource's
+   * token. See `resolveGithubCredentials` for the trade-off rationale.
+   */
+  async lookupGithubCredential(opts: {
+    tenantId: string;
+    sessionId: string;
+    hostname: string;
+    pathname: string;
+  }): Promise<{ scheme: "Basic" | "Bearer"; token: string; slug: string } | null> {
+    const services = await getCfServicesForTenant(this.env, opts.tenantId);
+    return resolveGithubCredentials(
+      services,
+      opts.tenantId,
+      opts.sessionId,
+      opts.hostname,
+      opts.pathname,
+    );
   }
 
   /**

--- a/apps/main/src/lib/github-creds.ts
+++ b/apps/main/src/lib/github-creds.ts
@@ -1,0 +1,176 @@
+/**
+ * GitHub credential routing for the network-layer outbound proxy.
+ *
+ * Sandbox containers fire plain HTTPS at github.com / api.github.com with
+ * no Authorization header. The agent worker's outbound interceptor calls
+ * `resolveGithubCredentials` to get an ordered candidate list of tokens
+ * to try (per-session, picked from the session's github_repository
+ * resources), then injects Authorization upstream and retries on 401.
+ *
+ * Scope (intentional, see γ trim decision):
+ *   - github.com (smart-HTTP git protocol) → Basic auth
+ *   - api.github.com (REST + GraphQL)      → Bearer
+ *   - everything else (uploads, lfs, codeload, raw, githubusercontent
+ *     CDN) is left to the catch-all credential resolver — public content
+ *     works as passthrough; private uncommon-host calls 401, accepted.
+ *
+ * Multi-repo routing strategy (intentionally simple):
+ *   - parse (owner, repo) from the request URL → if it matches a
+ *     github_repository resource, return that resource's token
+ *   - if it doesn't match (or path has no owner/repo, e.g. /graphql,
+ *     /user, /search), return the first github_repository resource's
+ *     token
+ *   - if the session has no github_repository resources at all, return
+ *     null (caller passes through unauthenticated)
+ *
+ * Known limitation: when a session attaches multiple repos with tokens
+ * that don't share scope (e.g. two PATs for two distinct orgs), non-repo-
+ * scoped calls (/graphql etc.) always use the first resource's token.
+ * The other token is simply unreachable for those calls. UI surfaces a
+ * hint about this.
+ *
+ * String-match safety: parseRepoSlug normalizes case, collapses path
+ * traversal (`..` / `//`), strips `.git`, validates against the GH login
+ * charset. Defenses are described inline.
+ */
+
+import type { Services } from "@open-managed-agents/services";
+
+/** Hosts whose outbound traffic the agent worker rewrites with a per-repo
+ *  GitHub token. Lowercase. Anything not in this set is left alone. */
+export const GITHUB_HOSTS = ["github.com", "api.github.com"] as const;
+export type GitHubHost = typeof GITHUB_HOSTS[number];
+
+export function isGithubHost(hostname: string): hostname is GitHubHost {
+  return (GITHUB_HOSTS as readonly string[]).includes(hostname.toLowerCase());
+}
+
+/** Auth scheme by host. github.com smart-HTTP is documented for Basic
+ *  with `x-access-token:<token>`; Bearer is undocumented for that endpoint
+ *  so we play safe. api.github.com officially accepts Bearer for both
+ *  PATs and installation tokens. */
+export function authSchemeFor(hostname: string): "Basic" | "Bearer" {
+  return hostname.toLowerCase() === "github.com" ? "Basic" : "Bearer";
+}
+
+// GitHub login/repo charset. Login is strict ASCII alnum + dashes
+// (no leading/trailing dash); repo names additionally allow `.` and `_`.
+const GH_LOGIN_RE = /^[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?$/;
+const GH_REPO_RE = /^[A-Za-z0-9._-]+$/;
+
+/** Normalize anything that looks like a GitHub repo reference to the
+ *  canonical lowercase `"owner/repo"` slug, or null if it isn't one.
+ *
+ *  Accepts:
+ *    - `https://github.com/Owner/Repo(.git)?[/anything]`
+ *    - `https://api.github.com/repos/Owner/Repo[/anything]`
+ *    - `git@github.com:Owner/Repo(.git)?`
+ *    - bare `Owner/Repo(.git)?`
+ *
+ *  Defenses:
+ *    - lowercases owner+repo (GitHub login is case-insensitive)
+ *    - collapses `..` and empty segments in path
+ *    - strips `.git` suffix
+ *    - rejects anything outside the GH login charset (no Unicode homoglyph)
+ */
+export function parseRepoSlug(input: string): string | null {
+  if (!input) return null;
+  let owner: string | undefined;
+  let repo: string | undefined;
+
+  // URL form (full or API).
+  if (input.startsWith("http://") || input.startsWith("https://")) {
+    let u: URL;
+    try { u = new URL(input); } catch { return null; }
+    const host = u.hostname.toLowerCase();
+    // Path-segment normalize: drop empties + `.`, collapse `..`.
+    const parts: string[] = [];
+    for (const seg of u.pathname.split("/")) {
+      if (!seg || seg === ".") continue;
+      if (seg === "..") { parts.pop(); continue; }
+      parts.push(seg);
+    }
+    if (host === "github.com" || host === "www.github.com") {
+      owner = parts[0];
+      repo = parts[1];
+    } else if (host === "api.github.com" && parts[0] === "repos") {
+      owner = parts[1];
+      repo = parts[2];
+    }
+  }
+
+  // SSH form: git@github.com:owner/repo(.git)?
+  if (!owner) {
+    const ssh = input.match(/^git@github\.com:([^/]+)\/([^/]+?)(?:\.git)?$/);
+    if (ssh) { owner = ssh[1]; repo = ssh[2]; }
+  }
+
+  // Bare: owner/repo(.git)? — only if no slashes beyond the one
+  if (!owner) {
+    const bare = input.match(/^([^/]+)\/([^/]+?)(?:\.git)?$/);
+    if (bare) { owner = bare[1]; repo = bare[2]; }
+  }
+
+  if (!owner || !repo) return null;
+  repo = repo.replace(/\.git$/i, "");
+  if (!GH_LOGIN_RE.test(owner) || !GH_REPO_RE.test(repo)) return null;
+  return `${owner.toLowerCase()}/${repo.toLowerCase()}`;
+}
+
+export interface GithubCandidate {
+  scheme: "Basic" | "Bearer";
+  token: string;
+  /** owner/repo of the source resource — for logging / debug only. */
+  slug: string;
+}
+
+/**
+ * Pick a GitHub token for an outbound call.
+ *
+ * Returns null in three cases (caller behavior identical: passthrough
+ * unauthenticated):
+ *   - host isn't a GitHub host we route
+ *   - session not found / archived
+ *   - session has no usable github_repository resources
+ *
+ * Otherwise: path-matched resource's token if the request URL slug
+ * matches one; first declared resource's token otherwise.
+ */
+export async function resolveGithubCredentials(
+  services: Services,
+  tenantId: string,
+  sid: string,
+  hostname: string,
+  pathname: string,
+): Promise<GithubCandidate | null> {
+  if (!isGithubHost(hostname)) return null;
+
+  const session = await services.sessions
+    .get({ tenantId, sessionId: sid })
+    .catch(() => null);
+  if (!session) return null;
+  if ((session as { archived_at?: string | null }).archived_at) return null;
+
+  const rows = await services.sessions
+    .listResourcesBySession({ sessionId: sid })
+    .catch(() => []);
+
+  const requestSlug = parseRepoSlug(`https://${hostname}${pathname}`);
+  const scheme = authSchemeFor(hostname);
+
+  let fallback: GithubCandidate | null = null;
+  for (const row of rows) {
+    const r = row.resource as { type?: string; url?: string } | undefined;
+    if (r?.type !== "github_repository" || !r.url) continue;
+    const resSlug = parseRepoSlug(r.url);
+    if (!resSlug) continue;
+    const token = await services.sessionSecrets
+      .get({ tenantId, sessionId: sid, resourceId: row.id })
+      .catch(() => undefined);
+    if (!token) continue;
+    const cand: GithubCandidate = { scheme, token, slug: resSlug };
+    if (resSlug === requestSlug) return cand;
+    if (!fallback) fallback = cand;   // first usable resource
+  }
+  return fallback;
+}

--- a/apps/main/src/routes/sessions.ts
+++ b/apps/main/src/routes/sessions.ts
@@ -21,6 +21,7 @@ import {
   type SessionRow,
 } from "@open-managed-agents/sessions-store";
 import { jsonPage, parsePageQuery } from "../lib/list-page";
+import { parseRepoSlug } from "../lib/github-creds";
 
 const app = new Hono<{
   Bindings: Env;
@@ -419,6 +420,26 @@ app.post("/", async (c) => {
       }
       seenMemoryStoreIds.add(r.memory_store_id);
     }
+  }
+
+  // Reject duplicate github_repository (same owner/repo slug) within a
+  // single session — the per-repo proxy resolver matches by slug, so two
+  // resources with the same slug would always pick the first one and the
+  // second's token would be silently unused. Surface as 422 instead.
+  const seenGithubSlugs = new Set<string>();
+  for (const r of body.resources ?? []) {
+    if (r.type !== "github_repository" && r.type !== "github_repo") continue;
+    const repoUrl = r.url || r.repo_url;
+    if (!repoUrl) continue;
+    const slug = parseRepoSlug(repoUrl);
+    if (!slug) continue;
+    if (seenGithubSlugs.has(slug)) {
+      return c.json(
+        { error: `Duplicate github_repository resource for ${slug}` },
+        422,
+      );
+    }
+    seenGithubSlugs.add(slug);
   }
 
   // Verify agent exists

--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -137,6 +137,19 @@ export interface Env {
       sessionId: string;
       hostname: string;
     }): Promise<{ type: "bearer"; token: string } | null>;
+    /**
+     * Per-repo GitHub credential lookup for the network-layer proxy
+     * (oma-sandbox.ts githubAuthHandler). Returns the picked token +
+     * scheme for the request URL, or null when no github_repository
+     * resource is attached to the session. See lib/github-creds.ts in
+     * apps/main for the picking rule.
+     */
+    lookupGithubCredential(opts: {
+      tenantId: string;
+      sessionId: string;
+      hostname: string;
+      pathname: string;
+    }): Promise<{ scheme: "Basic" | "Bearer"; token: string; slug: string } | null>;
   };
   // Public URL of the integrations gateway (used to build redirect URLs to
   // OAuth callbacks etc. when the gateway is on a different host).


### PR DESCRIPTION
## Summary

- **Network-layer GitHub credential proxy**: tokens never enter the sandbox. Every `github.com` / `api.github.com` call from the agent's container is intercepted at the TLS-MITM layer; an Authorization header is added in the agent worker; the container only sees the upstream response.
- **Dynamic session-create Resources UI**: replaces the static GitHub + Env-var blocks with a "+ Resource" list (github / file / memory store / env). Adds the previously-missing Files list page in the console.
- **Branch fallback** (clone default + `git checkout -b` if requested branch is missing) and **dev:staging** script as smaller co-traveling improvements.

## Network-layer proxy design

Pick rule (intentionally simple, single token per request):
- Parse (owner, repo) from the request URL → use the matching `github_repository` resource's token
- Path doesn't carry owner/repo (`/graphql`, `/user`, `/search`) → use the **first** declared resource's token (UI marks it `primary`)
- No 401 retry, no LRU cache. Multi-token-different-scope edge case is a documented known limitation.

Auth scheme is host-specific:
- `github.com` → `Basic base64("x-access-token:<token>")` (smart-HTTP; Bearer is undocumented for that endpoint)
- `api.github.com` → `Bearer <token>` (officially supported for both PATs and installation tokens)

Old auth surface is fully removed: no more `~/.git-credentials` writes, no more `registerCommandSecrets("gh", {GITHUB_TOKEN, ...})`. `git config core.askpass=/bin/true` ensures a proxy miss makes git fail-fast instead of hanging.

## Security profile

| Dimension | Before | After |
|---|---|---|
| Token in sandbox FS | `~/.git-credentials` plaintext | none |
| Token in sandbox env | `GITHUB_TOKEN` (per-cmd) | none |
| Token in workspace backup snapshot | yes | no |
| Token in agent-worker memory | write window only | per-request RPC window |
| Multi-repo isolation | per-host+path (git only) | per-URL slug (git + gh + REST + GraphQL) |

## Files

| File | What |
|---|---|
| `apps/main/src/lib/github-creds.ts` | new: `parseRepoSlug` + `resolveGithubCredentials` |
| `apps/main/src/index.ts` | `MAIN_MCP.lookupGithubCredential` RPC |
| `apps/main/src/routes/sessions.ts` | reject duplicate-slug `github_repository` at create-time |
| `packages/shared/src/env.ts` | `MAIN_MCP` type extended |
| `apps/agent/src/oma-sandbox.ts` | `githubAuthHandler` on `outboundByHost` for github.com + api.github.com |
| `apps/agent/src/runtime/resource-mounter.ts` | strip credential-write + gh env-injection; add askpass fail-fast; branch fallback |
| `apps/console/src/pages/SessionsList.tsx` | dynamic Resources block; `primary` badge on first github when ≥2 |
| `apps/console/src/pages/FilesList.tsx` | new Files list page |
| `apps/console/src/components/icons.tsx` `Layout.tsx` `main.tsx` | Files icon + nav + route |
| `apps/console/vite.config.ts` `package.json` | cookieDomainRewrite + `dev:staging` script |

## Known limitations

- GraphQL with insufficient-scope token returns HTTP 200 + `errors[].type=FORBIDDEN`, not 401, so wrong-token GraphQL surfaces as agent-visible errors rather than auto-retry.
- Uploads / LFS / codeload / raw private content not in proxy whitelist; passthrough → 401 for private. Out-of-scope for this PR.
- OAuth login flows can't transparently complete on localhost via the dev-staging proxy (callbacks pinned to staging domain).

## Test plan

- [ ] Single repo + PAT: `git clone` private repo from sandbox; verify no `~/.git-credentials` exists
- [ ] `gh pr list` with no `GH_TOKEN` set: returns 200
- [ ] Multi-repo, two distinct owners, two PATs: REST calls to each `/repos/owner/X/...` get the right token
- [ ] Multi-repo + GraphQL: `gh pr create` uses first declared repo's token; wrong scope returns FORBIDDEN body (expected)
- [ ] Proxy RPC failure (simulated): `git fetch` fast-fails instead of hanging
- [ ] Console: create session w/ 2 github resources, verify `primary` badge on first
- [ ] Files page: list, download, delete; scope filter by session id

🤖 Generated with [Claude Code](https://claude.com/claude-code)