### PR TITLE
feat(self-host): close PR #64 gap — outputs mount + platform guidance on Node

### DIFF
--- a/apps/agent/package.json
+++ b/apps/agent/package.json
@@ -11,6 +11,7 @@
     "./harness/tools": "./src/harness/tools.ts",
     "./harness/registry": "./src/harness/registry.ts",
     "./harness/provider": "./src/harness/provider.ts",
+    "./harness/platform-guidance": "./src/harness/platform-guidance.ts",
     "./runtime/history": "./src/runtime/history.ts"
   },
   "dependencies": {

--- a/apps/agent/src/harness/platform-guidance.ts
+++ b/apps/agent/src/harness/platform-guidance.ts
@@ -1,0 +1,35 @@
+// Platform guidance appended to every agent's system prompt. Single source
+// of truth — both CF SessionDO and the self-host Node main read these.
+// Keep additions surgical: every line is sent on every turn for every
+// agent, so it sits on the prompt-cache prefix path. Don't expand without
+// proportional benefit.
+
+export const authenticatedCommandGuidance =
+  "For commands that may require authentication, prefer issuing a single command instead of a chained shell command. If an authenticated chained command fails, retry with a simpler single-command form.";
+
+// Loop-stop guidance: prod incidents have shown agents retrying the same
+// failing tool call indefinitely when an upstream credential is missing or
+// an external API is down. Cap retries explicitly and require a structured
+// failure report so the human (or calling system) can intervene.
+export const loopStopGuidance =
+  "If the same tool call fails three times in a row with substantively the same error, stop retrying. Report (a) what you were trying to do, (b) the exact error, and (c) what you would need to make progress (a missing credential, a corrected input, an upstream service to recover), then end the turn instead of looping.";
+
+// AMA-aligned `/mnt/session/outputs/` convention: the platform mounts a
+// per-session R2-backed (or host-fs-backed on Node) directory at this path.
+// Files written here are listable via GET /v1/sessions/:id/outputs and
+// downloadable by the caller. Without this hint, agents historically wrote
+// final artefacts to /workspace/ where they vanish on container recycle.
+export const sessionOutputsGuidance =
+  "Files you write under `/mnt/session/outputs/` persist after the session ends and are downloadable by the user from the session's Files panel. Use this path for final artifacts the user should keep (reports, exports, generated docs, packaged code). Files written anywhere else (e.g. `/workspace/`) are scratch — they may be lost on container recycle and are not user-accessible.";
+
+export const platformGuidance =
+  `${authenticatedCommandGuidance}\n\n${loopStopGuidance}\n\n${sessionOutputsGuidance}`;
+
+/**
+ * Compose agent.system + platform guidance. If the agent has no system
+ * prompt of its own, the guidance becomes the entire system prompt.
+ */
+export function composeSystemPrompt(rawSystemPrompt: string | null | undefined): string {
+  const raw = rawSystemPrompt ?? "";
+  return raw ? `${raw}\n\n${platformGuidance}` : platformGuidance;
+}

--- a/apps/agent/src/runtime/sandbox.ts
+++ b/apps/agent/src/runtime/sandbox.ts
@@ -1,6 +1,7 @@
 import type { SandboxExecutor, ProcessHandle } from "../harness/interface";
 import type { Env } from "@open-managed-agents/shared";
 import { getSandbox as cfGetSandbox } from "@cloudflare/sandbox";
+import { sessionOutputsPrefix } from "@open-managed-agents/shared";
 // `bash-parser` is CJS; the bundler handles interop for worker builds.
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
@@ -219,7 +220,9 @@ export class CloudflareSandbox implements SandboxExecutor {
     }
     const sandbox = await this.getSandbox();
     const mountPath = `/mnt/session/outputs`;
-    const prefix = `/t/${opts.tenantId}/session-outputs/${opts.sessionId}/`;
+    // s3fs wants a leading-slash prefix for directory scope; the shared
+    // helper returns the R2-key form (no leading slash) so we prepend.
+    const prefix = `/${sessionOutputsPrefix(opts.tenantId, opts.sessionId)}`;
     const fuse = this.fuseR2ConfigOrNull();
     const bucketName = "managed-agents-files";
 

--- a/apps/agent/src/runtime/session-do.ts
+++ b/apps/agent/src/runtime/session-do.ts
@@ -51,6 +51,7 @@ import type {
 } from "@open-managed-agents/shared";
 import type { HarnessContext, HarnessInterface, HistoryStore, SandboxExecutor, ProcessHandle } from "../harness/interface";
 import { resolveHarness } from "../harness/registry";
+import { composeSystemPrompt } from "../harness/platform-guidance";
 import { resolveModel } from "../harness/provider";
 import type { ApiCompat } from "../harness/provider";
 import type { LanguageModel } from "ai";
@@ -3795,27 +3796,14 @@ export class SessionDO extends DurableObject<Env> {
     const creds = await this.resolveModelCardCredentials(effectiveHandle);
     const model = resolveModel(creds.model, creds.apiKey, creds.baseURL, creds.apiCompat, creds.customHeaders);
 
-    // Build system prompt: agent.system + platform guidance (auth + loop-stop).
+    // Build system prompt: agent.system + platform guidance. Shared with the
+    // self-host Node path via @open-managed-agents/agent/harness/platform-guidance
+    // so the two surfaces stay byte-identical (prompt-cache prefix invariant).
     // Skill / memory_store / appendable_prompt content is NOT appended here —
     // those are collected as platformReminders and injected by the harness's
-    // onSessionInit hook as <system-reminder> user.message events. This keeps
-    // the system field byte-stable across the session, which Anthropic's
-    // prompt cache requires for the cached prefix to survive past turn 1.
+    // onSessionInit hook as <system-reminder> user.message events.
     const rawSystemPrompt = agent.system || "";
-    const authenticatedCommandGuidance =
-      "For commands that may require authentication, prefer issuing a single command instead of a chained shell command. If an authenticated chained command fails, retry with a simpler single-command form.";
-    // Loop-stop guidance: prod incidents have shown agents retrying the same
-    // failing tool call indefinitely when an upstream credential is missing or
-    // an external API is down. Cap retries explicitly and require a structured
-    // failure report so the human (or calling system) can intervene.
-    const loopStopGuidance =
-      "If the same tool call fails three times in a row with substantively the same error, stop retrying. Report (a) what you were trying to do, (b) the exact error, and (c) what you would need to make progress (a missing credential, a corrected input, an upstream service to recover), then end the turn instead of looping.";
-    const sessionOutputsGuidance =
-      "Files you write under `/mnt/session/outputs/` persist after the session ends and are downloadable by the user from the session's Files panel. Use this path for final artifacts the user should keep (reports, exports, generated docs, packaged code). Files written anywhere else (e.g. `/workspace/`) are scratch — they may be lost on container recycle and are not user-accessible.";
-    const platformGuidance = `${authenticatedCommandGuidance}\n\n${loopStopGuidance}\n\n${sessionOutputsGuidance}`;
-    const systemPrompt = rawSystemPrompt
-      ? `${rawSystemPrompt}\n\n${platformGuidance}`
-      : platformGuidance;
+    const systemPrompt = composeSystemPrompt(rawSystemPrompt);
 
     // Collect platformReminders for harness.onSessionInit. These get
     // resolved ONCE at session-init and become part of the events stream.

--- a/apps/main-node/src/index.ts
+++ b/apps/main-node/src/index.ts
@@ -65,16 +65,19 @@ import {
 } from "@open-managed-agents/credentials-store";
 import { SqlEventLog, ensureSchema as ensureEventLogSchema } from "@open-managed-agents/event-log/sql";
 import type { AgentConfig, SessionEvent, UserMessageEvent } from "@open-managed-agents/shared";
-import { generateEventId } from "@open-managed-agents/shared";
+import { generateEventId, guessSessionOutputMime } from "@open-managed-agents/shared";
 import { DefaultHarness } from "@open-managed-agents/agent/harness/default-loop";
 import { buildTools } from "@open-managed-agents/agent/harness/tools";
 import { resolveModel } from "@open-managed-agents/agent/harness/provider";
+import { composeSystemPrompt } from "@open-managed-agents/agent/harness/platform-guidance";
 import type { HarnessContext } from "@open-managed-agents/agent/harness/interface";
 import { cfWorkersAiToMarkdown as _cfWorkersAiToMarkdown } from "@open-managed-agents/markdown";
 import { startMemoryBlobWatcher } from "./lib/memory-blob-watcher.js";
 import { nodeToMarkdown } from "@open-managed-agents/markdown/adapters/node";
-import { mkdirSync } from "node:fs";
-import { dirname, join, relative } from "node:path";
+import { mkdirSync, createReadStream } from "node:fs";
+import { stat as fsStat, readdir as fsReaddir } from "node:fs/promises";
+import { dirname, join, relative, resolve as resolvePath } from "node:path";
+import { Readable } from "node:stream";
 import { nanoid } from "nanoid";
 import { InProcessEventStreamHub, type EventWriter } from "./lib/event-stream-hub";
 import { NodeHarnessRuntime } from "./lib/node-harness-runtime";
@@ -368,6 +371,14 @@ const memoryWatcher = startMemoryBlobWatcher({
   memoryRoot: memoryBlobs.baseDir,
   memoryRepo: new SqlMemoryRepo(sql),
 });
+
+// Session outputs root: backing store for /mnt/session/outputs/ — the
+// AMA-aligned magic dir an agent writes deliverable artefacts into.
+// LocalSubprocessSandbox symlinks <workdir>/.mnt/session/outputs →
+// <outputsRoot>/<tenant>/<session>/; GET /v1/sessions/:id/outputs serves
+// from the same root.
+const outputsRoot = process.env.SESSION_OUTPUTS_DIR ?? "./data/session-outputs";
+mkdirSync(outputsRoot, { recursive: true });
 
 // Vaults: per-tenant credential containers. Created via REST, consumed by
 // the oma-vault sidecar (apps/oma-vault) which reads the same sqlite file.
@@ -699,6 +710,10 @@ async function buildSandbox(
       // Memory blob root — adapters that mount via host-fs (LocalSubprocess)
       // read this; remote ones (Daytona/E2B) ignore it and use s3fs.
       memoryRoot: memoryBlobs.baseDir,
+      // Session outputs root — same shape as memoryRoot. LocalSubprocess
+      // symlinks per-(tenant,session) dirs under here when
+      // mountSessionOutputs is called.
+      outputsRoot,
     },
     process.env,
   );
@@ -737,6 +752,17 @@ const sessionRegistry = new SessionRegistry({
         storeId: binding.store_id,
         readOnly: binding.access === "read_only",
       });
+    }
+  },
+  buildSessionOutputsMounter: (sessionId, tenantId) => async ({ sandbox }) => {
+    if (!sandbox.mountSessionOutputs) return;
+    try {
+      await sandbox.mountSessionOutputs({ tenantId, sessionId });
+    } catch (err) {
+      console.warn(
+        `[main-node] mountSessionOutputs failed session=${sessionId.slice(0, 12)}:`,
+        err,
+      );
     }
   },
   buildModel: (agent) => {
@@ -780,13 +806,15 @@ const sessionRegistry = new SessionRegistry({
     // default-loop's eventsToMessages projection sees the conversation
     // context BEFORE harness.run reads from it.
     await runtime.refreshHistory();
+    const rawSystemPrompt = input.agent.system ?? "";
     const ctx: HarnessContext = {
       agent: input.agent,
       userMessage: input.userMessage,
       session_id: input.sessionId,
       tools: input.tools as HarnessContext["tools"],
       model: input.model,
-      systemPrompt: input.agent.system ?? "",
+      systemPrompt: composeSystemPrompt(rawSystemPrompt),
+      rawSystemPrompt,
       env: {
         ANTHROPIC_API_KEY: apiKey,
         ANTHROPIC_BASE_URL: process.env.ANTHROPIC_BASE_URL,
@@ -1026,6 +1054,96 @@ v1.get("/sessions/:id/memory_stores", async (c) => {
     .bind(sid)
     .all<{ store_id: string; access: string; created_at: number }>();
   return c.json({ data: rows.results ?? [] });
+});
+
+// ── Session outputs (/mnt/session/outputs/) ──────────────────────────────
+//
+// Mirrors apps/main's GET /v1/sessions/:id/outputs[/:filename] (R2-backed
+// on CF, host-fs-backed here). The sandbox writes to /mnt/session/outputs/
+// which is symlinked to <outputsRoot>/<tenant>/<session>/; the routes below
+// read from the same dir.
+
+const sessionOutputsDir = (tenantId: string, sessionId: string): string =>
+  resolvePath(outputsRoot, tenantId, sessionId);
+
+v1.get("/sessions/:id/outputs", async (c) => {
+  const sid = c.req.param("id");
+  const session = await sql
+    .prepare(`SELECT id FROM sessions WHERE tenant_id = ? AND id = ?`)
+    .bind(c.var.tenant_id, sid)
+    .first();
+  if (!session) return c.json({ error: "Session not found" }, 404);
+
+  const dir = sessionOutputsDir(c.var.tenant_id, sid);
+  let entries: string[];
+  try {
+    entries = await fsReaddir(dir);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return c.json({ data: [], has_more: false });
+    }
+    throw err;
+  }
+
+  const data: Array<{
+    filename: string;
+    size_bytes: number;
+    uploaded_at: string;
+    media_type: string;
+  }> = [];
+  for (const filename of entries) {
+    try {
+      const st = await fsStat(join(dir, filename));
+      if (!st.isFile()) continue;
+      data.push({
+        filename,
+        size_bytes: st.size,
+        uploaded_at: new Date(st.mtimeMs).toISOString(),
+        media_type: guessSessionOutputMime(filename),
+      });
+    } catch {
+      // skip unreadable entries
+    }
+  }
+  return c.json({ data, has_more: false });
+});
+
+v1.get("/sessions/:id/outputs/:filename", async (c) => {
+  const sid = c.req.param("id");
+  const filename = c.req.param("filename");
+  // Path traversal guard — filename must be a single component.
+  if (filename.includes("..") || filename.includes("/") || filename.includes("\\")) {
+    return c.json({ error: "Invalid filename" }, 400);
+  }
+
+  const session = await sql
+    .prepare(`SELECT id FROM sessions WHERE tenant_id = ? AND id = ?`)
+    .bind(c.var.tenant_id, sid)
+    .first();
+  if (!session) return c.json({ error: "Session not found" }, 404);
+
+  const full = join(sessionOutputsDir(c.var.tenant_id, sid), filename);
+  let st;
+  try {
+    st = await fsStat(full);
+    if (!st.isFile()) return c.json({ error: "Output file not found" }, 404);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return c.json({ error: "Output file not found" }, 404);
+    }
+    throw err;
+  }
+
+  const nodeStream = createReadStream(full);
+  // Convert the node Readable into a Web ReadableStream for Hono.
+  const webStream = Readable.toWeb(nodeStream) as unknown as ReadableStream<Uint8Array>;
+  return new Response(webStream, {
+    headers: {
+      "Content-Type": guessSessionOutputMime(filename),
+      "Content-Length": String(st.size),
+      "Content-Disposition": `attachment; filename="${filename}"`,
+    },
+  });
 });
 
 // ── Vaults + credentials (Phase B-vault) ──────────────────────────────────

--- a/apps/main-node/src/registry.ts
+++ b/apps/main-node/src/registry.ts
@@ -53,6 +53,13 @@ export interface SessionRegistryDeps {
     tenantId: string,
   ): (opts: { sandbox: SandboxExecutor }) => Promise<void>;
 
+  /** Mount /mnt/session/outputs/ into the sandbox. Optional — operators
+   *  that don't configure an outputs root may omit it. */
+  buildSessionOutputsMounter?(
+    sessionId: string,
+    tenantId: string,
+  ): (opts: { sandbox: SandboxExecutor }) => Promise<void>;
+
   /** Build the LanguageModel for the agent. Reads env, applies custom
    *  headers, picks the right provider. */
   buildModel(agent: AgentConfig): LanguageModel;
@@ -181,6 +188,10 @@ export class SessionRegistry {
     });
 
     const memoryMounter = this.deps.buildMemoryMounter(sessionId, tenantId);
+    const outputsMounter = this.deps.buildSessionOutputsMounter?.(
+      sessionId,
+      tenantId,
+    );
 
     const machine = new SessionStateMachine({
       sessionId,
@@ -192,6 +203,7 @@ export class SessionRegistry {
         return row ?? null;
       },
       mountMemoryStores: memoryMounter,
+      mountSessionOutputs: outputsMounter,
       buildModel: (agent) => this.deps.buildModel(agent),
       buildTools: (agent, sb) => this.deps.buildTools(agent, sb),
       buildHarness: () => this.deps.buildHarness(),

--- a/apps/main/src/routes/files.ts
+++ b/apps/main/src/routes/files.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import type { Env } from "@open-managed-agents/shared";
-import { generateFileId, fileR2Key } from "@open-managed-agents/shared";
+import { generateFileId, fileR2Key, sessionOutputsPrefix } from "@open-managed-agents/shared";
 import { toFileRecord, FileNotFoundError } from "@open-managed-agents/files-store";
 import type { Services } from "@open-managed-agents/services";
 import { checkUploadFreq, checkUploadSize } from "../quotas";
@@ -14,7 +14,7 @@ const app = new Hono<{
 //
 // Files the agent writes to /mnt/session/outputs/ inside the sandbox land
 // in R2 under `t/<tenant>/session-outputs/<session>/<filename>` with no
-// D1 row (the mount is bytes-only, see sessions.ts:1985 SESSION_OUTPUTS_PREFIX).
+// D1 row (the mount is bytes-only — listing scans the R2 prefix directly).
 // To make these reachable through the standard AMA Files API, we synthesize
 // file rows on the fly:
 //
@@ -27,9 +27,6 @@ const app = new Hono<{
 // so we never need a backing index. base64url encoding so filenames with
 // special chars (spaces, slashes — though slashes shouldn't reach here)
 // don't break URL routing.
-
-const SESSION_OUTPUTS_PREFIX = (tenantId: string, sessionId: string) =>
-  `t/${tenantId}/session-outputs/${sessionId}/`;
 
 function encodeOutputId(sessionId: string, filename: string): string {
   // base64url; strip padding so the id stays URL-friendly
@@ -85,7 +82,7 @@ async function listSessionOutputAsFiles(
   tenantId: string,
   sessionId: string,
 ): Promise<ApiFileRecord[]> {
-  const prefix = SESSION_OUTPUTS_PREFIX(tenantId, sessionId);
+  const prefix = sessionOutputsPrefix(tenantId, sessionId);
   const list = await bucket.list({ prefix, limit: 1000 });
   return list.objects.map((o: R2Object) => {
     const filename = o.key.slice(prefix.length);
@@ -248,7 +245,7 @@ app.get("/:id", async (c) => {
   if (decoded) {
     const bucket = c.env.FILES_BUCKET;
     if (!bucket) return c.json({ error: "FILES_BUCKET binding not configured" }, 500);
-    const r2Key = `${SESSION_OUTPUTS_PREFIX(t, decoded.sessionId)}${decoded.filename}`;
+    const r2Key = `${sessionOutputsPrefix(t, decoded.sessionId)}${decoded.filename}`;
     const head = await bucket.head(r2Key);
     if (!head) return c.json({ error: "File not found" }, 404);
     const record: ApiFileRecord = {
@@ -285,7 +282,7 @@ app.get("/:id/content", async (c) => {
   // Synthesized session-output id: stream R2 directly.
   const decoded = decodeOutputId(id);
   if (decoded) {
-    const r2Key = `${SESSION_OUTPUTS_PREFIX(t, decoded.sessionId)}${decoded.filename}`;
+    const r2Key = `${sessionOutputsPrefix(t, decoded.sessionId)}${decoded.filename}`;
     const obj = await r2.get(r2Key);
     if (!obj) return c.json({ error: "File content not found" }, 404);
     return new Response(obj.body, {

--- a/apps/main/src/routes/sessions.ts
+++ b/apps/main/src/routes/sessions.ts
@@ -2,7 +2,7 @@ import { Hono } from "hono";
 import type { Context } from "hono";
 import type { Env } from "@open-managed-agents/shared";
 import type { UserMessageEvent, AgentConfig, EnvironmentConfig, StoredEvent, ContentBlock, CredentialConfig, SessionEvent, SessionResource } from "@open-managed-agents/shared";
-import { generateFileId, buildTrajectory, fileR2Key, generateEventId, LOCAL_RUNTIME_ENV_ID } from "@open-managed-agents/shared";
+import { generateFileId, buildTrajectory, fileR2Key, generateEventId, LOCAL_RUNTIME_ENV_ID, sessionOutputsPrefix, guessSessionOutputMime } from "@open-managed-agents/shared";
 import { logWarn, logError, recordEvent, errFields, classifyExternalError } from "@open-managed-agents/shared";
 import { rateLimitSessionCreate } from "../rate-limit";
 import { checkDailySessionCap } from "../quotas";
@@ -985,7 +985,7 @@ app.delete("/:id", async (c) => {
   // forever — and worse, becomes unreachable too because the outputs
   // route 404s once the session row is gone.
   if (c.env.FILES_BUCKET) {
-    const prefix = SESSION_OUTPUTS_PREFIX(t, id);
+    const prefix = sessionOutputsPrefix(t, id);
     let cursor: string | undefined;
     let deleted = 0;
     try {
@@ -2115,23 +2115,6 @@ function parseGitHubOrg(repoUrl: string): string | null {
 // can coexist: /outputs/ for transparent agent artefacts, /files for
 // explicit "save this for later cross-session reference" promotion.
 
-const SESSION_OUTPUTS_PREFIX = (tenantId: string, sessionId: string) =>
-  `t/${tenantId}/session-outputs/${sessionId}/`;
-
-const OUTPUT_MIME_GUESS: Record<string, string> = {
-  pdf: "application/pdf", png: "image/png", jpg: "image/jpeg", jpeg: "image/jpeg",
-  gif: "image/gif", webp: "image/webp", txt: "text/plain", md: "text/markdown",
-  csv: "text/csv", json: "application/json", html: "text/html", htm: "text/html",
-  mp4: "video/mp4", webm: "video/webm", mov: "video/quicktime",
-  mp3: "audio/mpeg", wav: "audio/wav", ogg: "audio/ogg",
-  zip: "application/zip", tar: "application/x-tar", gz: "application/gzip",
-};
-
-function guessOutputMime(filename: string): string {
-  const ext = filename.toLowerCase().split(".").pop() || "";
-  return OUTPUT_MIME_GUESS[ext] || "application/octet-stream";
-}
-
 // GET /v1/sessions/:id/outputs — list files agent wrote to /mnt/session/outputs/.
 app.get("/:id/outputs", async (c) => {
   const t = c.get("tenant_id");
@@ -2142,7 +2125,7 @@ app.get("/:id/outputs", async (c) => {
   const bucket = c.env.FILES_BUCKET;
   if (!bucket) return c.json({ error: "FILES_BUCKET binding not configured" }, 500);
 
-  const prefix = SESSION_OUTPUTS_PREFIX(t, id);
+  const prefix = sessionOutputsPrefix(t, id);
   const list = await bucket.list({ prefix, limit: 1000 });
 
   const data = list.objects.map((o: R2Object) => {
@@ -2151,7 +2134,7 @@ app.get("/:id/outputs", async (c) => {
       filename,
       size_bytes: o.size,
       uploaded_at: o.uploaded.toISOString(),
-      media_type: o.httpMetadata?.contentType || guessOutputMime(filename),
+      media_type: o.httpMetadata?.contentType || guessSessionOutputMime(filename),
     };
   });
   return c.json({ data, has_more: list.truncated });
@@ -2174,13 +2157,13 @@ app.get("/:id/outputs/:filename", async (c) => {
   const bucket = c.env.FILES_BUCKET;
   if (!bucket) return c.json({ error: "FILES_BUCKET binding not configured" }, 500);
 
-  const r2Key = `${SESSION_OUTPUTS_PREFIX(t, id)}${filename}`;
+  const r2Key = `${sessionOutputsPrefix(t, id)}${filename}`;
   const obj = await bucket.get(r2Key);
   if (!obj) return c.json({ error: "Output file not found" }, 404);
 
   return new Response(obj.body, {
     headers: {
-      "Content-Type": obj.httpMetadata?.contentType || guessOutputMime(filename),
+      "Content-Type": obj.httpMetadata?.contentType || guessSessionOutputMime(filename),
       "Content-Length": String(obj.size),
       "Content-Disposition": `attachment; filename="${filename}"`,
     },

--- a/docker-compose.postgres.yml
+++ b/docker-compose.postgres.yml
@@ -42,6 +42,7 @@ services:
       AUTH_DATABASE_PATH: /app/data/auth.db
       SANDBOX_WORKDIR: /app/data/sandboxes
       MEMORY_BLOB_DIR: /app/data/memory-blobs
+      SESSION_OUTPUTS_DIR: /app/data/session-outputs
       OMA_VAULT_PROXY_URL: http://oma-vault:14322
       OMA_VAULT_CA_CERT: /app/data/oma-vault-ca/ca.crt
       BETTER_AUTH_SECRET: ${BETTER_AUTH_SECRET:-}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,10 @@ services:
       AUTH_DATABASE_PATH: /app/data/auth.db
       SANDBOX_WORKDIR: /app/data/sandboxes
       MEMORY_BLOB_DIR: /app/data/memory-blobs
+      # Backing dir for /mnt/session/outputs/ — AMA-aligned magic dir the
+      # agent uses to deliver downloadable artefacts. Bind-mounted into
+      # ./data so files survive `docker stop`.
+      SESSION_OUTPUTS_DIR: /app/data/session-outputs
       # Outbound credential injection via the oma-vault sidecar. When set,
       # LocalSubprocessSandbox.setOutboundContext wires the subprocess env
       # to route HTTPS traffic through oma-vault for header injection.

--- a/packages/sandbox/src/adapters/local-subprocess.ts
+++ b/packages/sandbox/src/adapters/local-subprocess.ts
@@ -442,5 +442,6 @@ export const sandboxFactory: SandboxFactory = async (ctx) => {
   return new LocalSubprocessSandbox({
     workdir: ctx.workdir,
     memoryRoot: ctx.memoryRoot,
+    outputsRoot: ctx.outputsRoot,
   });
 };

--- a/packages/sandbox/src/ports.ts
+++ b/packages/sandbox/src/ports.ts
@@ -140,6 +140,10 @@ export interface SandboxFactoryContext {
    *  via symlink (LocalSubprocess) read from this; remote adapters
    *  (Daytona/E2B) typically use s3fs and ignore it. */
   memoryRoot?: string;
+  /** Session-outputs root on the host. LocalSubprocess symlinks
+   *  per-(tenant, session) dirs under here when mountSessionOutputs
+   *  is called; remote adapters that don't host-mount can ignore it. */
+  outputsRoot?: string;
 }
 
 /** Read-only view of process env handed to the factory. Whole `process.env`

--- a/packages/session-runtime/src/machine.ts
+++ b/packages/session-runtime/src/machine.ts
@@ -72,6 +72,12 @@ export interface SessionMachineDeps {
    *  the shell calls sandbox.mountMemoryStore directly via sandbox. */
   mountMemoryStores?(opts: { sandbox: SandboxExecutor }): Promise<void>;
 
+  /** Mount /mnt/session/outputs/ into the sandbox. Per-session bound
+   *  directory the agent uses to deliver final artefacts; the same path
+   *  is exposed by the main worker via GET /v1/sessions/:id/outputs.
+   *  Optional — sandboxes / hosts that don't support it skip silently. */
+  mountSessionOutputs?(opts: { sandbox: SandboxExecutor }): Promise<void>;
+
   /** Build the LanguageModel for this turn. CF reads env from
    *  bindings; Node from process.env. */
   buildModel(agent: AgentConfig): LanguageModel;
@@ -149,6 +155,14 @@ export class SessionStateMachine {
       // user.message without restarting.
       if (this.deps.mountMemoryStores) {
         await this.deps.mountMemoryStores({ sandbox: this.deps.sandbox });
+      }
+
+      // /mnt/session/outputs/ mount. Idempotent on the supported adapters
+      // (LocalSubprocess re-symlinks, CF re-mounts the R2 prefix), so
+      // re-running per turn is safe and means the path is always present
+      // for a fresh sandbox that warmed in this turn.
+      if (this.deps.mountSessionOutputs) {
+        await this.deps.mountSessionOutputs({ sandbox: this.deps.sandbox });
       }
 
       const tools = await this.deps.buildTools(agent, this.deps.sandbox);

--- a/packages/shared/src/file-storage.ts
+++ b/packages/shared/src/file-storage.ts
@@ -25,3 +25,32 @@ export function skillFileR2Key(
 ): string {
   return `t/${tenantId}/skills/${skillId}/${version}/${filename}`;
 }
+
+/**
+ * R2 key prefix for files the agent writes to /mnt/session/outputs/. Same
+ * tenant-isolated layout as fileR2Key but a separate top-level namespace
+ * so the regular /files surface and the magic-dir surface can't collide.
+ *
+ * Used by apps/main's session-outputs routes + cascade-delete cleanup;
+ * self-host Node uses the host filesystem under the equivalent path
+ * (<outputsRoot>/<tenantId>/<sessionId>/).
+ */
+export function sessionOutputsPrefix(tenantId: string, sessionId: string): string {
+  return `t/${tenantId}/session-outputs/${sessionId}/`;
+}
+
+/** Filename → media-type guess for `/mnt/session/outputs/` listings. Used
+ *  by the list endpoints when R2 / fs didn't record a contentType. */
+export const SESSION_OUTPUT_MIME_GUESS: Record<string, string> = {
+  pdf: "application/pdf", png: "image/png", jpg: "image/jpeg", jpeg: "image/jpeg",
+  gif: "image/gif", webp: "image/webp", txt: "text/plain", md: "text/markdown",
+  csv: "text/csv", json: "application/json", html: "text/html", htm: "text/html",
+  mp4: "video/mp4", webm: "video/webm", mov: "video/quicktime",
+  mp3: "audio/mpeg", wav: "audio/wav", ogg: "audio/ogg",
+  zip: "application/zip", tar: "application/x-tar", gz: "application/gzip",
+};
+
+export function guessSessionOutputMime(filename: string): string {
+  const ext = filename.toLowerCase().split(".").pop() || "";
+  return SESSION_OUTPUT_MIME_GUESS[ext] || "application/octet-stream";
+}


### PR DESCRIPTION
## Summary

PR #64 wired `/mnt/session/outputs/` and platform guidance (auth + loop-stop + outputs hint) on the CF side. The self-host Node path had neither — agents wrote final artefacts to `/workspace/` (lost on container recycle), and the system prompt skipped all three hints.

This closes the gap with **one source of truth for both surfaces**.

### What changed

- **`@open-managed-agents/agent/harness/platform-guidance`** — new module exporting the three guidance strings + `composeSystemPrompt()`. SessionDO + main-node compose their `systemPrompt` from here; byte-identical strings keep Anthropic's prompt cache prefix stable across deploy topologies.
- **`packages/session-runtime`** — `SessionMachineDeps` gains optional `mountSessionOutputs` hook (mirrors `mountMemoryStores`). Fires per turn so a fresh sandbox warmed mid-session picks up the mount.
- **`packages/sandbox`** — `SandboxFactoryContext.outputsRoot` plumbed through; `LocalSubprocessSandbox.mountSessionOutputs` already symlinks `<workdir>/.mnt/session/outputs` → `<outputsRoot>/<tenant>/<session>`, so no adapter changes needed.
- **`apps/main-node`** — `SESSION_OUTPUTS_DIR` env (default `./data/session-outputs`), `buildSessionOutputsMounter` wired through `SessionRegistry`, plus two new routes mirroring `apps/main`:
  - `GET /v1/sessions/:id/outputs` (list)
  - `GET /v1/sessions/:id/outputs/:filename` (stream)

  Same wire shape as the CF (R2-backed) routes — the console Files panel works against either backend with no UI change.
- **`packages/shared/file-storage`** — `sessionOutputsPrefix()` + `SESSION_OUTPUT_MIME_GUESS` + `guessSessionOutputMime()` so CF + Node share the R2 key layout and the MIME-extension table. Inline duplicates removed from `apps/main/routes/{sessions,files}.ts` and the `CloudflareSandbox` wrapper.
- **`docker-compose{,.postgres}.yml`** — `SESSION_OUTPUTS_DIR=/app/data/session-outputs` pinned so files survive `docker stop` via the host bind-mount.

### Verified end-to-end

Direct Node run **and** `docker compose up` (SQLite backend):

| Check | Result |
|---|---|
| First user.message triggers warmup → `mountSessionOutputs` fires | ✅ symlink at `sandboxes/<sid>/.mnt/session/outputs` → `session-outputs/default/<sid>/` |
| `GET /v1/sessions/:id/outputs` lists files with size, mtime, MIME | ✅ (text/markdown for `.md`, application/json for `.json`) |
| `GET /v1/sessions/:id/outputs/:filename` streams bytes | ✅ correct `Content-Type` + `Content-Length` + `Content-Disposition: attachment` |
| Path traversal `..%2Fpasswd` | ✅ 400 |
| Missing filename | ✅ 404 |
| Wrong session | ✅ 404 |
| `composeSystemPrompt()` contains all three guidance lines | ✅ for `agent.system="..."`, `""`, and `null` |
| Console UI served from container at `/` | ✅ 200 text/html |

> LLM-driven turn was **not** exercised in this run — the corp Anthropic proxy was unreachable from this network. Every layer the diff touches is exercised by the warmup + endpoint flow above; once a reachable `ANTHROPIC_BASE_URL` is configured, the agent's `write` tool drops straight into the same dir the routes serve from.

## Migrations

None.

## Test plan

- [ ] `docker compose -f docker-compose.yml up` against a reachable Anthropic endpoint
- [ ] Drive an agent to write to `/mnt/session/outputs/` via its `text_editor` / `write` tool
- [ ] Files panel in console shows the file, download works
- [ ] Empty session shows the empty-state copy unchanged