### PR TITLE
fix(web): point landing CTAs at app.openma.dev + redirect old Console paths

### DIFF
--- a/apps/web/src/layouts/Base.astro
+++ b/apps/web/src/layouts/Base.astro
@@ -123,7 +123,7 @@ const allSchemas = [organizationSchema(), websiteSchema(), ...schemas];
           <a href="https://docs.openma.dev">Docs</a>
           <a href="https://github.com/open-ma/open-managed-agents" target="_blank" rel="noopener">GitHub</a>
           <a
-            href="https://openma.dev/login"
+            href="https://app.openma.dev/login"
             class="px-3 py-1.5 rounded-md bg-[var(--color-fg)] text-[var(--color-bg)] font-medium"
             >Sign in</a
           >

--- a/apps/web/src/pages/index.astro
+++ b/apps/web/src/pages/index.astro
@@ -33,7 +33,7 @@ function formatDate(d: Date) {
       </p>
       <div class="mt-8 flex items-center justify-center gap-3 flex-wrap">
         <a
-          href="https://openma.dev/login"
+          href="https://app.openma.dev/login"
           class="px-5 py-3 rounded-md bg-[var(--color-fg)] text-[var(--color-bg)] font-medium"
           >Get started</a
         >
@@ -148,7 +148,7 @@ function formatDate(d: Date) {
       </p>
       <div class="flex items-center justify-center gap-3 flex-wrap">
         <a
-          href="https://openma.dev/login"
+          href="https://app.openma.dev/login"
           class="px-5 py-3 rounded-md bg-[var(--color-fg)] text-[var(--color-bg)] font-medium"
           >Try it free</a
         >

--- a/apps/web/src/worker.ts
+++ b/apps/web/src/worker.ts
@@ -1,22 +1,70 @@
 // Tiny shim that fronts the static Astro build:
-//   - www.openma.dev → 301 → openma.dev (apex is canonical)
-//   - everything else: pass through to env.ASSETS
-// Without this the worker would just be a pure-static `assets:` deploy
-// and CF custom-domain rules can't do hostname-level redirects on
-// their own. Worker code costs us nothing — assets short-circuit before
-// any JS runs for cache hits.
+//   - www.openma.dev/* → 301 → openma.dev/*  (apex is canonical)
+//   - openma.dev/{login,sessions,agents,...} → 301 → app.openma.dev/...
+//     (old bookmarks from when apex was the Console SPA)
+//   - everything else: pass through to env.ASSETS (Astro static)
+//
+// CF custom-domain rules can't do hostname-level redirects on their own,
+// and asset serving short-circuits before the worker unless
+// `assets.run_worker_first` is set in wrangler.jsonc.
 
 interface Env {
   ASSETS: { fetch: typeof fetch };
 }
 
+// Top-level paths that used to belong to the Console SPA when apex
+// was managed-agents. Catches old bookmarks + the few hardcoded
+// openma.dev/login links we already patched but might miss.
+const CONSOLE_PATH_PREFIXES = [
+  "/login",
+  "/signup",
+  "/sessions",
+  "/agents",
+  "/environments",
+  "/vaults",
+  "/dashboard",
+  "/billing",
+  "/settings",
+  "/integrations",
+  "/memory",
+  "/runtimes",
+  "/usage",
+];
+
+function isConsolePath(pathname: string): boolean {
+  return CONSOLE_PATH_PREFIXES.some(
+    (p) => pathname === p || pathname.startsWith(`${p}/`),
+  );
+}
+
+// www → apex: drop the leading "www." subdomain. Works for both prod
+// (www.openma.dev → openma.dev) and staging (www.staging.openma.dev →
+// staging.openma.dev). Keeps the path + query intact.
+function wwwToApex(url: URL): URL {
+  const out = new URL(url.toString());
+  out.hostname = out.hostname.replace(/^www\./, "");
+  return out;
+}
+
+// apex → app: same hostname swap, leading "app." prefix instead.
+function apexToApp(url: URL): URL {
+  const out = new URL(url.toString());
+  out.hostname = `app.${out.hostname}`;
+  return out;
+}
+
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     const url = new URL(request.url);
-    if (url.hostname === "www.openma.dev" || url.hostname === "www.staging.openma.dev") {
-      url.hostname = url.hostname.replace(/^www\./, "");
-      return Response.redirect(url.toString(), 301);
+
+    if (url.hostname.startsWith("www.")) {
+      return Response.redirect(wwwToApex(url).toString(), 301);
     }
+
+    if (isConsolePath(url.pathname)) {
+      return Response.redirect(apexToApp(url).toString(), 301);
+    }
+
     return env.ASSETS.fetch(request);
   },
 };


### PR DESCRIPTION
Live bug — `https://openma.dev/login` 404s because the landing site has no /login route (Console moved to app.openma.dev). Fix:

1. Repoint the three landing CTAs from `openma.dev/login` → `app.openma.dev/login`
2. Extend worker.ts: any request to `openma.dev/{login,sessions,agents,billing,…}` 301s to `app.openma.dev/<same-path>`. Catches stale bookmarks too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)