### PR TITLE
fix(billing+ux): sandbox_active emit + outputs guidance + Files panel

### DIFF
--- a/apps/agent/src/oma-sandbox.ts
+++ b/apps/agent/src/oma-sandbox.ts
@@ -305,6 +305,21 @@ export class OmaSandbox extends Sandbox {
   }
 
   /**
+   * Public entry point for the SessionDO `/destroy` path to emit the
+   * sandbox_active_seconds row BEFORE calling `sandbox.destroy()`. The
+   * CF Containers SDK fires `onStop` async to destroy() — by the time
+   * SessionDO returns 200, the onStop callback may still be inflight or
+   * may have been dropped if the DO got evicted. Calling this explicitly
+   * gives us a synchronous emit in the SessionDO's request lifecycle.
+   *
+   * Idempotent via storage-delete-after-emit — a later onStop fires this
+   * again but reads `undefined` from storage and no-ops.
+   */
+  async emitSandboxActiveNow(): Promise<void> {
+    await this.recordSandboxActiveOnStop();
+  }
+
+  /**
    * Compute container active-seconds from the stored billing context's
    * startedAt and emit one usage_events row of kind=sandbox_active_seconds.
    * Resets the startedAt cursor so a re-start in the same session DO

--- a/apps/agent/src/runtime/sandbox.ts
+++ b/apps/agent/src/runtime/sandbox.ts
@@ -474,6 +474,53 @@ export class CloudflareSandbox implements SandboxExecutor {
   }
 
   /**
+   * Forward (tenant, session, agent) tuple to OmaSandbox so its onStop /
+   * pre-destroy emit can attribute the sandbox_active_seconds row. The
+   * wrapper exists because SessionDO holds a CloudflareSandbox, not the
+   * underlying DO stub — without this passthrough, the optional-chain
+   * check at session-do.ts warmup silently no-ops.
+   */
+  async setBillingContext(opts: {
+    tenantId: string;
+    sessionId: string;
+    agentId: string | null;
+  }): Promise<void> {
+    if (!opts.tenantId || !opts.sessionId) return;
+    try {
+      const sandbox = (await this.getSandbox()) as unknown as {
+        setBillingContext?: (c: { tenantId: string; sessionId: string; agentId: string | null }) => Promise<void>;
+      };
+      if (typeof sandbox.setBillingContext !== "function") return;
+      await sandbox.setBillingContext(opts);
+    } catch (err) {
+      console.error(
+        `[sandbox] setBillingContext failed: ${(err as Error).message ?? err}`,
+      );
+    }
+  }
+
+  /**
+   * Trigger the sandbox_active_seconds emit synchronously. Called by
+   * SessionDO's `/destroy` handler BEFORE `destroy()` so the write lands
+   * in the request lifecycle (CF's onStop callback fires async to destroy
+   * and can be dropped on DO eviction). Idempotent via storage-delete
+   * inside OmaSandbox.
+   */
+  async emitSandboxActiveNow(): Promise<void> {
+    try {
+      const sandbox = (await this.getSandbox()) as unknown as {
+        emitSandboxActiveNow?: () => Promise<void>;
+      };
+      if (typeof sandbox.emitSandboxActiveNow !== "function") return;
+      await sandbox.emitSandboxActiveNow();
+    } catch (err) {
+      console.error(
+        `[sandbox] emitSandboxActiveNow failed: ${(err as Error).message ?? err}`,
+      );
+    }
+  }
+
+  /**
    * Reset the CF Container's sleepAfter inactivity timer. SessionDO calls
    * this from its alarm while there are background_tasks rows so a long-
    * running `python script.py &` survives past sleepAfter without us doing

--- a/apps/agent/src/runtime/session-do.ts
+++ b/apps/agent/src/runtime/session-do.ts
@@ -1438,6 +1438,21 @@ export class SessionDO extends DurableObject<Env> {
       if (this.sandbox?.snapshotWorkspaceNow) {
         try { await this.sandbox.snapshotWorkspaceNow(); } catch {}
       }
+      // Emit sandbox_active_seconds BEFORE destroy. CF's onStop callback
+      // runs async to destroy() and can be dropped if the OmaSandbox DO
+      // gets evicted before it fires (observed empirically on staging).
+      // The explicit emit here puts the write in SessionDO's request
+      // lifecycle — synchronous and reliable. onStop still wired as a
+      // fallback for non-/destroy teardowns (sleepAfter, OOM); the
+      // emit is idempotent (storage delete after success).
+      const sandboxBilling = this.sandbox as unknown as {
+        emitSandboxActiveNow?: () => Promise<void>;
+      } | null;
+      if (sandboxBilling?.emitSandboxActiveNow) {
+        try { await sandboxBilling.emitSandboxActiveNow(); } catch (err) {
+          logWarn({ op: "session_do.destroy.sandbox_emit", session_id: this.state.session_id, err }, "sandbox usage emit failed");
+        }
+      }
       // Destroy the sandbox container (kills processes, unmounts, stops container)
       if (this.sandbox?.destroy) {
         try { await this.sandbox.destroy(); } catch (err) {
@@ -3795,7 +3810,9 @@ export class SessionDO extends DurableObject<Env> {
     // failure report so the human (or calling system) can intervene.
     const loopStopGuidance =
       "If the same tool call fails three times in a row with substantively the same error, stop retrying. Report (a) what you were trying to do, (b) the exact error, and (c) what you would need to make progress (a missing credential, a corrected input, an upstream service to recover), then end the turn instead of looping.";
-    const platformGuidance = `${authenticatedCommandGuidance}\n\n${loopStopGuidance}`;
+    const sessionOutputsGuidance =
+      "Files you write under `/mnt/session/outputs/` persist after the session ends and are downloadable by the user from the session's Files panel. Use this path for final artifacts the user should keep (reports, exports, generated docs, packaged code). Files written anywhere else (e.g. `/workspace/`) are scratch — they may be lost on container recycle and are not user-accessible.";
+    const platformGuidance = `${authenticatedCommandGuidance}\n\n${loopStopGuidance}\n\n${sessionOutputsGuidance}`;
     const systemPrompt = rawSystemPrompt
       ? `${rawSystemPrompt}\n\n${platformGuidance}`
       : platformGuidance;

--- a/apps/console/src/pages/SessionDetail.tsx
+++ b/apps/console/src/pages/SessionDetail.tsx
@@ -49,6 +49,7 @@ export function SessionDetail() {
     | { kind: "vault"; id: string }
     | null
   >(null);
+  const [showFiles, setShowFiles] = useState(false);
   const [linear, setLinear] = useState<{
     issueId?: string;
     issueIdentifier?: string;
@@ -483,6 +484,17 @@ export function SessionDetail() {
               {interrupting ? "Stopping…" : "Stop"}
             </button>
           )}
+          <button
+            onClick={() => setShowFiles((v) => !v)}
+            className={`px-2.5 py-1 rounded-md text-xs font-medium border transition-colors ${
+              showFiles
+                ? "bg-bg-surface text-fg border-border-strong"
+                : "bg-bg-surface text-fg-muted border-border hover:text-fg hover:border-border-strong"
+            }`}
+            title="Files the agent wrote to /mnt/session/outputs/"
+          >
+            Files
+          </button>
         </div>
         <div className="flex items-center gap-2 flex-wrap">
           <StatusPill status={status as "idle" | "running" | "terminated" | "error" | string} />
@@ -796,6 +808,9 @@ export function SessionDetail() {
             panel={resourcePanel}
             onClose={() => setResourcePanel(null)}
           />
+        )}
+        {showFiles && id && (
+          <FilesPanel sessionId={id} onClose={() => setShowFiles(false)} />
         )}
       </div>
       <TrajectoryViewerModal
@@ -1152,6 +1167,94 @@ function ResourcePanel({
         >
           Go to {panel.kind} →
         </Link>
+      </div>
+    </aside>
+  );
+}
+
+interface SessionOutputFile {
+  filename: string;
+  size_bytes: number;
+  uploaded_at: string;
+  media_type: string;
+}
+
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  if (n < 1024 * 1024 * 1024) return `${(n / 1024 / 1024).toFixed(1)} MB`;
+  return `${(n / 1024 / 1024 / 1024).toFixed(2)} GB`;
+}
+
+function FilesPanel({ sessionId, onClose }: { sessionId: string; onClose: () => void }) {
+  const { api } = useApi();
+  const [files, setFiles] = useState<SessionOutputFile[] | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    setFiles(null);
+    setErr(null);
+    api<{ data: SessionOutputFile[]; has_more: boolean }>(
+      `/v1/sessions/${sessionId}/outputs`,
+    )
+      .then((d) => setFiles(d.data ?? []))
+      .catch((e) => setErr(e instanceof Error ? e.message : String(e)));
+    // api closure changes every render; sessionId is the only stable input
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sessionId]);
+
+  return (
+    <aside className="w-[420px] shrink-0 border-l border-border bg-bg flex flex-col min-h-0">
+      <div className="px-4 py-3 border-b border-border flex items-start gap-3 shrink-0">
+        <div className="min-w-0 flex-1">
+          <div className="text-[10px] uppercase tracking-wide text-fg-subtle font-mono">
+            Files
+          </div>
+          <div className="text-base font-semibold text-fg">Session outputs</div>
+          <div className="text-xs text-fg-muted mt-0.5">
+            Files the agent wrote to <code className="font-mono">/mnt/session/outputs/</code>
+          </div>
+        </div>
+        <button
+          onClick={onClose}
+          className="text-fg-subtle hover:text-fg-muted text-lg leading-none px-1"
+          title="Close"
+        >
+          ×
+        </button>
+      </div>
+      <div className="flex-1 overflow-y-auto p-4 text-xs">
+        {err && <div className="text-danger">Failed to load: {err}</div>}
+        {!files && !err && <div className="text-fg-subtle">Loading…</div>}
+        {files && files.length === 0 && (
+          <div className="text-fg-subtle">
+            No files yet. The agent must write under <code className="font-mono">/mnt/session/outputs/</code> for files to appear here.
+          </div>
+        )}
+        {files && files.length > 0 && (
+          <ul className="space-y-1">
+            {files.map((f) => (
+              <li
+                key={f.filename}
+                className="flex items-center gap-3 py-2 border-b border-border/40 last:border-b-0"
+              >
+                <div className="min-w-0 flex-1">
+                  <a
+                    href={`/v1/sessions/${sessionId}/outputs/${encodeURIComponent(f.filename)}`}
+                    download={f.filename}
+                    className="font-mono text-fg hover:text-info truncate block"
+                    title={f.filename}
+                  >
+                    {f.filename}
+                  </a>
+                  <div className="text-[10px] text-fg-subtle mt-0.5">
+                    {formatBytes(f.size_bytes)} · {f.media_type} · {new Date(f.uploaded_at).toLocaleString()}
+                  </div>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
       </div>
     </aside>
   );


### PR DESCRIPTION
## Summary
- Fix `sandbox_active_seconds` never emitting — `CloudflareSandbox` wrapper was missing the `setBillingContext` / `emitSandboxActiveNow` forwarders, so the optional-chain check at warmup silently no-oped and `BILLING_CTX_KEY` was never written. Adds the forwarders + an explicit pre-destroy emit in SessionDO `/destroy` (CF's `onStop` fires async to `destroy()` and gets dropped on DO eviction).
- Tell agents about the AMA `/mnt/session/outputs/` magic dir via a one-line platformGuidance entry next to the existing auth + loop-stop guidance. Every agent now learns it without per-agent system-prompt changes.
- Console: **Files** button on session detail. Opens a side panel listing files the agent wrote to `/mnt/session/outputs/`, each as a download link.

## Verified on staging
- `sess-zo8fiqscirc3srd9` ran bash + browser → all three `usage_events` kinds emitted (`session_alive`, `sandbox_active`, `browser_active`), cron debited the correct 10¢.
- Bare agent (`system: "You are a helpful assistant."`) asked to "save a file I can download later" → wrote to `/mnt/session/outputs/weather-report.md` unprompted, file appeared in the Files panel + `/v1/sessions/:id/outputs`.

## Migrations
None new. `0017_usage_events.sql` (from PR #58) needed to be applied to the 4 prod auth shards — done out-of-band before opening this PR. Migration is `CREATE TABLE IF NOT EXISTS` + `CREATE INDEX IF NOT EXISTS`, fully idempotent, and was also recorded in `d1_migrations` on each shard for tracking hygiene.

## Test plan
- [ ] Local: bench-staging.py still passes
- [ ] Staging deploy: confirm new agent run produces all three `usage_events` rows + cron debit
- [ ] Console: Files button renders next to Stop, panel opens, lists files, download works
- [ ] Empty-state copy renders for sessions with no outputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)