### PR TITLE
feat(secrets): encrypt credentials.auth + model_cards api keys; rename MCP_SIGNING_KEY → PLATFORM_ROOT_SECRET

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -1,2 +1,7 @@
 API_KEY=dev-test-key-change-me
 ANTHROPIC_API_KEY=sk-ant-xxx
+
+# Required: at-rest encryption key for credentials.auth and
+# model_cards.api_key_cipher. Workers throw at first request if missing.
+# Generate with:  openssl rand -base64 32
+PLATFORM_ROOT_SECRET=

--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,13 @@ ANTHROPIC_API_KEY=sk-...
 #   openssl rand -hex 32
 BETTER_AUTH_SECRET=
 
+# Required: at-rest encryption key for credentials.auth and
+# model_cards.api_key_cipher. The Cloudflare worker build refuses to start
+# without it (and the Node self-host is moving the same direction).
+# Generate with:
+#   openssl rand -base64 32
+PLATFORM_ROOT_SECRET=
+
 # Public base URL — used for cookie domain + OAuth redirect URLs. Defaults
 # to "*" trusted-origins if missing (only OK for local dev).
 # PUBLIC_BASE_URL=https://oma.example.com

--- a/apps/docs/src/content/docs/build/integrations.mdx
+++ b/apps/docs/src/content/docs/build/integrations.mdx
@@ -76,7 +76,7 @@ Use the abstract repos in `packages/integrations-adapters-cf/`. They give you ty
 
 ## Webhook security
 
-The base provider verifies webhook signatures using `MCP_SIGNING_KEY` for outbound delivery and per-provider signing keys for inbound. Don't bypass this. If the third-party service has its own signature scheme, validate it inside `parseWebhook` and return `null` on failure.
+The base provider verifies webhook signatures using `PLATFORM_ROOT_SECRET` for outbound delivery and per-provider signing keys for inbound. Don't bypass this. If the third-party service has its own signature scheme, validate it inside `parseWebhook` and return `null` on failure.
 
 <Aside type="caution" title="Tenant isolation">
   Every webhook event must be resolved to a tenant before dispatching. The adapters expose `findInstallationByExternalId` for this — use it.

--- a/apps/docs/src/content/docs/reference/configuration.mdx
+++ b/apps/docs/src/content/docs/reference/configuration.mdx
@@ -158,7 +158,7 @@ Required for self-host. Set as Worker secrets via `npx wrangler secret put NAME`
 | `BETTER_AUTH_SECRET` | main | better-auth session signing key |
 | `API_KEY` | main | Initial dev API key for the REST API |
 | `INTEGRATIONS_INTERNAL_SECRET` | main, integrations | Shared secret between main and integrations workers |
-| `MCP_SIGNING_KEY` | integrations | Signs outbound MCP tokens |
+| `PLATFORM_ROOT_SECRET` | main, integrations | Root secret for at-rest encryption (credentials, model card keys, integration tokens) and outbound MCP token signing |
 
 ### Optional integrations
 

--- a/apps/docs/src/content/docs/self-host/deploy.mdx
+++ b/apps/docs/src/content/docs/self-host/deploy.mdx
@@ -78,7 +78,7 @@ End-to-end deploy of openma to your own Cloudflare account. Plan on 30–60 minu
    npx wrangler secret put BETTER_AUTH_SECRET       # any random 32+ char string
    npx wrangler secret put API_KEY                  # initial dev API key
    npx wrangler secret put INTEGRATIONS_INTERNAL_SECRET   # shared between main + integrations
-   npx wrangler secret put MCP_SIGNING_KEY          # for outbound MCP token signing
+   npx wrangler secret put PLATFORM_ROOT_SECRET    # at-rest encryption + outbound MCP token signing
 
    # Per worker — repeat for apps/main, apps/agent, apps/integrations as needed
    npx wrangler secret put ANTHROPIC_API_KEY -c apps/agent/wrangler.jsonc

--- a/apps/integrations/src/env.ts
+++ b/apps/integrations/src/env.ts
@@ -25,7 +25,7 @@ export interface Env {
   // Signs short-lived JWTs handed to agent sessions for MCP tool calls.
   // Also used as the seed for AES-GCM token-at-rest encryption (with a
   // distinct label per use, so JWT signing keys ≠ token encryption keys).
-  MCP_SIGNING_KEY: string;
+  PLATFORM_ROOT_SECRET: string;
 
   // Shared secret with apps/main, gating /v1/internal/* endpoints. Must match
   // INTEGRATIONS_INTERNAL_SECRET on the main worker.

--- a/apps/integrations/src/wire.ts
+++ b/apps/integrations/src/wire.ts
@@ -37,7 +37,7 @@ function cfEnvOf(env: Env): CfContainerEnv {
   return {
     integrationsDb: env.INTEGRATIONS_DB,
     controlPlaneDb: env.AUTH_DB,
-    MCP_SIGNING_KEY: env.MCP_SIGNING_KEY,
+    PLATFORM_ROOT_SECRET: env.PLATFORM_ROOT_SECRET,
     MAIN: env.MAIN,
     INTEGRATIONS_INTERNAL_SECRET: env.INTEGRATIONS_INTERNAL_SECRET,
   };

--- a/apps/main/migrations/0001_schema.sql
+++ b/apps/main/migrations/0001_schema.sql
@@ -250,6 +250,12 @@ CREATE INDEX IF NOT EXISTS "idx_vaults_tenant"
 -- Three auth types: mcp_oauth | static_bearer | command_secret.
 -- Hot fields denormalized to dedicated columns for indexing; full
 -- CredentialAuth as JSON in `auth`. Writers MUST keep them in sync.
+--
+-- `auth` is encrypted at rest via AES-256-GCM (WebCryptoAesGcm with the
+-- `credentials.auth` HKDF label). Format: base64url(iv || ciphertext).
+-- Wired in packages/services/src/index.ts. Hot-path columns (auth_type,
+-- mcp_server_url, provider) stay plaintext — they're SQL index keys, not
+-- secrets.
 -- ============================================================
 
 CREATE TABLE IF NOT EXISTS "credentials" (
@@ -459,9 +465,9 @@ CREATE INDEX IF NOT EXISTS "idx_eval_runs_status_active"
 -- ============================================================
 -- MODEL CARDS (packages/model-cards-store)
 -- Replaces t:{tenant}:modelcard:{id} + t:{tenant}:modelcard:{id}:key KV.
--- api_key_cipher is opaque (Crypto port output). Default service factory
--- uses identity Crypto so values match legacy KV cleartext until a real
--- AES-GCM impl is wired (see model-cards-store INTEGRATION_GUIDE.md).
+-- api_key_cipher is AES-256-GCM (WebCryptoAesGcm with the
+-- `model.cards.keys` HKDF label). Format: base64url(iv || ciphertext).
+-- Wired in packages/services/src/index.ts.
 -- ============================================================
 
 CREATE TABLE IF NOT EXISTS "model_cards" (

--- a/apps/main/src/routes/integrations.ts
+++ b/apps/main/src/routes/integrations.ts
@@ -44,16 +44,16 @@ app.use("*", async (c, next) => {
 
 /**
  * Build the integrations repo bag for this request. Returns null with a 503
- * Response when MCP_SIGNING_KEY is missing — caller should `return` it.
+ * Response when PLATFORM_ROOT_SECRET is missing — caller should `return` it.
  *
  * apps/main consumes only the repo half of the integrations Container; the
  * SessionCreator/VaultManager half lives in apps/integrations because it
  * needs the MAIN service binding (which apps/main does not have on itself).
  */
 function reposOr503(c: { env: Env; json: (b: unknown, s?: number) => Response }) {
-  const k = (c.env as unknown as Record<string, unknown>).MCP_SIGNING_KEY;
+  const k = (c.env as unknown as Record<string, unknown>).PLATFORM_ROOT_SECRET;
   if (typeof k !== "string" || !k) {
-    return { repos: null, err: c.json({ error: "MCP_SIGNING_KEY not configured" }, 503) as Response };
+    return { repos: null, err: c.json({ error: "PLATFORM_ROOT_SECRET not configured" }, 503) as Response };
   }
   if (!c.env.INTEGRATIONS_DB) {
     return { repos: null, err: c.json({ error: "INTEGRATIONS_DB binding missing" }, 503) as Response };
@@ -62,7 +62,7 @@ function reposOr503(c: { env: Env; json: (b: unknown, s?: number) => Response })
     repos: buildCfRepos({
       integrationsDb: c.env.INTEGRATIONS_DB,
       controlPlaneDb: c.env.AUTH_DB,
-      MCP_SIGNING_KEY: k,
+      PLATFORM_ROOT_SECRET: k,
     }),
     err: null,
   };
@@ -74,9 +74,9 @@ function reposOr503(c: { env: Env; json: (b: unknown, s?: number) => Response })
  * setup the linear/github routes use.
  */
 function slackReposOr503(c: { env: Env; json: (b: unknown, s?: number) => Response }) {
-  const k = (c.env as unknown as Record<string, unknown>).MCP_SIGNING_KEY;
+  const k = (c.env as unknown as Record<string, unknown>).PLATFORM_ROOT_SECRET;
   if (typeof k !== "string" || !k) {
-    return { repos: null, err: c.json({ error: "MCP_SIGNING_KEY not configured" }, 503) as Response };
+    return { repos: null, err: c.json({ error: "PLATFORM_ROOT_SECRET not configured" }, 503) as Response };
   }
   if (!c.env.INTEGRATIONS_DB) {
     return { repos: null, err: c.json({ error: "INTEGRATIONS_DB binding missing" }, 503) as Response };
@@ -103,9 +103,9 @@ function slackReposOr503(c: { env: Env; json: (b: unknown, s?: number) => Respon
  * the same shape as `slackReposOr503` so the route handlers stay symmetric.
  */
 function githubReposOr503(c: { env: Env; json: (b: unknown, s?: number) => Response }) {
-  const k = (c.env as unknown as Record<string, unknown>).MCP_SIGNING_KEY;
+  const k = (c.env as unknown as Record<string, unknown>).PLATFORM_ROOT_SECRET;
   if (typeof k !== "string" || !k) {
-    return { repos: null, err: c.json({ error: "MCP_SIGNING_KEY not configured" }, 503) as Response };
+    return { repos: null, err: c.json({ error: "PLATFORM_ROOT_SECRET not configured" }, 503) as Response };
   }
   if (!c.env.INTEGRATIONS_DB) {
     return { repos: null, err: c.json({ error: "INTEGRATIONS_DB binding missing" }, 503) as Response };

--- a/docs/lanes.md
+++ b/docs/lanes.md
@@ -111,7 +111,7 @@ Required CI vars/secrets (already used by `deploy.yml`):
 - `vars.CLOUDFLARE_ACCOUNT_ID`
 - `secrets.CLOUDFLARE_API_TOKEN`
 - `secrets.API_KEY`, `secrets.ANTHROPIC_API_KEY`, `secrets.BETTER_AUTH_SECRET`,
-  `secrets.INTEGRATIONS_INTERNAL_SECRET`, `secrets.MCP_SIGNING_KEY`,
+  `secrets.INTEGRATIONS_INTERNAL_SECRET`, `secrets.PLATFORM_ROOT_SECRET`,
   `secrets.INTERNAL_TOKEN`
 - Optional: `secrets.ANTHROPIC_BASE_URL`, `secrets.TAVILY_API_KEY`
 

--- a/docs/linear-integration-sop.md
+++ b/docs/linear-integration-sop.md
@@ -38,11 +38,11 @@ export GATEWAY="https://managed-agents-integrations.acme.workers.dev"
 
 ```bash
 # Random 32 bytes, base64. Run twice — DIFFERENT values for each var.
-openssl rand -base64 32   # MCP_SIGNING_KEY
+openssl rand -base64 32   # PLATFORM_ROOT_SECRET
 openssl rand -base64 32   # INTEGRATIONS_INTERNAL_SECRET
 ```
 
-Save both to your password manager. The same `MCP_SIGNING_KEY` and `INTEGRATIONS_INTERNAL_SECRET` are set on **both** the gateway worker and the main worker. If they don't match, things fail with "401 unauthorized" or "invalid token".
+Save both to your password manager. The same `PLATFORM_ROOT_SECRET` and `INTEGRATIONS_INTERNAL_SECRET` are set on **both** the gateway worker and the main worker. If they don't match, things fail with "401 unauthorized" or "invalid token".
 
 ---
 
@@ -87,7 +87,7 @@ Commit this change. (Different env? Use a `[env.production]` block, but for one-
 cd apps/integrations
 
 # Set the 2 secrets (paste the value when prompted)
-wrangler secret put MCP_SIGNING_KEY                # from step 2
+wrangler secret put PLATFORM_ROOT_SECRET                # from step 2
 wrangler secret put INTEGRATIONS_INTERNAL_SECRET   # from step 2
 
 # Deploy
@@ -111,7 +111,7 @@ If you get HTML instead of JSON, the URL is wrong (probably hitting your main wo
 cd apps/main
 
 # Same two secrets — MUST match step 2's values exactly
-wrangler secret put MCP_SIGNING_KEY
+wrangler secret put PLATFORM_ROOT_SECRET
 wrangler secret put INTEGRATIONS_INTERNAL_SECRET
 
 wrangler deploy
@@ -221,17 +221,17 @@ In Linear, this agent appears as its own user with `@<persona>` autocomplete and
 
 ### Rotate per-app `client_secret` or `webhook_secret`
 
-Per-app secrets live in D1 (`linear_apps.client_secret_cipher` / `webhook_secret_cipher`), encrypted with `MCP_SIGNING_KEY`. To rotate one publication's secrets without rotating `MCP_SIGNING_KEY`:
+Per-app secrets live in D1 (`linear_apps.client_secret_cipher` / `webhook_secret_cipher`), encrypted with `PLATFORM_ROOT_SECRET`. To rotate one publication's secrets without rotating `PLATFORM_ROOT_SECRET`:
 
 1. In Linear app settings, click "Regenerate" for the secret.
 2. Re-publish from Console (the wizard re-encrypts and writes the new value).
 
-### Rotate `MCP_SIGNING_KEY`
+### Rotate `PLATFORM_ROOT_SECRET`
 
 ⚠️ **Destructive**: rotating this orphans all encrypted-at-rest tokens (`linear_installations.access_token_cipher`, `linear_apps.client_secret_cipher`, etc.). Existing publications will fail with "missing client secret" until they're re-installed.
 
 Process:
-1. `wrangler secret put MCP_SIGNING_KEY` on **both** workers.
+1. `wrangler secret put PLATFORM_ROOT_SECRET` on **both** workers.
 2. `wrangler deploy` both.
 3. Tell users to re-publish their Linear integrations from Console.
 
@@ -261,13 +261,13 @@ Skip step 1 (no public URL needed). Use `wrangler dev` for both workers:
 # Terminal 1 — gateway
 cd apps/integrations
 echo 'GATEWAY_ORIGIN = "http://localhost:8788"' > .dev.vars
-echo 'MCP_SIGNING_KEY = "..."' >> .dev.vars
+echo 'PLATFORM_ROOT_SECRET = "..."' >> .dev.vars
 echo 'INTEGRATIONS_INTERNAL_SECRET = "..."' >> .dev.vars
 wrangler dev --port 8788
 
 # Terminal 2 — main
 cd apps/main
-echo 'MCP_SIGNING_KEY = "..."' > .dev.vars
+echo 'PLATFORM_ROOT_SECRET = "..."' > .dev.vars
 echo 'INTEGRATIONS_INTERNAL_SECRET = "..."' >> .dev.vars
 wrangler dev --port 8787
 ```

--- a/docs/zh-CN/lanes.zh-CN.md
+++ b/docs/zh-CN/lanes.zh-CN.md
@@ -84,7 +84,7 @@ CI 必须配置（`deploy.yml` 也已经在用）：
 - `vars.CF_SUBDOMAIN` —— 你 Cloudflare 账号的 workers.dev 子域
 - `vars.CLOUDFLARE_ACCOUNT_ID`
 - `secrets.CLOUDFLARE_API_TOKEN`
-- `secrets.API_KEY`、`secrets.ANTHROPIC_API_KEY`、`secrets.BETTER_AUTH_SECRET`、`secrets.INTEGRATIONS_INTERNAL_SECRET`、`secrets.MCP_SIGNING_KEY`、`secrets.INTERNAL_TOKEN`
+- `secrets.API_KEY`、`secrets.ANTHROPIC_API_KEY`、`secrets.BETTER_AUTH_SECRET`、`secrets.INTEGRATIONS_INTERNAL_SECRET`、`secrets.PLATFORM_ROOT_SECRET`、`secrets.INTERNAL_TOKEN`
 - 可选：`secrets.ANTHROPIC_BASE_URL`、`secrets.TAVILY_API_KEY`
 
 Lane 使用 Cloudflare 公开的「永远通过」Turnstile key（site `1x00000000000000000000AA` / secret `1x0000000000000000000000000000000AA`），这两个值硬编码在 `lane-generate.mjs` 和 `deploy-lane.yml` 里，让 `/auth/*` 流程不依赖把 prod 的真实 Turnstile secret 暴露到 lane。**不要在 lane 上用敏感凭据注册账号——AUTH_DB 与 prod 共享，用户记录会持久存在。**

--- a/docs/zh-CN/linear-integration-sop.zh-CN.md
+++ b/docs/zh-CN/linear-integration-sop.zh-CN.md
@@ -38,11 +38,11 @@ export GATEWAY="https://managed-agents-integrations.acme.workers.dev"
 
 ```bash
 # 32 字节随机，base64。**跑两次——两次的值必须不同**。
-openssl rand -base64 32   # MCP_SIGNING_KEY
+openssl rand -base64 32   # PLATFORM_ROOT_SECRET
 openssl rand -base64 32   # INTEGRATIONS_INTERNAL_SECRET
 ```
 
-两个都存进密码管理器。同样的 `MCP_SIGNING_KEY` 和 `INTEGRATIONS_INTERNAL_SECRET` 要在 **gateway worker 和 main worker 双方**都配。**两边不一致就会报「401 unauthorized」或「invalid token」。**
+两个都存进密码管理器。同样的 `PLATFORM_ROOT_SECRET` 和 `INTEGRATIONS_INTERNAL_SECRET` 要在 **gateway worker 和 main worker 双方**都配。**两边不一致就会报「401 unauthorized」或「invalid token」。**
 
 ---
 
@@ -87,7 +87,7 @@ Linear 只会展示 `client_id` + `client_secret` **一次**。把它们贴回 C
 cd apps/integrations
 
 # 设置 2 个 secret（提示输入时贴值进去）
-wrangler secret put MCP_SIGNING_KEY                # 第 2 步生成
+wrangler secret put PLATFORM_ROOT_SECRET                # 第 2 步生成
 wrangler secret put INTEGRATIONS_INTERNAL_SECRET   # 第 2 步生成
 
 # 部署
@@ -111,7 +111,7 @@ curl $GATEWAY/health
 cd apps/main
 
 # 同样的两个 secret —— 必须与第 2 步的值**完全一致**
-wrangler secret put MCP_SIGNING_KEY
+wrangler secret put PLATFORM_ROOT_SECRET
 wrangler secret put INTEGRATIONS_INTERNAL_SECRET
 
 wrangler deploy
@@ -222,18 +222,18 @@ curl -b 'session=...' https://<MAIN>/v1/integrations/linear/installations
 
 ### 轮换 per-app 的 `client_secret` 或 `webhook_secret`
 
-这些 per-app secret 存在 D1（`linear_apps.client_secret_cipher` / `webhook_secret_cipher`），用 `MCP_SIGNING_KEY` 加密。要轮换某一个 publication 的 secret 而不动 `MCP_SIGNING_KEY`：
+这些 per-app secret 存在 D1（`linear_apps.client_secret_cipher` / `webhook_secret_cipher`），用 `PLATFORM_ROOT_SECRET` 加密。要轮换某一个 publication 的 secret 而不动 `PLATFORM_ROOT_SECRET`：
 
 1. 在 Linear app 设置里，对该 secret 点「Regenerate」。
 2. 在 Console 重新走一次 publish（向导会用新值重新加密并写入）。
 
-### 轮换 `MCP_SIGNING_KEY`
+### 轮换 `PLATFORM_ROOT_SECRET`
 
 ⚠️ **破坏性**：轮换它会让所有静态加密的 token 全部成「孤儿」（`linear_installations.access_token_cipher`、`linear_apps.client_secret_cipher` 等）。已有的 publication 都会因「missing client secret」失败，直到重新安装。
 
 流程：
 
-1. 在**两个 worker**上 `wrangler secret put MCP_SIGNING_KEY`。
+1. 在**两个 worker**上 `wrangler secret put PLATFORM_ROOT_SECRET`。
 2. 两个 worker 都 `wrangler deploy`。
 3. 通知用户从 Console 重新发布 Linear 集成。
 
@@ -263,13 +263,13 @@ curl -b 'session=...' https://<MAIN>/v1/integrations/linear/installations
 # 终端 1 —— gateway
 cd apps/integrations
 echo 'GATEWAY_ORIGIN = "http://localhost:8788"' > .dev.vars
-echo 'MCP_SIGNING_KEY = "..."' >> .dev.vars
+echo 'PLATFORM_ROOT_SECRET = "..."' >> .dev.vars
 echo 'INTEGRATIONS_INTERNAL_SECRET = "..."' >> .dev.vars
 wrangler dev --port 8788
 
 # 终端 2 —— main
 cd apps/main
-echo 'MCP_SIGNING_KEY = "..."' > .dev.vars
+echo 'PLATFORM_ROOT_SECRET = "..."' > .dev.vars
 echo 'INTEGRATIONS_INTERNAL_SECRET = "..."' >> .dev.vars
 wrangler dev --port 8787
 ```

--- a/packages/credentials-store/src/adapters/index.ts
+++ b/packages/credentials-store/src/adapters/index.ts
@@ -5,16 +5,16 @@ export { SqlCredentialRepo } from "./sql-credential-repo";
 import { SqlCredentialRepo } from "./sql-credential-repo";
 import { CfD1SqlClient } from "@open-managed-agents/sql-client/adapters/cf-d1";
 import type { SqlClient } from "@open-managed-agents/sql-client";
-import type { Logger } from "../ports";
+import type { Crypto, Logger } from "../ports";
 import { CredentialService } from "../service";
 
 /** CF deployment factory. */
 export function createCfCredentialService(
   deps: { db: D1Database },
-  opts?: { logger?: Logger },
+  opts?: { logger?: Logger; crypto?: Crypto },
 ): CredentialService {
   return new CredentialService({
-    repo: new SqlCredentialRepo(new CfD1SqlClient(deps.db)),
+    repo: new SqlCredentialRepo(new CfD1SqlClient(deps.db), { crypto: opts?.crypto }),
     logger: opts?.logger,
   });
 }
@@ -22,10 +22,10 @@ export function createCfCredentialService(
 /** Node deployment factory — accepts any SqlClient. */
 export function createSqliteCredentialService(
   deps: { client: SqlClient },
-  opts?: { logger?: Logger },
+  opts?: { logger?: Logger; crypto?: Crypto },
 ): CredentialService {
   return new CredentialService({
-    repo: new SqlCredentialRepo(deps.client),
+    repo: new SqlCredentialRepo(deps.client, { crypto: opts?.crypto }),
     logger: opts?.logger,
   });
 }

--- a/packages/credentials-store/src/adapters/sql-credential-repo.ts
+++ b/packages/credentials-store/src/adapters/sql-credential-repo.ts
@@ -4,6 +4,7 @@ import { CredentialDuplicateMcpUrlError, CredentialNotFoundError } from "../erro
 import type {
   CredentialRepo,
   CredentialUpdateFields,
+  Crypto,
   NewCredentialInput,
 } from "../ports";
 import type { CredentialRow } from "../types";
@@ -15,11 +16,22 @@ import type { CredentialRow } from "../types";
  * Hot fields (auth_type, mcp_server_url, provider) are denormalized into their
  * own columns for indexing; the full CredentialAuth lives in the `auth` JSON
  * column. Writers must keep them in sync — see `bindAuthColumns`.
+ *
+ * The `auth` column is encrypted via the {@link Crypto} port. The denormalized
+ * hot-path columns stay plaintext (they're SQL index keys, not secrets).
+ * See ports.ts for the rationale on placing crypto at the repo layer.
  */
 export class SqlCredentialRepo implements CredentialRepo {
-  constructor(private readonly db: SqlClient) {}
+  private readonly db: SqlClient;
+  private readonly crypto: Crypto;
+
+  constructor(db: SqlClient, opts?: { crypto?: Crypto }) {
+    this.db = db;
+    this.crypto = opts?.crypto ?? identityCrypto;
+  }
 
   async insert(input: NewCredentialInput): Promise<CredentialRow> {
+    const authCipher = await this.crypto.encrypt(JSON.stringify(input.auth));
     try {
       await this.db
         .prepare(
@@ -35,7 +47,7 @@ export class SqlCredentialRepo implements CredentialRepo {
           input.auth.type,
           input.auth.mcp_server_url ?? null,
           input.auth.provider ?? null,
-          JSON.stringify(input.auth),
+          authCipher,
           input.createdAt,
         )
         .run();
@@ -61,7 +73,7 @@ export class SqlCredentialRepo implements CredentialRepo {
       )
       .bind(credentialId, tenantId, vaultId)
       .first<DbCredential>();
-    return row ? toRow(row) : null;
+    return row ? await this.toRow(row) : null;
   }
 
   async list(
@@ -76,7 +88,7 @@ export class SqlCredentialRepo implements CredentialRepo {
          FROM credentials WHERE tenant_id = ? AND vault_id = ? AND archived_at IS NULL
          ORDER BY created_at ASC`;
     const result = await this.db.prepare(sql).bind(tenantId, vaultId).all<DbCredential>();
-    return (result.results ?? []).map(toRow);
+    return this.toRows(result.results ?? []);
   }
 
   async countAll(tenantId: string, vaultId: string): Promise<number> {
@@ -101,7 +113,7 @@ export class SqlCredentialRepo implements CredentialRepo {
       )
       .bind(tenantId, vaultId, mcpServerUrl)
       .first<DbCredential>();
-    return row ? toRow(row) : null;
+    return row ? await this.toRow(row) : null;
   }
 
   async listByVaults(tenantId: string, vaultIds: string[]): Promise<CredentialRow[]> {
@@ -116,7 +128,7 @@ export class SqlCredentialRepo implements CredentialRepo {
       )
       .bind(tenantId, ...vaultIds)
       .all<DbCredential>();
-    return (result.results ?? []).map(toRow);
+    return this.toRows(result.results ?? []);
   }
 
   async listProviderTagged(tenantId: string, vaultIds: string[]): Promise<CredentialRow[]> {
@@ -131,7 +143,7 @@ export class SqlCredentialRepo implements CredentialRepo {
       )
       .bind(tenantId, ...vaultIds)
       .all<DbCredential>();
-    return (result.results ?? []).map(toRow);
+    return this.toRows(result.results ?? []);
   }
 
   async update(
@@ -149,13 +161,15 @@ export class SqlCredentialRepo implements CredentialRepo {
     if (update.auth !== undefined) {
       // Keep denormalized columns in sync with the JSON blob. mcp_server_url
       // is immutable per service-layer check, but we still rewrite it for
-      // correctness if a caller ever bypasses the service.
+      // correctness if a caller ever bypasses the service. The JSON blob is
+      // encrypted; the denormalized columns stay plaintext for indexing.
+      const authCipher = await this.crypto.encrypt(JSON.stringify(update.auth));
       sets.push("auth_type = ?", "mcp_server_url = ?", "provider = ?", "auth = ?");
       binds.push(
         update.auth.type,
         update.auth.mcp_server_url ?? null,
         update.auth.provider ?? null,
-        JSON.stringify(update.auth),
+        authCipher,
       );
     }
     sets.push("updated_at = ?");
@@ -216,6 +230,24 @@ export class SqlCredentialRepo implements CredentialRepo {
       .bind(credentialId, tenantId, vaultId)
       .run();
   }
+
+  private async toRow(r: DbCredential): Promise<CredentialRow> {
+    const authJson = await this.crypto.decrypt(r.auth);
+    return {
+      id: r.id,
+      tenant_id: r.tenant_id,
+      vault_id: r.vault_id,
+      display_name: r.display_name,
+      auth: JSON.parse(authJson) as CredentialAuth,
+      created_at: msToIso(r.created_at),
+      updated_at: r.updated_at !== null ? msToIso(r.updated_at) : null,
+      archived_at: r.archived_at !== null ? msToIso(r.archived_at) : null,
+    };
+  }
+
+  private async toRows(rs: DbCredential[]): Promise<CredentialRow[]> {
+    return Promise.all(rs.map((r) => this.toRow(r)));
+  }
 }
 
 interface DbCredential {
@@ -223,23 +255,10 @@ interface DbCredential {
   tenant_id: string;
   vault_id: string;
   display_name: string;
-  auth: string; // JSON
+  auth: string; // ciphertext (was: plaintext JSON pre-encryption rollout)
   created_at: number;
   updated_at: number | null;
   archived_at: number | null;
-}
-
-function toRow(r: DbCredential): CredentialRow {
-  return {
-    id: r.id,
-    tenant_id: r.tenant_id,
-    vault_id: r.vault_id,
-    display_name: r.display_name,
-    auth: JSON.parse(r.auth) as CredentialAuth,
-    created_at: msToIso(r.created_at),
-    updated_at: r.updated_at !== null ? msToIso(r.updated_at) : null,
-    archived_at: r.archived_at !== null ? msToIso(r.archived_at) : null,
-  };
 }
 
 function msToIso(ms: number): string {
@@ -257,3 +276,17 @@ function isMcpUrlUniqueViolation(err: unknown): boolean {
     (/mcp_server_url/i.test(msg) || /idx_credentials_mcp_url_active/i.test(msg))
   );
 }
+
+/**
+ * Identity (passthrough) crypto — used as the default when callers don't wire
+ * a real one. Matches the legacy plaintext-on-disk behavior so existing tests
+ * keep working without ceremony. Production wiring MUST override this.
+ */
+const identityCrypto: Crypto = {
+  async encrypt(plaintext) {
+    return plaintext;
+  },
+  async decrypt(ciphertext) {
+    return ciphertext;
+  },
+};

--- a/packages/credentials-store/src/ports.ts
+++ b/packages/credentials-store/src/ports.ts
@@ -121,3 +121,22 @@ export interface IdGenerator {
 export interface Logger {
   warn(msg: string, ctx?: unknown): void;
 }
+
+/**
+ * Symmetric encryption boundary for the `auth` JSON blob at rest.
+ *
+ * Wired at the repo layer (not the service layer) so that the read-merge-write
+ * semantics in CredentialService.update / refreshAuth stay transparent — the
+ * service sees plaintext-typed CredentialRow regardless of on-disk format.
+ *
+ * Default repo wiring uses an identity (passthrough) crypto so existing
+ * in-memory tests keep working. Production callers MUST pass a real
+ * implementation (e.g. WebCryptoAesGcm).
+ *
+ * The hot-path columns (auth_type, mcp_server_url, provider) stay plaintext —
+ * they're SQL index keys, not secrets. Only the `auth` JSON blob is encrypted.
+ */
+export interface Crypto {
+  encrypt(plaintext: string): Promise<string>;
+  decrypt(ciphertext: string): Promise<string>;
+}

--- a/packages/credentials-store/src/test-fakes.ts
+++ b/packages/credentials-store/src/test-fakes.ts
@@ -1,6 +1,11 @@
 // In-memory implementations of every port for unit tests. Mirrors the partial
 // UNIQUE semantics + cascade behavior of the D1 adapter so tests catch the same
 // constraint violations.
+//
+// Crypto symmetry: this fake mirrors SqlCredentialRepo's encrypt-on-write /
+// decrypt-on-read boundary. By default it uses an identity (passthrough)
+// crypto so existing tests keep working unchanged. Pass a custom Crypto (e.g.
+// FakeCrypto below) to exercise the encryption path in a unit test.
 
 import type { CredentialAuth } from "@open-managed-agents/shared";
 import { CredentialDuplicateMcpUrlError, CredentialNotFoundError } from "./errors";
@@ -8,6 +13,7 @@ import type {
   Clock,
   CredentialRepo,
   CredentialUpdateFields,
+  Crypto,
   IdGenerator,
   Logger,
   NewCredentialInput,
@@ -15,12 +21,20 @@ import type {
 import { CredentialService } from "./service";
 import type { CredentialRow } from "./types";
 
+/**
+ * In-memory row mirrors the SQL schema: hot-path fields denormalized
+ * alongside an encrypted `auth_cipher` blob. Crypto is optional — defaults to
+ * identity so the row's `auth_cipher` is just `JSON.stringify(auth)`.
+ */
 interface InMemCredential {
   id: string;
   tenant_id: string;
   vault_id: string;
   display_name: string;
-  auth: CredentialAuth;
+  auth_type: string;
+  mcp_server_url: string | null;
+  provider: string | null;
+  auth_cipher: string;
   created_at: number;
   updated_at: number | null;
   archived_at: number | null;
@@ -28,6 +42,11 @@ interface InMemCredential {
 
 export class InMemoryCredentialRepo implements CredentialRepo {
   private readonly byId = new Map<string, InMemCredential>();
+  private readonly crypto: Crypto;
+
+  constructor(opts?: { crypto?: Crypto }) {
+    this.crypto = opts?.crypto ?? identityCrypto;
+  }
 
   async insert(input: NewCredentialInput): Promise<CredentialRow> {
     // Match the D1 partial UNIQUE: (tenant_id, vault_id, mcp_server_url)
@@ -38,7 +57,7 @@ export class InMemoryCredentialRepo implements CredentialRepo {
           c.tenant_id === input.tenantId &&
           c.vault_id === input.vaultId &&
           c.archived_at === null &&
-          c.auth.mcp_server_url === input.auth.mcp_server_url
+          c.mcp_server_url === input.auth.mcp_server_url
         ) {
           throw new CredentialDuplicateMcpUrlError();
         }
@@ -49,20 +68,23 @@ export class InMemoryCredentialRepo implements CredentialRepo {
       tenant_id: input.tenantId,
       vault_id: input.vaultId,
       display_name: input.displayName,
-      auth: input.auth,
+      auth_type: input.auth.type,
+      mcp_server_url: input.auth.mcp_server_url ?? null,
+      provider: input.auth.provider ?? null,
+      auth_cipher: await this.crypto.encrypt(JSON.stringify(input.auth)),
       created_at: input.createdAt,
       updated_at: null,
       archived_at: null,
     };
     this.byId.set(input.id, row);
-    return toRow(row);
+    return await this.toRow(row);
   }
 
   async get(tenantId: string, vaultId: string, credentialId: string): Promise<CredentialRow | null> {
     const row = this.byId.get(credentialId);
     if (!row) return null;
     if (row.tenant_id !== tenantId || row.vault_id !== vaultId) return null;
-    return toRow(row);
+    return await this.toRow(row);
   }
 
   async list(
@@ -70,11 +92,11 @@ export class InMemoryCredentialRepo implements CredentialRepo {
     vaultId: string,
     opts: { includeArchived: boolean },
   ): Promise<CredentialRow[]> {
-    return Array.from(this.byId.values())
+    const matches = Array.from(this.byId.values())
       .filter((c) => c.tenant_id === tenantId && c.vault_id === vaultId)
       .filter((c) => opts.includeArchived || c.archived_at === null)
-      .sort((a, b) => a.created_at - b.created_at)
-      .map(toRow);
+      .sort((a, b) => a.created_at - b.created_at);
+    return Promise.all(matches.map((m) => this.toRow(m)));
   }
 
   async countAll(tenantId: string, vaultId: string): Promise<number> {
@@ -95,9 +117,9 @@ export class InMemoryCredentialRepo implements CredentialRepo {
         c.tenant_id === tenantId &&
         c.vault_id === vaultId &&
         c.archived_at === null &&
-        c.auth.mcp_server_url === mcpServerUrl
+        c.mcp_server_url === mcpServerUrl
       ) {
-        return toRow(c);
+        return await this.toRow(c);
       }
     }
     return null;
@@ -106,24 +128,23 @@ export class InMemoryCredentialRepo implements CredentialRepo {
   async listByVaults(tenantId: string, vaultIds: string[]): Promise<CredentialRow[]> {
     if (!vaultIds.length) return [];
     const set = new Set(vaultIds);
-    return Array.from(this.byId.values())
+    const matches = Array.from(this.byId.values())
       .filter((c) => c.tenant_id === tenantId && set.has(c.vault_id))
-      .sort((a, b) => a.created_at - b.created_at)
-      .map(toRow);
+      .sort((a, b) => a.created_at - b.created_at);
+    return Promise.all(matches.map((m) => this.toRow(m)));
   }
 
   async listProviderTagged(tenantId: string, vaultIds: string[]): Promise<CredentialRow[]> {
     if (!vaultIds.length) return [];
     const set = new Set(vaultIds);
-    return Array.from(this.byId.values())
-      .filter(
-        (c) =>
-          c.tenant_id === tenantId &&
-          set.has(c.vault_id) &&
-          c.archived_at === null &&
-          !!c.auth.provider,
-      )
-      .map(toRow);
+    const matches = Array.from(this.byId.values()).filter(
+      (c) =>
+        c.tenant_id === tenantId &&
+        set.has(c.vault_id) &&
+        c.archived_at === null &&
+        c.provider !== null,
+    );
+    return Promise.all(matches.map((m) => this.toRow(m)));
   }
 
   async update(
@@ -137,9 +158,14 @@ export class InMemoryCredentialRepo implements CredentialRepo {
       throw new CredentialNotFoundError();
     }
     if (update.displayName !== undefined) row.display_name = update.displayName;
-    if (update.auth !== undefined) row.auth = update.auth;
+    if (update.auth !== undefined) {
+      row.auth_type = update.auth.type;
+      row.mcp_server_url = update.auth.mcp_server_url ?? null;
+      row.provider = update.auth.provider ?? null;
+      row.auth_cipher = await this.crypto.encrypt(JSON.stringify(update.auth));
+    }
     row.updated_at = update.updatedAt;
-    return toRow(row);
+    return await this.toRow(row);
   }
 
   async archive(
@@ -154,7 +180,7 @@ export class InMemoryCredentialRepo implements CredentialRepo {
     }
     row.archived_at = archivedAt;
     row.updated_at = archivedAt;
-    return toRow(row);
+    return await this.toRow(row);
   }
 
   async archiveByVault(
@@ -174,6 +200,29 @@ export class InMemoryCredentialRepo implements CredentialRepo {
     const row = this.byId.get(credentialId);
     if (!row || row.tenant_id !== tenantId || row.vault_id !== vaultId) return;
     this.byId.delete(credentialId);
+  }
+
+  /**
+   * Test introspection: returns the raw encrypted blob for a row, bypassing
+   * crypto. Use to assert that the on-disk format is encrypted and not the
+   * plaintext JSON.
+   */
+  __getRawAuthCipher(credentialId: string): string | undefined {
+    return this.byId.get(credentialId)?.auth_cipher;
+  }
+
+  private async toRow(c: InMemCredential): Promise<CredentialRow> {
+    const authJson = await this.crypto.decrypt(c.auth_cipher);
+    return {
+      id: c.id,
+      tenant_id: c.tenant_id,
+      vault_id: c.vault_id,
+      display_name: c.display_name,
+      auth: JSON.parse(authJson) as CredentialAuth,
+      created_at: msToIso(c.created_at),
+      updated_at: c.updated_at !== null ? msToIso(c.updated_at) : null,
+      archived_at: c.archived_at !== null ? msToIso(c.archived_at) : null,
+    };
   }
 }
 
@@ -202,18 +251,40 @@ export class SilentLogger implements Logger {
 }
 
 /**
+ * Reversible test crypto with a recognizable wrapper so tests can:
+ *   1. assert the on-disk blob is the cipher (not the plaintext)
+ *   2. confirm decrypt is wired (would fail to parse otherwise)
+ *
+ * Mirrors packages/model-cards-store/src/test-fakes.ts:FakeCrypto for
+ * cross-store consistency.
+ */
+export class FakeCrypto implements Crypto {
+  async encrypt(plaintext: string): Promise<string> {
+    return `enc(${plaintext})`;
+  }
+  async decrypt(ciphertext: string): Promise<string> {
+    if (!ciphertext.startsWith("enc(") || !ciphertext.endsWith(")")) {
+      throw new Error(`FakeCrypto.decrypt: not a fake-cipher: ${ciphertext}`);
+    }
+    return ciphertext.slice(4, -1);
+  }
+}
+
+/**
  * Convenience factory — full in-memory wiring with sane defaults. Tests can
- * pass overrides for any port (e.g. a ManualClock for deterministic timestamps).
+ * pass overrides for any port (e.g. a ManualClock for deterministic timestamps,
+ * FakeCrypto to exercise the encryption boundary).
  */
 export function createInMemoryCredentialService(opts?: {
   clock?: Clock;
   ids?: IdGenerator;
   logger?: Logger;
+  crypto?: Crypto;
 }): {
   service: CredentialService;
   repo: InMemoryCredentialRepo;
 } {
-  const repo = new InMemoryCredentialRepo();
+  const repo = new InMemoryCredentialRepo({ crypto: opts?.crypto });
   const service = new CredentialService({
     repo,
     clock: opts?.clock,
@@ -225,18 +296,14 @@ export function createInMemoryCredentialService(opts?: {
 
 // ── helpers ──
 
-function toRow(c: InMemCredential): CredentialRow {
-  return {
-    id: c.id,
-    tenant_id: c.tenant_id,
-    vault_id: c.vault_id,
-    display_name: c.display_name,
-    auth: c.auth,
-    created_at: msToIso(c.created_at),
-    updated_at: c.updated_at !== null ? msToIso(c.updated_at) : null,
-    archived_at: c.archived_at !== null ? msToIso(c.archived_at) : null,
-  };
-}
+const identityCrypto: Crypto = {
+  async encrypt(plaintext) {
+    return plaintext;
+  },
+  async decrypt(ciphertext) {
+    return ciphertext;
+  },
+};
 
 function msToIso(ms: number): string {
   return new Date(ms).toISOString();

--- a/packages/integrations-adapters-cf/src/cf-container.ts
+++ b/packages/integrations-adapters-cf/src/cf-container.ts
@@ -56,7 +56,7 @@ export interface CfReposEnv {
   /** Control-plane DB for cross-tenant lookups (TenantResolver).
    *  Always env.AUTH_DB — the better-auth user table never moves. */
   controlPlaneDb: D1Database;
-  MCP_SIGNING_KEY: string;
+  PLATFORM_ROOT_SECRET: string;
 }
 
 /** Env subset needed by buildCfContainer (extends CfReposEnv). */
@@ -73,15 +73,15 @@ export interface CfContainerEnv extends CfReposEnv {
  *
  * Token-at-rest encryption uses the "integrations.tokens" label so the derived
  * key is distinct from the JWT signing key, even though both seed from the
- * same MCP_SIGNING_KEY root secret.
+ * same PLATFORM_ROOT_SECRET root secret.
  */
 export function buildCfRepos(env: CfReposEnv) {
   const idb = env.integrationsDb;
   const clock = new SystemClock();
   const ids = new CryptoIdGenerator();
-  const cryptoImpl = new WebCryptoAesGcm(env.MCP_SIGNING_KEY, "integrations.tokens");
+  const cryptoImpl = new WebCryptoAesGcm(env.PLATFORM_ROOT_SECRET, "integrations.tokens");
   const hmac = new WebCryptoHmacVerifier();
-  const jwt = new WebCryptoJwtSigner(env.MCP_SIGNING_KEY);
+  const jwt = new WebCryptoJwtSigner(env.PLATFORM_ROOT_SECRET);
   const http = new WorkerHttpClient();
   // TenantResolver always queries control-plane (better-auth `user` table) —
   // it must work without per-tenant routing being decided yet (e.g. install

--- a/packages/integrations-adapters-cf/src/crypto.test.ts
+++ b/packages/integrations-adapters-cf/src/crypto.test.ts
@@ -1,0 +1,76 @@
+// Roundtrip tests for WebCryptoAesGcm. The class has been in production for
+// integration token encryption since OPE-7, but until now had no tests of its
+// own — these fill that gap.
+
+import { describe, it, expect } from "vitest";
+import { WebCryptoAesGcm } from "./crypto";
+
+const SECRET = "test-secret-at-least-32-chars-for-realism";
+
+describe("WebCryptoAesGcm", () => {
+  it("roundtrips an arbitrary string", async () => {
+    const c = new WebCryptoAesGcm(SECRET, "test.label");
+    const cipher = await c.encrypt("hello world");
+    const round = await c.decrypt(cipher);
+    expect(round).toBe("hello world");
+  });
+
+  it("produces a different ciphertext each call (random IV)", async () => {
+    const c = new WebCryptoAesGcm(SECRET, "test.label");
+    const a = await c.encrypt("same plaintext");
+    const b = await c.encrypt("same plaintext");
+    expect(a).not.toBe(b);
+    expect(await c.decrypt(a)).toBe("same plaintext");
+    expect(await c.decrypt(b)).toBe("same plaintext");
+  });
+
+  it("emits ciphertext that does not contain the plaintext", async () => {
+    const c = new WebCryptoAesGcm(SECRET, "test.label");
+    const cipher = await c.encrypt("sk-abc-very-secret");
+    expect(cipher).not.toContain("sk-abc");
+    expect(cipher).not.toContain("very-secret");
+  });
+
+  it("isolates ciphertexts by label (HKDF-style derivation)", async () => {
+    const a = new WebCryptoAesGcm(SECRET, "label.alpha");
+    const b = new WebCryptoAesGcm(SECRET, "label.beta");
+    const cipher = await a.encrypt("hello");
+    await expect(b.decrypt(cipher)).rejects.toThrow();
+  });
+
+  it("isolates ciphertexts by secret", async () => {
+    const a = new WebCryptoAesGcm("secret-A-padded-to-be-long-enough", "test.label");
+    const b = new WebCryptoAesGcm("secret-B-padded-to-be-long-enough", "test.label");
+    const cipher = await a.encrypt("hello");
+    await expect(b.decrypt(cipher)).rejects.toThrow();
+  });
+
+  it("uses default label 'integrations.tokens' when none given", async () => {
+    const explicit = new WebCryptoAesGcm(SECRET, "integrations.tokens");
+    const implicit = new WebCryptoAesGcm(SECRET);
+    const cipher = await explicit.encrypt("token");
+    expect(await implicit.decrypt(cipher)).toBe("token");
+  });
+
+  it("rejects empty secret in constructor", () => {
+    expect(() => new WebCryptoAesGcm("", "test.label")).toThrow(/non-empty/);
+  });
+
+  it("rejects ciphertext shorter than the IV", async () => {
+    const c = new WebCryptoAesGcm(SECRET, "test.label");
+    // base64url for 4 bytes (less than the 12-byte IV)
+    await expect(c.decrypt("AAAAAA")).rejects.toThrow();
+  });
+
+  it("handles unicode plaintext", async () => {
+    const c = new WebCryptoAesGcm(SECRET, "test.label");
+    const cipher = await c.encrypt("你好 🌍 emoji");
+    expect(await c.decrypt(cipher)).toBe("你好 🌍 emoji");
+  });
+
+  it("handles empty-string plaintext", async () => {
+    const c = new WebCryptoAesGcm(SECRET, "test.label");
+    const cipher = await c.encrypt("");
+    expect(await c.decrypt(cipher)).toBe("");
+  });
+});

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -11,6 +11,7 @@
     "@open-managed-agents/blob-store": "workspace:*",
     "@open-managed-agents/kv-store": "workspace:*",
     "@open-managed-agents/credentials-store": "workspace:*",
+    "@open-managed-agents/integrations-adapters-cf": "workspace:*",
     "@open-managed-agents/memory-store": "workspace:*",
     "@open-managed-agents/vaults-store": "workspace:*",
     "@open-managed-agents/sessions-store": "workspace:*",

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -91,6 +91,9 @@ import {
   createCfShardPoolService,
   createCfMemoryStoreTenantIndexService,
 } from "@open-managed-agents/tenant-dbs-store";
+import {
+  WebCryptoAesGcm,
+} from "@open-managed-agents/integrations-adapters-cf";
 import { type BlobStore, blobStoreFromR2 } from "@open-managed-agents/blob-store";
 import { type KvStore, CfKvStore } from "@open-managed-agents/kv-store";
 import { parseStoreBackends, pickBackend } from "./store-backends";
@@ -202,6 +205,19 @@ export interface AppContextWithTenant {
 // ============================================================
 
 /**
+ * Build a label-scoped at-rest encryption boundary for a single subsystem.
+ * Each subsystem (model cards, credentials, …) passes a distinct `label`;
+ * HKDF-style derivation in WebCryptoAesGcm gives each one a different AES key,
+ * so a leak in one subsystem cannot decrypt another's ciphertexts.
+ *
+ * Caller MUST have already verified that env.PLATFORM_ROOT_SECRET is non-empty
+ * (buildServices throws at boot if it isn't).
+ */
+function mintCrypto(env: Env, label: string): WebCryptoAesGcm {
+  return new WebCryptoAesGcm(env.PLATFORM_ROOT_SECRET!, label);
+}
+
+/**
  * Production / staging on Cloudflare Workers. Wires every service against
  * the resolved per-tenant D1 database. The TenantDbProvider middleware
  * resolves the right DB for the current request before this factory runs.
@@ -225,9 +241,23 @@ export interface AppContextWithTenant {
  */
 export function buildServices(env: Env, db: D1Database): Services {
   const overrides = parseStoreBackends(env);
+  // At-rest encryption is mandatory in this build. Refuse to start if the
+  // signing key isn't configured rather than silently writing plaintext —
+  // historical regressions of that exact shape are why this check exists.
+  if (!env.PLATFORM_ROOT_SECRET) {
+    throw new Error(
+      "buildServices: PLATFORM_ROOT_SECRET is required for at-rest encryption of credentials.auth and model_cards.api_key_cipher. " +
+        "Set it via `wrangler secret put PLATFORM_ROOT_SECRET` (or in .dev.vars for local dev). " +
+        "Generate with: openssl rand -base64 32",
+    );
+  }
   return {
     credentials: pickBackend(overrides, "credentials", {
-      cf: () => createCfCredentialService({ db }),
+      cf: () =>
+        createCfCredentialService(
+          { db },
+          { crypto: mintCrypto(env, "credentials.auth") },
+        ),
       // pg: () => createPgCredentialService({ pg: getPgPool(env) }),
     }),
     memory: pickBackend(overrides, "memory", {
@@ -257,7 +287,11 @@ export function buildServices(env: Env, db: D1Database): Services {
       // pg: () => createPgEvalRunService({ pg: getPgPool(env) }),
     }),
     modelCards: pickBackend(overrides, "modelCards", {
-      cf: () => createCfModelCardService({ db }),
+      cf: () =>
+        createCfModelCardService(
+          { db },
+          { crypto: mintCrypto(env, "model.cards.keys") },
+        ),
       // pg: () => createPgModelCardService({ pg: getPgPool(env) }),
     }),
     agents: pickBackend(overrides, "agents", {

--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -161,7 +161,7 @@ export interface Env {
   // OAuth callbacks etc. when the gateway is on a different host).
   INTEGRATIONS_PUBLIC_URL?: string;
   // Used by integrations subsystem to sign tokens at rest. Gateway's value.
-  MCP_SIGNING_KEY?: string;
+  PLATFORM_ROOT_SECRET?: string;
   // Killswitch for per-tenant D1 routing. Unset / "true" / anything else =
   // routing enabled (the default — uses tenant_shard meta table). Set to
   // "false" or "0" to roll back to the shared-AUTH_DB provider without

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -699,6 +699,9 @@ importers:
       '@open-managed-agents/files-store':
         specifier: workspace:*
         version: link:../files-store
+      '@open-managed-agents/integrations-adapters-cf':
+        specifier: workspace:*
+        version: link:../integrations-adapters-cf
       '@open-managed-agents/kv-store':
         specifier: workspace:*
         version: link:../kv-store
@@ -1260,6 +1263,34 @@ packages:
     engines: {node: '>=18.0.0'}
     cpu: [arm64]
     os: [darwin]
+
+  '@boxlite-ai/boxlite-linux-arm64-gnu@0.8.2':
+    resolution: {integrity: sha512-x/VR5JtGj3Z8LCo+rPeaHUfpCztKMcYt0GnFpq+OwrH0WIZj7P5Rz98INmF8aaX7CoJmA+livT1cwJuOZwaQ0w==}
+    engines: {node: '>=18.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@boxlite-ai/boxlite-linux-arm64-gnu@0.9.3':
+    resolution: {integrity: sha512-LzlBz8VHGZbiJP/1JztlBNHKSAATksIJgjxMcWxsJLLxENrsCgsi0hLfeRKLDvmsyuQawcpzbYzoSYRbAKkCjw==}
+    engines: {node: '>=18.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@boxlite-ai/boxlite-linux-x64-gnu@0.8.2':
+    resolution: {integrity: sha512-xTZNgHGlsBrhXlPy/BuoCVKefIs3kZcBMUXBMehk7WzMXNSz8nnNjAz2wr7IuR1qwNrqTn9S+08dDpCmKvuJNg==}
+    engines: {node: '>=18.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@boxlite-ai/boxlite-linux-x64-gnu@0.9.3':
+    resolution: {integrity: sha512-azwKVAiEBUvGTy0kg9bBumUBOysyUVNG8llqOss6Xdu5yu0tm7NRZXgcT9nnS/vuRBPH5056C0iUwsxGI3QgXA==}
+    engines: {node: '>=18.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
 
   '@boxlite-ai/boxlite@0.8.2':
     resolution: {integrity: sha512-PvoTMjOwZWPnseW7WINoIYctIQQB6XlQJTvCut9dWlNmQ2hKVGCX3gX1GruO93SNCv+yai005i23BomtKEQxEw==}
@@ -2329,6 +2360,11 @@ packages:
 
   '@pagefind/default-ui@1.5.2':
     resolution: {integrity: sha512-pm1LMnQg8N2B3n2TnjKlhaFihpz6zTiA4HiGQ6/slKO/+8K9CAU5kcjdSSPgpuk1PMuuN4hxLipUIifnrkl3Sg==}
+
+  '@pagefind/freebsd-x64@1.5.2':
+    resolution: {integrity: sha512-7EVzo9+0w+2cbe671BtMj10UlNo83I+HrLVLfRxO731svHRJKUfJ/mo05gU14pe9PCfpKNQT8FS3Xc/oDN6pOA==}
+    cpu: [x64]
+    os: [freebsd]
 
   '@pagefind/linux-arm64@1.5.2':
     resolution: {integrity: sha512-Ovt9+K35sqzn8H3ZMXGwls4TD/wMJuvRtShHIsmUQREmaxjrDEX7gHckRCrwYJ4XE1H1p6HkLz3wukrAnsfXQw==}
@@ -7448,14 +7484,30 @@ snapshots:
   '@boxlite-ai/boxlite-darwin-arm64@0.9.3':
     optional: true
 
+  '@boxlite-ai/boxlite-linux-arm64-gnu@0.8.2':
+    optional: true
+
+  '@boxlite-ai/boxlite-linux-arm64-gnu@0.9.3':
+    optional: true
+
+  '@boxlite-ai/boxlite-linux-x64-gnu@0.8.2':
+    optional: true
+
+  '@boxlite-ai/boxlite-linux-x64-gnu@0.9.3':
+    optional: true
+
   '@boxlite-ai/boxlite@0.8.2(playwright-core@1.59.1)':
     optionalDependencies:
       '@boxlite-ai/boxlite-darwin-arm64': 0.8.2
+      '@boxlite-ai/boxlite-linux-arm64-gnu': 0.8.2
+      '@boxlite-ai/boxlite-linux-x64-gnu': 0.8.2
       playwright-core: 1.59.1
 
   '@boxlite-ai/boxlite@0.9.3(playwright-core@1.59.1)':
     optionalDependencies:
       '@boxlite-ai/boxlite-darwin-arm64': 0.9.3
+      '@boxlite-ai/boxlite-linux-arm64-gnu': 0.9.3
+      '@boxlite-ai/boxlite-linux-x64-gnu': 0.9.3
       playwright-core: 1.59.1
 
   '@bufbuild/protobuf@2.12.0': {}
@@ -8535,6 +8587,9 @@ snapshots:
     optional: true
 
   '@pagefind/default-ui@1.5.2': {}
+
+  '@pagefind/freebsd-x64@1.5.2':
+    optional: true
 
   '@pagefind/linux-arm64@1.5.2':
     optional: true
@@ -12075,6 +12130,7 @@ snapshots:
     optionalDependencies:
       '@pagefind/darwin-arm64': 1.5.2
       '@pagefind/darwin-x64': 1.5.2
+      '@pagefind/freebsd-x64': 1.5.2
       '@pagefind/linux-arm64': 1.5.2
       '@pagefind/linux-x64': 1.5.2
       '@pagefind/windows-arm64': 1.5.2

--- a/scripts/backfill-encrypt-secrets.README.md
+++ b/scripts/backfill-encrypt-secrets.README.md
@@ -1,0 +1,118 @@
+# Backfill: encrypt model card API keys and vault credentials
+
+Operator runbook for `scripts/backfill-encrypt-secrets.ts`. Idempotent — the
+script try-decrypts every row before writing, so a row that's already
+encrypted under the current key is a no-op. Re-running is the recovery path
+if a previous run was interrupted.
+
+## What this fixes
+
+`model_cards.api_key_cipher` and `credentials.auth` were stored as plaintext
+prior to this PR despite their column names. The new runtime AES-256-GCM-only
+build refuses any decrypt that fails the GCM tag check; this script rewrites
+all existing rows in-place to the encrypted format.
+
+## Required env / secrets
+
+| | |
+|---|---|
+| `CF_ACCOUNT_ID` | Cloudflare account UUID |
+| `CF_API_TOKEN` | API token with `D1: Edit` on every shard you'll touch |
+| `PLATFORM_ROOT_SECRET` | Same value as the worker's `wrangler secret`. **Mismatch produces ciphertext the worker can't decrypt.** |
+
+Cloudflare secrets are write-only — if you don't know the current
+`PLATFORM_ROOT_SECRET` value, use the value you originally set when provisioning
+the worker. If it's truly lost, the only path is to rotate the worker's
+secret AND run this script with the new value (and accept that any
+already-encrypted integration tokens become unreadable).
+
+## Step-by-step cutover
+
+### 1. Pre-flight (no impact)
+
+Dry-run on every shard to surface row counts and any unparseable
+`credentials.auth` JSON **before** going live:
+
+```bash
+for db in $(./scripts/list-shards.sh); do
+  pnpm tsx scripts/backfill-encrypt-secrets.ts --db="$db" --dry-run
+done
+```
+
+If validation reports rows that fail `JSON.parse`, investigate before
+proceeding. Bad data needs to be fixed or deleted — encrypting garbage is a
+one-way trip.
+
+### 2. Deploy new code
+
+`wrangler deploy` (or your usual pipeline). From this moment, every read of
+plaintext rows in `model_cards.api_key_cipher` / `credentials.auth` returns a
+500 from the relevant route. Affected paths:
+
+- Agent worker model resolution (`/v1/model_cards/:id/key`)
+- MCP proxy auth (`/v1/mcp-proxy/...`)
+- OAuth refresh (writes still succeed — they overwrite with ciphertext, only
+  reads of pre-existing rows fail)
+
+### 3. Backfill in parallel
+
+Run the script across every shard at maximum sustainable parallelism. Each
+invocation handles one shard:
+
+```bash
+SHARDS=$(./scripts/list-shards.sh)
+echo "$SHARDS" | xargs -P 8 -I {} \
+  pnpm tsx scripts/backfill-encrypt-secrets.ts --db={} --shard={}
+```
+
+Tune `-P 8` based on Cloudflare API rate limits; 8–16 has been comfortable in
+similar migrations.
+
+### 4. Verify
+
+Re-run with `--dry-run` for each shard:
+
+```bash
+for db in $(./scripts/list-shards.sh); do
+  pnpm tsx scripts/backfill-encrypt-secrets.ts --db="$db" --dry-run
+done
+```
+
+For every shard the summary must show `needsEncryption=0` for both
+`model_cards.api_key_cipher` and `credentials.auth`. If any non-zero, re-run
+the non-dry-run script for that shard.
+
+## Recovery from interruption
+
+The script try-decrypts every row before writing — a row already encrypted
+under the current `PLATFORM_ROOT_SECRET` is detected and skipped. Re-running after
+an interrupted attempt picks up exactly where the previous run stopped. No
+risk of double-encrypting.
+
+## Rollback
+
+There is no clean rollback once the new code is deployed:
+
+- Revert deploy → old code runs `identityCrypto`, treats ciphertext as
+  plaintext, hands it to LLM providers / MCP servers, every request fails
+  upstream.
+- The new code refuses to start without `PLATFORM_ROOT_SECRET`, and refuses to
+  decrypt anything that doesn't match the GCM tag.
+
+The intended response to mid-backfill failure is **finish the backfill**, not
+roll back. This is the cost of the single-step cutover the team chose.
+
+## Errors
+
+- **`PARSE failed: Unexpected token …`** — A `credentials.auth` row contains
+  malformed JSON. Inspect with
+  `wrangler d1 execute … --command "SELECT id, substr(auth, 1, 100) FROM credentials WHERE id = '…'"`.
+  Either fix the JSON manually or `DELETE` the row (then revoke the
+  corresponding upstream credential).
+- **CF API 401 / 403** — Token missing `D1: Edit` on the target shard. Mint a
+  scoped token rather than a global one for this operation.
+- **Many "errors" in the per-row report after a partial run** — usually means
+  one of the script's previous invocations encrypted with a *different*
+  `PLATFORM_ROOT_SECRET`. Try-decrypt fails, then encrypt-and-write attempts to
+  re-encrypt the existing ciphertext as if it were plaintext. Stop and
+  reconcile which key the worker actually has before continuing.

--- a/scripts/backfill-encrypt-secrets.ts
+++ b/scripts/backfill-encrypt-secrets.ts
@@ -1,0 +1,308 @@
+#!/usr/bin/env tsx
+/**
+ * One-shot backfill: encrypt the `model_cards.api_key_cipher` and
+ * `credentials.auth` columns in a single tenant D1 shard.
+ *
+ * Why: these columns were named for encryption from day one but the runtime
+ * was using an identity (passthrough) Crypto, so existing rows are stored as
+ * plaintext. The new code (this PR) wires real AES-256-GCM via WebCryptoAesGcm
+ * and refuses to start without `PLATFORM_ROOT_SECRET`. This script walks every
+ * plaintext row and rewrites it as ciphertext so the runtime can read it.
+ *
+ * Idempotent via try-decrypt: rows that already decrypt cleanly under the
+ * current key are skipped. Re-run is safe (and is the recovery path if a
+ * previous run was interrupted).
+ *
+ * Cutover (single-step, accepted operator-managed downtime):
+ *   1. Dry-run on every shard (`--dry-run`) to surface row counts.
+ *   2. Deploy the new code (the runtime starts rejecting plaintext rows
+ *      immediately — model card / credential reads return 500 until step 3
+ *      finishes).
+ *   3. Run this script on every shard, ideally in parallel, to cap the
+ *      window during which reads fail.
+ *   4. Verify by re-running with --dry-run; needsEncryption must be 0.
+ *
+ * The PLATFORM_ROOT_SECRET MUST be the same value the worker has — derive
+ * mismatch will produce ciphertext the runtime can't decrypt. Read it from
+ * `wrangler secret list <worker>` if unsure (the value isn't exposed; use the
+ * value you originally set).
+ *
+ * Usage:
+ *   CF_ACCOUNT_ID=… CF_API_TOKEN=… PLATFORM_ROOT_SECRET=… \
+ *     pnpm tsx scripts/backfill-encrypt-secrets.ts \
+ *       --db=<d1-database-id> [--shard=<label>] [--dry-run]
+ *
+ *   --db          D1 database UUID for the tenant shard to migrate (required).
+ *   --shard       Optional human-readable label used in log lines.
+ *   --dry-run     Count rows that WOULD be touched; don't write.
+ *   --account     CF account UUID (or via CF_ACCOUNT_ID env).
+ *   --token       CF API token with D1:Edit on this account (or CF_API_TOKEN).
+ *   --signing-key Platform root secret (or PLATFORM_ROOT_SECRET env).
+ *   --page        Rows per page (default 200). Lower if you hit D1 size limits.
+ */
+
+import { WebCryptoAesGcm } from "../packages/integrations-adapters-cf/src/crypto";
+
+interface CfApiResponse<T> {
+  success: boolean;
+  result: T;
+  errors?: Array<{ code?: number; message: string }>;
+}
+
+async function cf<T>(
+  accountId: string,
+  token: string,
+  path: string,
+  init?: RequestInit,
+): Promise<T> {
+  const res = await fetch(
+    `https://api.cloudflare.com/client/v4/accounts/${accountId}${path}`,
+    {
+      ...init,
+      headers: {
+        authorization: `Bearer ${token}`,
+        "content-type": "application/json",
+        ...(init?.headers as Record<string, string> | undefined),
+      },
+    },
+  );
+  const body = (await res.json()) as CfApiResponse<T>;
+  if (!body.success) {
+    throw new Error(
+      `CF API ${res.status}: ${body.errors?.map((e) => e.message).join("; ") ?? "unknown"}`,
+    );
+  }
+  return body.result;
+}
+
+async function d1Query<T = Record<string, unknown>>(
+  accountId: string,
+  token: string,
+  databaseId: string,
+  sql: string,
+  params: unknown[] = [],
+): Promise<T[]> {
+  const out = await cf<Array<{ results: T[] }>>(
+    accountId,
+    token,
+    `/d1/database/${databaseId}/query`,
+    { method: "POST", body: JSON.stringify({ sql, params }) },
+  );
+  return out[0]?.results ?? [];
+}
+
+interface BackfillResult {
+  table: string;
+  scanned: number;
+  alreadyEncrypted: number;
+  needsEncryption: number;
+  encrypted: number;
+  errors: Array<{ id: string; reason: string }>;
+}
+
+async function backfillColumn(opts: {
+  accountId: string;
+  token: string;
+  dbId: string;
+  table: string;
+  idColumn: string;
+  cipherColumn: string;
+  crypto: WebCryptoAesGcm;
+  pageSize: number;
+  dryRun: boolean;
+  validatePlaintext?: (plaintext: string) => void;
+}): Promise<BackfillResult> {
+  const result: BackfillResult = {
+    table: `${opts.table}.${opts.cipherColumn}`,
+    scanned: 0,
+    alreadyEncrypted: 0,
+    needsEncryption: 0,
+    encrypted: 0,
+    errors: [],
+  };
+
+  let lastId: string | null = null;
+  while (true) {
+    // Keyset-paginate by primary key. We fetch every row (no SQL-level
+    // already-encrypted filter) because there's no marker — we use try-decrypt
+    // per row to decide.
+    const sql = lastId === null
+      ? `SELECT ${opts.idColumn} AS id, ${opts.cipherColumn} AS value
+         FROM ${opts.table}
+         ORDER BY ${opts.idColumn}
+         LIMIT ?`
+      : `SELECT ${opts.idColumn} AS id, ${opts.cipherColumn} AS value
+         FROM ${opts.table}
+         WHERE ${opts.idColumn} > ?
+         ORDER BY ${opts.idColumn}
+         LIMIT ?`;
+    const params = lastId === null ? [opts.pageSize] : [lastId, opts.pageSize];
+
+    const rows = await d1Query<{ id: string; value: string }>(
+      opts.accountId,
+      opts.token,
+      opts.dbId,
+      sql,
+      params,
+    );
+    if (rows.length === 0) break;
+
+    result.scanned += rows.length;
+
+    for (const row of rows) {
+      // Try-decrypt under the configured key. Success ⇒ already encrypted.
+      // Failure ⇒ plaintext (or corrupt — surface those in errors below).
+      try {
+        await opts.crypto.decrypt(row.value);
+        result.alreadyEncrypted += 1;
+        continue;
+      } catch {
+        // Fall through: treat as plaintext.
+      }
+
+      result.needsEncryption += 1;
+
+      try {
+        if (opts.validatePlaintext) opts.validatePlaintext(row.value);
+
+        if (!opts.dryRun) {
+          const encrypted = await opts.crypto.encrypt(row.value);
+          await d1Query(
+            opts.accountId,
+            opts.token,
+            opts.dbId,
+            `UPDATE ${opts.table} SET ${opts.cipherColumn} = ? WHERE ${opts.idColumn} = ?`,
+            [encrypted, row.id],
+          );
+          result.encrypted += 1;
+        }
+      } catch (err) {
+        result.errors.push({
+          id: row.id,
+          reason: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+
+    console.log(
+      `  [${opts.table}.${opts.cipherColumn}] scanned ${result.scanned}, ` +
+        `alreadyEncrypted ${result.alreadyEncrypted}, encrypted ${result.encrypted}, ` +
+        `errors ${result.errors.length}`,
+    );
+
+    lastId = rows[rows.length - 1]!.id;
+    if (rows.length < opts.pageSize) break;
+  }
+
+  return result;
+}
+
+function parseArgs(): Record<string, string> {
+  return Object.fromEntries(
+    process.argv
+      .slice(2)
+      .filter((a) => a.startsWith("--"))
+      .map((a) => {
+        const [k, v] = a.slice(2).split("=");
+        return [k!, v ?? "true"];
+      }),
+  );
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs();
+  const accountId = args.account ?? process.env.CF_ACCOUNT_ID;
+  const token = args.token ?? process.env.CF_API_TOKEN;
+  const dbId = args.db;
+  const shard = args.shard ?? dbId;
+  const signingKey = args["signing-key"] ?? process.env.PLATFORM_ROOT_SECRET;
+  const pageSize = parseInt(args.page ?? "200", 10);
+  const dryRun = args["dry-run"] === "true";
+
+  if (!accountId || !token || !dbId || !signingKey) {
+    console.error(
+      "Usage: pnpm tsx scripts/backfill-encrypt-secrets.ts \\\n" +
+        "  --db=<d1-database-id> [--shard=<label>] [--dry-run]\n" +
+        "Required env (or flags): CF_ACCOUNT_ID, CF_API_TOKEN, PLATFORM_ROOT_SECRET",
+    );
+    process.exit(1);
+  }
+
+  console.log(`[shard=${shard}] dbId=${dbId} dryRun=${dryRun} pageSize=${pageSize}`);
+
+  const modelCardsCrypto = new WebCryptoAesGcm(signingKey, "model.cards.keys");
+  const credentialsCrypto = new WebCryptoAesGcm(signingKey, "credentials.auth");
+
+  console.log(`\n=== model_cards.api_key_cipher ===`);
+  const modelCardsResult = await backfillColumn({
+    accountId,
+    token,
+    dbId,
+    table: "model_cards",
+    idColumn: "id",
+    cipherColumn: "api_key_cipher",
+    crypto: modelCardsCrypto,
+    pageSize,
+    dryRun,
+  });
+
+  console.log(`\n=== credentials.auth ===`);
+  const credentialsResult = await backfillColumn({
+    accountId,
+    token,
+    dbId,
+    table: "credentials",
+    idColumn: "id",
+    cipherColumn: "auth",
+    crypto: credentialsCrypto,
+    pageSize,
+    dryRun,
+    // credentials.auth MUST parse as JSON post-decrypt or the runtime will
+    // 500 on read. Surface bad rows now rather than after they're encrypted.
+    validatePlaintext: (plaintext) => {
+      JSON.parse(plaintext);
+    },
+  });
+
+  console.log(`\n=== Summary [shard=${shard}] ===`);
+  for (const r of [modelCardsResult, credentialsResult]) {
+    console.log(
+      `  ${r.table}: scanned=${r.scanned}, alreadyEncrypted=${r.alreadyEncrypted}, ` +
+        `encrypted=${r.encrypted}, errors=${r.errors.length}`,
+    );
+    if (r.errors.length > 0) {
+      console.log(`    First 5 errors:`);
+      for (const e of r.errors.slice(0, 5)) {
+        console.log(`      ${e.id}: ${e.reason}`);
+      }
+    }
+  }
+
+  const totalErrors = modelCardsResult.errors.length + credentialsResult.errors.length;
+  if (totalErrors > 0) {
+    console.error(`\n✗ ${totalErrors} rows failed to encrypt. Investigate before re-running.`);
+    process.exit(2);
+  }
+
+  if (dryRun) {
+    console.log(
+      `\n✓ Dry run complete. No writes performed. Re-run without --dry-run to apply.`,
+    );
+  } else {
+    const remaining = modelCardsResult.needsEncryption + credentialsResult.needsEncryption -
+      modelCardsResult.encrypted - credentialsResult.encrypted;
+    if (remaining === 0) {
+      console.log(
+        `\n✓ Backfill complete. Verify by re-running with --dry-run; needsEncryption must be 0.`,
+      );
+    } else {
+      console.error(`\n✗ ${remaining} rows still need encryption. Re-run.`);
+      process.exit(2);
+    }
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/set-platform-root-secret.sh
+++ b/scripts/set-platform-root-secret.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+#
+# Set PLATFORM_ROOT_SECRET on every worker that needs it (main +
+# integrations × staging + prod). Idempotent — re-runs overwrite with
+# the same value.
+#
+# Three ways to provide the value, in priority order:
+#   1. --key VALUE          (or --key=VALUE) — direct CLI arg.
+#                           CAUTION: ends up in shell history. Mitigate with
+#                           a leading space and HISTCONTROL=ignorespace, or
+#                           clear history after.
+#   2. PLATFORM_ROOT_SECRET env var
+#   3. Interactive prompt (no echo, requires re-typing to confirm)
+#
+# Usage:
+#   scripts/set-platform-root-secret.sh --key xxxxx               # all 4 targets
+#   scripts/set-platform-root-secret.sh --key xxxxx --staging-only
+#   scripts/set-platform-root-secret.sh --key xxxxx --prod-only
+#   scripts/set-platform-root-secret.sh                           # interactive prompt
+#   PLATFORM_ROOT_SECRET=xxx scripts/set-platform-root-secret.sh --yes
+#
+# After it succeeds:
+#   1. `wrangler secret list ...` will show both PLATFORM_ROOT_SECRET and
+#      MCP_SIGNING_KEY (legacy). They coexist until step 3.
+#   2. Deploy the new code (which expects PLATFORM_ROOT_SECRET).
+#   3. Verify, then `wrangler secret delete MCP_SIGNING_KEY` on the same 4
+#      targets to clean up.
+#
+# Pre-req: cwd = repo root; wrangler installed and logged in (`wrangler whoami`).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$ROOT_DIR"
+
+# ── argument parsing ──
+INCLUDE_STAGING=1
+INCLUDE_PROD=1
+SKIP_CONFIRM=0
+KEY_FROM_ARG=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --staging-only) INCLUDE_PROD=0; shift ;;
+    --prod-only)    INCLUDE_STAGING=0; shift ;;
+    --yes|-y)       SKIP_CONFIRM=1; shift ;;
+    --key)          KEY_FROM_ARG="${2:-}"; shift 2 ;;
+    --key=*)        KEY_FROM_ARG="${1#*=}"; shift ;;
+    -h|--help)
+      sed -n '2,/^$/p' "$0" | sed 's/^# \?//'
+      exit 0
+      ;;
+    *)
+      echo "unknown arg: $1 (use --help)" >&2
+      exit 2
+      ;;
+  esac
+done
+
+# ── target list (config, env, label) ──
+TARGETS=()
+if [[ $INCLUDE_STAGING -eq 1 ]]; then
+  TARGETS+=("apps/main/wrangler.jsonc:staging:main/staging")
+  TARGETS+=("apps/integrations/wrangler.jsonc:staging:integrations/staging")
+fi
+if [[ $INCLUDE_PROD -eq 1 ]]; then
+  TARGETS+=("apps/main/wrangler.jsonc::main/production")
+  TARGETS+=("apps/integrations/wrangler.jsonc::integrations/production")
+fi
+
+if [[ ${#TARGETS[@]} -eq 0 ]]; then
+  echo "no targets selected" >&2
+  exit 2
+fi
+
+# ── obtain the secret value ──
+# Priority: --key arg > PLATFORM_ROOT_SECRET env var > interactive prompt.
+VALUE="${KEY_FROM_ARG:-${PLATFORM_ROOT_SECRET:-}}"
+if [[ -z "$VALUE" ]]; then
+  echo "Enter PLATFORM_ROOT_SECRET (input hidden, ENTER when done):"
+  read -rs VALUE
+  echo
+  if [[ -z "$VALUE" ]]; then
+    echo "empty value — aborting" >&2
+    exit 1
+  fi
+  echo "Re-enter to confirm:"
+  read -rs CONFIRM
+  echo
+  if [[ "$VALUE" != "$CONFIRM" ]]; then
+    echo "values don't match — aborting" >&2
+    exit 1
+  fi
+  unset CONFIRM
+fi
+unset KEY_FROM_ARG
+
+# ── confirmation ──
+echo
+echo "Will set PLATFORM_ROOT_SECRET on:"
+for t in "${TARGETS[@]}"; do
+  IFS=':' read -r _config _env label <<<"$t"
+  echo "  - $label"
+done
+echo
+if [[ $SKIP_CONFIRM -eq 0 ]]; then
+  read -rp "Proceed? [y/N] " ans
+  if [[ "$ans" != "y" && "$ans" != "Y" ]]; then
+    echo "aborted"
+    exit 1
+  fi
+fi
+
+# ── do the puts ──
+SUCCESS=()
+FAIL=()
+for t in "${TARGETS[@]}"; do
+  IFS=':' read -r config env label <<<"$t"
+  # Always pass --env explicitly. Empty string ("") tells wrangler to target
+  # the top-level (production) env rather than triggering the "multiple
+  # environments defined, none specified" warning.
+  cmd=(npx wrangler secret put PLATFORM_ROOT_SECRET --config "$config" --env="$env")
+  echo
+  echo "→ $label"
+  if printf '%s' "$VALUE" | "${cmd[@]}"; then
+    SUCCESS+=("$label")
+  else
+    FAIL+=("$label")
+    echo "  FAILED — continuing with the rest, will report at end" >&2
+  fi
+done
+
+# ── scrub the value from this shell ──
+unset VALUE
+
+# ── summary + verification hint ──
+echo
+echo "==== Summary ===="
+echo "Set OK : ${#SUCCESS[@]}"
+for s in "${SUCCESS[@]}"; do echo "  ✓ $s"; done
+if [[ ${#FAIL[@]} -gt 0 ]]; then
+  echo "Failed : ${#FAIL[@]}"
+  for f in "${FAIL[@]}"; do echo "  ✗ $f"; done
+  echo
+  echo "Re-run for the failed targets after fixing the underlying issue."
+  exit 3
+fi
+
+echo
+echo "Verify each target shows PLATFORM_ROOT_SECRET:"
+for t in "${TARGETS[@]}"; do
+  IFS=':' read -r config env _label <<<"$t"
+  echo "  npx wrangler secret list --config $config --env=\"$env\""
+done

--- a/skills/openma/integrations-linear.md
+++ b/skills/openma/integrations-linear.md
@@ -270,7 +270,7 @@ and hand them the install URL with the same a/b choice.
   (`oma linear unpublish <pub>`), re-run the publish flow, and pass the
   `lin_wh_…` value Linear shows (right side of the OAuth app's Webhooks
   panel) to `oma linear submit --webhook-secret`.
-- `MCP_SIGNING_KEY` rotation breaks already-stored secrets — they were
+- `PLATFORM_ROOT_SECRET` rotation breaks already-stored secrets — they were
   encrypted with the old key and won't decrypt. Re-run the publish flow.
 - A delivery shows `reason=installation_not_found_or_revoked` after the
   install was approved — the App row's `publication_id` is null because

--- a/skills/openma/linear-local-test.md
+++ b/skills/openma/linear-local-test.md
@@ -55,7 +55,7 @@ brew install cloudflared                      # tunnel to expose :8787 publicly
 ### 1. Generate two secrets (once per laptop)
 
 ```bash
-openssl rand -base64 32   # MCP_SIGNING_KEY
+openssl rand -base64 32   # PLATFORM_ROOT_SECRET
 openssl rand -base64 32   # INTEGRATIONS_INTERNAL_SECRET
 ```
 
@@ -63,14 +63,14 @@ openssl rand -base64 32   # INTEGRATIONS_INTERNAL_SECRET
 
 `apps/main/.dev.vars`:
 ```
-MCP_SIGNING_KEY=<value-1>
+PLATFORM_ROOT_SECRET=<value-1>
 INTEGRATIONS_INTERNAL_SECRET=<value-2>
 # plus whatever else apps/main needs (BETTER_AUTH_SECRET, ANTHROPIC_API_KEY, ...)
 ```
 
 `apps/integrations/.dev.vars`:
 ```
-MCP_SIGNING_KEY=<value-1>
+PLATFORM_ROOT_SECRET=<value-1>
 INTEGRATIONS_INTERNAL_SECRET=<value-2>
 GATEWAY_ORIGIN=http://localhost:8787
 ```

--- a/test/unit/credentials-store-encryption.test.ts
+++ b/test/unit/credentials-store-encryption.test.ts
@@ -1,0 +1,201 @@
+// Encryption-boundary tests for the credentials store. Wires
+// CredentialService against an InMemoryCredentialRepo + FakeCrypto and proves:
+//   1. The on-disk blob (auth_cipher) is the cipher, not the plaintext JSON.
+//   2. Round-trip via service.create → service.get returns the original auth.
+//   3. Partial-update merge semantics still work after encryption was added
+//      (read-merge-write happens on plaintext-typed rows, repo re-encrypts).
+//   4. stripSecrets operates on the decrypted output, removing the same
+//      fields it always did.
+//   5. Hot-path columns (mcp_server_url, provider) remain queryable — the
+//      partial UNIQUE check fires regardless of encryption.
+//
+// The InMemoryCredentialRepo intentionally mirrors SqlCredentialRepo's
+// encrypt-on-write / decrypt-on-read boundary so this unit test exercises the
+// same semantics that production hits.
+
+import { describe, it, expect } from "vitest";
+import {
+  CredentialDuplicateMcpUrlError,
+  stripSecrets,
+} from "../../packages/credentials-store/src/index";
+import {
+  FakeCrypto,
+  ManualClock,
+  createInMemoryCredentialService,
+} from "../../packages/credentials-store/src/test-fakes";
+
+const TENANT = "tn_test_enc";
+const VAULT = "vlt_test_enc";
+
+describe("CredentialService — encryption boundary", () => {
+  it("stores the cipher on disk, not the plaintext JSON", async () => {
+    const { service, repo } = createInMemoryCredentialService({
+      crypto: new FakeCrypto(),
+    });
+    const created = await service.create({
+      tenantId: TENANT,
+      vaultId: VAULT,
+      displayName: "OAuth cred",
+      auth: {
+        type: "mcp_oauth",
+        mcp_server_url: "https://mcp.example.com",
+        access_token: "sk-very-secret-access-token",
+        refresh_token: "rt-very-secret-refresh-token",
+      },
+    });
+
+    const raw = repo.__getRawAuthCipher(created.id);
+    expect(raw).toBeDefined();
+    // FakeCrypto wraps with `enc(...)` — proves encryption was called.
+    expect(raw!.startsWith("enc(")).toBe(true);
+    expect(raw!.endsWith(")")).toBe(true);
+    // The plaintext secrets must not appear in the on-disk blob in raw form;
+    // FakeCrypto's "enc(" wrapper carries the JSON inside, so we strip the
+    // wrapper and verify the inner payload IS the JSON (proving the cipher
+    // is what's persisted, not the parsed object). With a real WebCryptoAesGcm
+    // the secrets wouldn't appear at all — that's covered by the model-cards
+    // and integrations roundtrip suites.
+    const inner = raw!.slice(4, -1);
+    expect(JSON.parse(inner).access_token).toBe("sk-very-secret-access-token");
+  });
+
+  it("round-trips the auth blob through create → get", async () => {
+    const { service } = createInMemoryCredentialService({
+      crypto: new FakeCrypto(),
+    });
+    const auth = {
+      type: "static_bearer" as const,
+      mcp_server_url: "https://api.example.com",
+      token: "bearer-token-12345",
+    };
+    const created = await service.create({
+      tenantId: TENANT,
+      vaultId: VAULT,
+      displayName: "Bearer cred",
+      auth,
+    });
+
+    const fetched = await service.get({
+      tenantId: TENANT,
+      vaultId: VAULT,
+      credentialId: created.id,
+    });
+    expect(fetched).not.toBeNull();
+    expect(fetched!.auth).toEqual(auth);
+  });
+
+  it("preserves untouched fields across partial-update merges", async () => {
+    const clock = new ManualClock(1_000_000);
+    const { service } = createInMemoryCredentialService({
+      clock,
+      crypto: new FakeCrypto(),
+    });
+    const created = await service.create({
+      tenantId: TENANT,
+      vaultId: VAULT,
+      displayName: "OAuth",
+      auth: {
+        type: "mcp_oauth",
+        mcp_server_url: "https://mcp.example.com",
+        access_token: "old-access",
+        refresh_token: "old-refresh",
+        client_id: "client-abc",
+        client_secret: "secret-xyz",
+        token_endpoint: "https://mcp.example.com/oauth/token",
+      },
+    });
+
+    clock.advance(60_000);
+    const updated = await service.update({
+      tenantId: TENANT,
+      vaultId: VAULT,
+      credentialId: created.id,
+      auth: { access_token: "new-access" },
+    });
+
+    // Partial merge: access_token replaced, everything else preserved.
+    expect(updated.auth.access_token).toBe("new-access");
+    expect(updated.auth.refresh_token).toBe("old-refresh");
+    expect(updated.auth.client_id).toBe("client-abc");
+    expect(updated.auth.client_secret).toBe("secret-xyz");
+    expect(updated.auth.mcp_server_url).toBe("https://mcp.example.com");
+    expect(updated.auth.type).toBe("mcp_oauth");
+  });
+
+  it("stripSecrets still removes secret fields after encryption is wired", async () => {
+    const { service } = createInMemoryCredentialService({
+      crypto: new FakeCrypto(),
+    });
+    const created = await service.create({
+      tenantId: TENANT,
+      vaultId: VAULT,
+      displayName: "OAuth",
+      auth: {
+        type: "mcp_oauth",
+        mcp_server_url: "https://mcp.example.com",
+        access_token: "secret-access",
+        refresh_token: "secret-refresh",
+        client_secret: "secret-client",
+        client_id: "client-id-not-secret",
+      },
+    });
+
+    const stripped = stripSecrets(created);
+    expect(stripped.auth.access_token).toBeUndefined();
+    expect(stripped.auth.refresh_token).toBeUndefined();
+    expect(stripped.auth.client_secret).toBeUndefined();
+    // Non-secret fields preserved.
+    expect(stripped.auth.client_id).toBe("client-id-not-secret");
+    expect(stripped.auth.mcp_server_url).toBe("https://mcp.example.com");
+  });
+
+  it("partial UNIQUE on mcp_server_url fires regardless of encryption (denormalized column intact)", async () => {
+    const { service } = createInMemoryCredentialService({
+      crypto: new FakeCrypto(),
+    });
+    await service.create({
+      tenantId: TENANT,
+      vaultId: VAULT,
+      displayName: "First",
+      auth: {
+        type: "static_bearer",
+        mcp_server_url: "https://shared.example.com",
+        token: "first-token",
+      },
+    });
+    await expect(
+      service.create({
+        tenantId: TENANT,
+        vaultId: VAULT,
+        displayName: "Second",
+        auth: {
+          type: "static_bearer",
+          mcp_server_url: "https://shared.example.com",
+          token: "second-token",
+        },
+      }),
+    ).rejects.toBeInstanceOf(CredentialDuplicateMcpUrlError);
+  });
+
+  it("decrypt failure surfaces — corrupted on-disk blob throws on read", async () => {
+    const { service, repo } = createInMemoryCredentialService({
+      crypto: new FakeCrypto(),
+    });
+    const created = await service.create({
+      tenantId: TENANT,
+      vaultId: VAULT,
+      displayName: "tampered",
+      auth: { type: "static_bearer", token: "ok" },
+    });
+    // Corrupt the cipher: drop the FakeCrypto wrapper.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (repo as any).byId.get(created.id).auth_cipher = "garbage-no-wrapper";
+    await expect(
+      service.get({
+        tenantId: TENANT,
+        vaultId: VAULT,
+        credentialId: created.id,
+      }),
+    ).rejects.toThrow(/not a fake-cipher/);
+  });
+});

--- a/test/unit/model-cards-store-encryption.test.ts
+++ b/test/unit/model-cards-store-encryption.test.ts
@@ -1,0 +1,98 @@
+// Encryption-roundtrip tests for the model card store. Wires a real
+// WebCryptoAesGcm (the production primitive) into createInMemoryModelCardService
+// and proves that the api_key path encrypts at rest and decrypts on demand,
+// without breaking the api_key_preview invariant.
+//
+// The existing service unit tests use FakeCrypto. This file complements them
+// by exercising the actual AES-256-GCM implementation that production wires
+// up — same algorithm, same Web Crypto API, same key derivation.
+
+import { describe, it, expect } from "vitest";
+import { apiKeyPreview } from "../../packages/model-cards-store/src/index";
+import { createInMemoryModelCardService } from "../../packages/model-cards-store/src/test-fakes";
+import { WebCryptoAesGcm } from "../../packages/integrations-adapters-cf/src/crypto";
+
+const TENANT = "tn_test_mdl_enc";
+const SECRET = "test-secret-padded-to-be-thirtytwo-chars";
+
+function realCrypto() {
+  return new WebCryptoAesGcm(SECRET, "model.cards.keys");
+}
+
+describe("ModelCardService — real AES-GCM encryption", () => {
+  it("round-trips api_key via getApiKey", async () => {
+    const { service } = createInMemoryModelCardService({ crypto: realCrypto() });
+    const card = await service.create({
+      tenantId: TENANT,
+      modelId: "claude-sonnet-4-6",
+      provider: "ant",
+      apiKey: "sk-ant-supersecret-roundtripme-9876",
+    });
+    const key = await service.getApiKey({ tenantId: TENANT, cardId: card.id });
+    expect(key).toBe("sk-ant-supersecret-roundtripme-9876");
+  });
+
+  it("api_key_preview matches plaintext last-4 (computed independent of cipher)", async () => {
+    const { service } = createInMemoryModelCardService({ crypto: realCrypto() });
+    const card = await service.create({
+      tenantId: TENANT,
+      modelId: "gpt-4o",
+      provider: "openai",
+      apiKey: "sk-test-very-long-key-ending-1234",
+    });
+    expect(card.api_key_preview).toBe("1234");
+    expect(apiKeyPreview("sk-test-very-long-key-ending-1234")).toBe("1234");
+  });
+
+  it("re-encrypts on update and the new key is retrievable", async () => {
+    const { service } = createInMemoryModelCardService({ crypto: realCrypto() });
+    const card = await service.create({
+      tenantId: TENANT,
+      modelId: "claude-sonnet-4-6",
+      provider: "ant",
+      apiKey: "sk-original-key-aaaa",
+    });
+    await service.update({
+      tenantId: TENANT,
+      cardId: card.id,
+      apiKey: "sk-rotated-key-bbbb",
+    });
+    const got = await service.getApiKey({ tenantId: TENANT, cardId: card.id });
+    expect(got).toBe("sk-rotated-key-bbbb");
+  });
+
+  it("ciphertext does not contain the plaintext", async () => {
+    // Sneak a peek at the cipher via a recording crypto wrapper.
+    const seen: string[] = [];
+    const inner = new WebCryptoAesGcm(SECRET, "model.cards.keys");
+    const recording = {
+      encrypt: async (plaintext: string) => {
+        const cipher = await inner.encrypt(plaintext);
+        seen.push(cipher);
+        return cipher;
+      },
+      decrypt: (cipher: string) => inner.decrypt(cipher),
+    };
+
+    const { service } = createInMemoryModelCardService({ crypto: recording });
+    await service.create({
+      tenantId: TENANT,
+      modelId: "claude-sonnet-4-6",
+      provider: "ant",
+      apiKey: "sk-plaintext-marker-abcdef",
+    });
+    expect(seen.length).toBeGreaterThan(0);
+    for (const cipher of seen) {
+      expect(cipher).not.toContain("sk-plaintext-marker");
+      expect(cipher).not.toContain("abcdef");
+    }
+  });
+
+  it("rejects ciphertext encrypted under a different label (key isolation)", async () => {
+    const cryptoA = new WebCryptoAesGcm(SECRET, "model.cards.keys");
+    const cryptoB = new WebCryptoAesGcm(SECRET, "credentials.auth");
+
+    const cipher = await cryptoA.encrypt("sk-secret-from-A");
+    await expect(cryptoB.decrypt(cipher)).rejects.toThrow();
+  });
+});

--- a/test/unit/services-dispatch.test.ts
+++ b/test/unit/services-dispatch.test.ts
@@ -25,6 +25,9 @@ function envWith(extras: Record<string, string | undefined> = {}): Env {
   return {
     AUTH_DB: fakeDb,
     CONFIG_KV: {} as unknown,
+    // Required by buildServices for at-rest encryption — value doesn't matter
+    // for these tests since they don't actually run encrypt/decrypt.
+    PLATFORM_ROOT_SECRET: "test-platform-root-secret-for-services-dispatch",
     ...extras,
   } as unknown as Env;
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,10 @@ const cfWorkerOptions = {
       API_KEY: "test-key",
       ANTHROPIC_API_KEY: "sk-ant-test-key",
       BETTER_AUTH_SECRET: "test-auth-secret-for-vitest",
+      // Required by buildServices for at-rest encryption of credentials.auth
+      // and model_cards.api_key_cipher. Tests don't care about the value as
+      // long as it's stable across encrypt/decrypt within a single process.
+      PLATFORM_ROOT_SECRET: "test-platform-root-secret-padded-to-thirtytwo",
       RATE_LIMIT_WRITE: 10000,
       RATE_LIMIT_READ: 10000,
     },


### PR DESCRIPTION
## Summary

- **Encrypts `credentials.auth` at rest** via AES-256-GCM at the `SqlCredentialRepo` layer. Hot-path columns (`auth_type` / `mcp_server_url` / `provider`) stay plaintext for indexing; only the JSON blob is encrypted. Adds a new `Crypto` port to `credentials-store` (mirror of `model-cards-store`).
- **Encrypts `model_cards.api_key_cipher`** by wiring a real `WebCryptoAesGcm` into the existing `Crypto` port (was defaulting to no-op `identityCrypto` despite the `_cipher` column name).
- **Boot-time enforcement**: `buildServices` throws if `PLATFORM_ROOT_SECRET` is missing — no silent plaintext fallback ever again.
- **Renames `MCP_SIGNING_KEY` → `PLATFORM_ROOT_SECRET`** across source, configs, tests, scripts, and active docs (archived docs left as historical record). Old name described only the original outbound-MCP JWT signing use; the same secret had drifted into AES key derivation for integrations tokens, credentials, and model card keys. New name reflects actual scope.
- **Operator tooling**: `scripts/set-platform-root-secret.sh` (one-shot to set the secret on all 4 worker targets); `scripts/backfill-encrypt-secrets.ts` + README (idempotent backfill via try-decrypt for environments that need it).
- **No `v1:` prefix or version wrapper**: chose direct AES-GCM with no scaffolding. Future key rotation = run another full backfill (acceptable at current data volume).

## Test plan

Unit tests:
- [x] `pnpm vitest run` — 72 / 72 pass across encryption-related suites
  - `packages/integrations-adapters-cf/src/crypto.test.ts` (10) — fills the prior test gap for `WebCryptoAesGcm`
  - `test/unit/credentials-store-encryption.test.ts` (6) — round-trip, partial merge, `stripSecrets`, hot-path indexing
  - `test/unit/model-cards-store-encryption.test.ts` (5) — round-trip with real AES-GCM, `api_key_preview` invariant, label isolation
  - `test/unit/credentials-store-service.test.ts` (20) — pre-existing tests still pass

Staging verification (CI run [25719514337](https://github.com/open-ma/openma-hosted/actions/runs/25719514337)):
- [x] CI deploy succeeded (3 workers: main, agent, integrations)
- [x] `GET /v1/me` → 200 (worker boots, `PLATFORM_ROOT_SECRET` wired)
- [x] `GET /v1/model_cards` → 200 (decrypt path ready)
- [x] **model_cards round-trip**: `POST /v1/model_cards` (write encrypted) → `GET /v1/model_cards` (preview shows last-4 of plaintext, not cipher) → `GET /v1/model_cards/:id/key` (returns full plaintext) → `DELETE` cleanup
- [x] **credentials.auth round-trip**: vault create → credential create with `static_bearer` (write encrypted) → list (decrypt path; `auth.type` + `mcp_server_url` visible, `auth.token` correctly stripped by `stripSecrets`) → cleanup

Prod cutover plan (post-merge):
- [ ] Bump `openma-hosted/.oma-version` to this PR's merge SHA
- [ ] Push hosted/main → Deploy workflow runs
- [ ] Wipe prod plaintext rows (5 model_cards + 6 credentials) — same approach as staging
- [ ] User recreates real keys via the new encrypted write path

🤖 Generated with [Claude Code](https://claude.com/claude-code)