### PR TITLE
fix(console): use SecretInput/TextInput in ModelCard + Vault forms

### DIFF
--- a/apps/console/src/pages/ModelCardsList.tsx
+++ b/apps/console/src/pages/ModelCardsList.tsx
@@ -4,6 +4,7 @@ import { useCursorList } from "../lib/useCursorList";
 import { Modal } from "../components/Modal";
 import { Button } from "../components/Button";
 import { ListPage } from "../components/ListPage";
+import { TextInput, SecretInput } from "../components/Input";
 import type { ModelCard } from "@open-managed-agents/api-types";
 
 const PROVIDERS = [
@@ -220,8 +221,8 @@ export function ModelCardsList() {
               Model ID *
               <span className="ml-1 text-xs text-fg-subtle">(tenant-unique handle agents reference)</span>
             </label>
-            <input value={form.model_id} onChange={(e) => setForm({ ...form, model_id: e.target.value })} className={inputCls}
-              placeholder="claude-prod, claude-sonnet-4-6, bedrock-sonnet, ..." autoComplete="off" />
+            <TextInput value={form.model_id} onChange={(e) => setForm({ ...form, model_id: e.target.value })} className={inputCls}
+              placeholder="claude-prod, claude-sonnet-4-6, bedrock-sonnet, ..." />
           </div>
           <div>
             <label className="text-sm text-fg-muted block mb-1">API Format *</label>
@@ -245,9 +246,9 @@ export function ModelCardsList() {
           </div>
           <div>
             <label className="text-sm text-fg-muted block mb-1">API Key {editingId ? "" : "*"}</label>
-            <input type="password" value={form.api_key} onChange={(e) => setForm({ ...form, api_key: e.target.value })} className={inputCls}
+            <SecretInput value={form.api_key} onChange={(e) => setForm({ ...form, api_key: e.target.value })} className={inputCls}
               placeholder={editingId ? "Leave blank to keep current key" : "sk-..."}
-              autoComplete="new-password" name="model-api-key-field"
+              name="model-api-key-field"
               onBlur={() => { if (OFFICIAL_PROVIDERS.has(form.provider) && form.api_key) fetchModels(form.provider, form.api_key); }} />
             {OFFICIAL_PROVIDERS.has(form.provider) && modelsLoading && (
               <p className="text-xs text-fg-subtle mt-1">Loading models...</p>

--- a/apps/console/src/pages/VaultsList.tsx
+++ b/apps/console/src/pages/VaultsList.tsx
@@ -4,6 +4,7 @@ import { useCursorList } from "../lib/useCursorList";
 import { Modal } from "../components/Modal";
 import { Button } from "../components/Button";
 import { ListPage } from "../components/ListPage";
+import { TextInput, SecretInput } from "../components/Input";
 import { MCP_REGISTRY, type McpRegistryEntry } from "../data/mcp-registry";
 
 interface Vault { id: string; name: string; created_at: string; archived_at?: string; }
@@ -480,7 +481,7 @@ export function VaultsList() {
 
           <div>
             <label className="text-sm text-fg-muted block mb-1">Display Name <span className="text-fg-subtle">(optional)</span></label>
-            <input
+            <TextInput
               value={cliForm.display_name}
               onChange={(e) => setCliForm({ ...cliForm, display_name: e.target.value })}
               className={inputCls}
@@ -490,8 +491,7 @@ export function VaultsList() {
           </div>
           <div>
             <label className="text-sm text-fg-muted block mb-1">Token <span className="text-fg-subtle">(write-only — leave blank to use OAuth above)</span></label>
-            <input
-              type="password"
+            <SecretInput
               value={cliForm.token}
               onChange={(e) => setCliForm({ ...cliForm, token: e.target.value })}
               className={inputCls}


### PR DESCRIPTION
## Summary

- ModelCard and Vault create/edit forms had bare `<input type="password">` next to a plain text input. Chrome's password manager identifies that pair as a login form and silently autofills with saved domain credentials — on staging the Model ID got filled with the saved IAM email (`hrhrng@foxmail.com`), with the API Key dropdown offering the saved password right next to it.
- Migrated both forms to use the existing `SecretInput` / `TextInput` from `apps/console/src/components/Input.tsx`. Those components encode `autoComplete="new-password"` (the only autocomplete token Chrome actually honors for autofill suppression) plus `data-1p-ignore` / `data-lpignore` for 1Password and LastPass.
- No behavior change beyond the autofill fix; visual styling preserved by passing the local `inputCls` through.

## Test plan

- [ ] On staging (where saved `app.staging.openma.dev` credentials exist), open **+ New model card** — Model ID should not auto-populate; API Key field should not pop the saved-password dropdown.
- [ ] Same check for **+ Add CLI** in Vaults.
- [ ] Eye toggle on API Key / Token reveals and re-masks the value.
- [ ] On-blur model fetch in Model Card form still fires when API Key is filled for an official provider.

🤖 Generated with [Claude Code](https://claude.com/claude-code)