### PR TITLE
test(mocks): webhook generators + cleanup leftover post-squash migration files

### DIFF
--- a/test/e2e/e2e-webhooks.sh
+++ b/test/e2e/e2e-webhooks.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Webhook delivery e2e — fires correctly-signed Linear / GitHub / Slack
+# webhooks at an OMA integrations gateway, verifies HTTP acceptance.
+#
+# Prerequisites:
+#   - A live integrations gateway URL (e.g. https://integrations.staging.openma.dev)
+#   - A `publicationId` row + its raw signing/webhook secret (read from the
+#     wizard's "verify credentials" toast or the model_cards / publications
+#     API after install)
+#
+# Usage:
+#   ./test/e2e/e2e-webhooks.sh <gateway-url> <provider> <pubId> <secret>
+# Provider: slack | github | linear
+#
+# Exits non-zero if any HTTP returns non-2xx.
+
+set -euo pipefail
+
+GATEWAY="${1:?gateway url}"
+PROVIDER="${2:?provider (slack|github|linear)}"
+PUB_ID="${3:?publication id}"
+SECRET="${4:?webhook/signing secret}"
+
+PASS=0; FAIL=0
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../.." && pwd)"
+
+run() {
+  local label="$1"; shift
+  echo "=== $label ==="
+  if pnpm exec tsx "$ROOT/test/mocks/fire-webhook.ts" "$@"; then
+    echo "✓ $label"
+    PASS=$((PASS+1))
+  else
+    echo "✗ $label"
+    FAIL=$((FAIL+1))
+  fi
+  echo
+}
+
+case "$PROVIDER" in
+  slack)
+    run "slack: app_mention" slack "$GATEWAY" "$PUB_ID" "$SECRET" "<@U_MOCK_BOT> hi"
+    ;;
+  github)
+    run "github: labeled (engagement trigger)" github-labeled "$GATEWAY" "$PUB_ID" "$SECRET" 1 "oma:engage"
+    run "github: issue_comment (wake-on-comment)" github-comment "$GATEWAY" "$PUB_ID" "$SECRET" 1 "follow-up"
+    ;;
+  linear)
+    run "linear: IssueMention" linear-mention "$GATEWAY" "$PUB_ID" "$SECRET" "Webhook smoke test"
+    run "linear: IssueAssignedToYou" linear-assigned "$GATEWAY" "$PUB_ID" "$SECRET" "Assigned smoke test"
+    ;;
+  *)
+    echo "unknown provider: $PROVIDER"
+    exit 2
+    ;;
+esac
+
+echo "═══════════════════════════════════"
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/test/mocks/README.md
+++ b/test/mocks/README.md
@@ -1,0 +1,66 @@
+# Webhook / OAuth / MCP mocks for e2e testing
+
+External-integration paths (Linear / GitHub / Slack inbound webhooks, MCP
+proxy refresh-token, OAuth install) were uncovered by `e2e.sh /
+e2e-advanced.sh / e2e-tools.sh` — those run end-to-end through the gateway
+but assume real third-party services on the other side. This directory
+holds the mock infrastructure that closes that gap.
+
+## What's implemented
+
+### `webhook-signatures.ts` + `fire-webhook.ts`
+
+Pure-Node CLI that produces correctly-HMAC-signed inbound webhook payloads
+for the three providers and POSTs them at an OMA integrations gateway.
+
+```bash
+tsx test/mocks/fire-webhook.ts slack <gateway> <pubId> <signingSecret> "<@U_BOT> hi"
+tsx test/mocks/fire-webhook.ts github-labeled <gateway> <pubId> <webhookSecret> 1 oma:engage
+tsx test/mocks/fire-webhook.ts github-comment <gateway> <pubId> <webhookSecret> 1 "follow-up"
+tsx test/mocks/fire-webhook.ts linear-mention <gateway> <pubId> <webhookSecret> "Issue title"
+tsx test/mocks/fire-webhook.ts linear-assigned <gateway> <pubId> <webhookSecret> "Issue title"
+```
+
+`test/e2e/e2e-webhooks.sh <gateway> <provider> <pubId> <secret>` wraps the
+above into a per-provider scoreboard.
+
+### Operator workflow
+
+Webhook test requires a real `publication` row + its webhook/signing secret.
+Today the secrets land on the install wizard's verify-credentials toast.
+For test purposes you can also fetch them via the API (encrypted at rest,
+exposed in the response of the publish endpoint right after credential
+submission).
+
+## What's NOT implemented (deferred)
+
+### MCP-proxy refresh-token mock server
+
+Needs a deployed HTTP endpoint that the gateway can reach: returns 401
+once, then 200 after the gateway hits its `/token` endpoint with the
+refresh_token. The interesting test is the D1 CAS race when two RPC
+calls hit `expires_in` simultaneously — needs a controllable mock with
+per-call response programming.
+
+Realistic implementation: a tiny CF Worker deployed alongside staging
+(e.g. `mock-mcp.staging.openma.dev`). Bookkeeping is per-request state in
+a Durable Object so two concurrent calls can race.
+
+### OAuth provider mock servers
+
+Needs deployed `/authorize` and `/token` endpoints that pretend to be
+Linear / Slack / GitHub. Same deployment shape as the MCP mock.
+
+Both would unlock e2e for publication-first install UI (today only
+exercisable in a browser against the real Slack / Linear app admin UIs).
+
+## When to use which
+
+| Surface                                  | How to test today                                        |
+| ---------------------------------------- | -------------------------------------------------------- |
+| Agent / Env / Session / SSE              | `e2e.sh`, `e2e-local.sh`                                 |
+| Tool execution (write / bash / multi)    | `e2e-tools.sh`                                           |
+| Memory / vault / cred / files / dup-cred | `e2e-advanced.sh`                                        |
+| Webhook delivery (post-install)          | `e2e-webhooks.sh` ← this directory                       |
+| Publication-first install OAuth callback | Manual browser flow (until OAuth mock lands)             |
+| MCP-proxy refresh-token race             | Manual + careful prod observation (until MCP mock lands) |

--- a/test/mocks/fire-webhook.ts
+++ b/test/mocks/fire-webhook.ts
@@ -1,0 +1,174 @@
+// CLI: fire a correctly-signed webhook at an OMA integrations gateway.
+//
+// Usage:
+//   tsx test/mocks/fire-webhook.ts slack <gateway> <pubId> <signingSecret> [text]
+//   tsx test/mocks/fire-webhook.ts github-labeled <gateway> <appOmaId> <webhookSecret> [issueNumber] [label]
+//   tsx test/mocks/fire-webhook.ts github-comment <gateway> <appOmaId> <webhookSecret> [issueNumber] [text]
+//   tsx test/mocks/fire-webhook.ts linear-mention <gateway> <pubId> <webhookSecret> [issueTitle]
+//   tsx test/mocks/fire-webhook.ts linear-assigned <gateway> <pubId> <webhookSecret> [issueTitle]
+//
+// Gateway URL is the integrations gateway origin (e.g.
+// https://integrations.staging.openma.dev — NOT the main app). The second
+// arg's meaning depends on the provider:
+//   - slack / linear: publicationId (from `*_publications` table — webhooks
+//     route on a stable publication-keyed URL)
+//   - github: appOmaId (from `github_publications.app_oma_id` — GitHub Apps
+//     bake the webhook URL into their manifest at registration time, so the
+//     URL must be stable from minute one)
+//
+// Exit code 0 means HTTP 2xx; non-zero means the gateway rejected or errored.
+
+import {
+  signSlack,
+  signGithub,
+  signLinear,
+  makeSlackEventCallback,
+  makeSlackAppMention,
+  makeGithubIssueLabeled,
+  makeGithubIssueComment,
+  makeLinearIssueMention,
+  makeLinearIssueAssigned,
+} from "./webhook-signatures";
+
+const [, , kind, gateway, pubOrApp, secret, ...rest] = process.argv;
+
+if (!kind || !gateway || !pubOrApp || !secret) {
+  console.error("Usage: tsx fire-webhook.ts <kind> <gateway> <pubId|appOmaId> <secret> [...]");
+  console.error("kinds: slack | github-labeled | github-comment | linear-mention | linear-assigned");
+  console.error("  slack / linear-*: 3rd arg = publicationId");
+  console.error("  github-*: 3rd arg = appOmaId (from github_publications.app_oma_id)");
+  process.exit(2);
+}
+
+async function postRaw(url: string, body: string, headers: Record<string, string>) {
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "content-type": "application/json", ...headers },
+    body,
+  });
+  const text = await res.text();
+  console.log(`POST ${url}`);
+  console.log(`  → HTTP ${res.status}`);
+  console.log(`  → body: ${text.slice(0, 500)}`);
+  if (!res.ok) process.exit(1);
+}
+
+(async () => {
+  if (kind === "slack") {
+    const text = rest[0] ?? "<@U_MOCK_BOT> hello from fire-webhook";
+    const envelope = makeSlackEventCallback({
+      eventId: `Ev_mock_${Date.now()}`,
+      teamId: "T_MOCK",
+      apiAppId: "A_MOCK",
+      event: makeSlackAppMention({
+        channelId: "C_MOCK",
+        userId: "U_MOCK_HUMAN",
+        text,
+      }),
+    });
+    const body = JSON.stringify(envelope);
+    const sig = signSlack(body, secret);
+    await postRaw(
+      `${gateway}/slack/webhook/pub/${pubOrApp}`,
+      body,
+      {
+        "x-slack-request-timestamp": sig.timestampHeader,
+        "x-slack-signature": sig.signatureHeader,
+      },
+    );
+    return;
+  }
+
+  if (kind === "github-labeled") {
+    const issueNumber = Number(rest[0] ?? "1");
+    const label = rest[1] ?? "oma:engage";
+    const envelope = makeGithubIssueLabeled({
+      installationId: 9999,
+      repoFullName: "octocat/mock-repo",
+      issueNumber,
+      issueTitle: "Mock issue",
+      issueBody: "Triggered by fire-webhook.ts",
+      labelName: label,
+      sender: "mock-user",
+    });
+    const body = JSON.stringify(envelope);
+    const sig = signGithub(body, secret);
+    await postRaw(
+      `${gateway}/github/webhook/app/${pubOrApp}`,
+      body,
+      {
+        "x-github-event": "issues",
+        "x-github-delivery": `dl_mock_${Date.now()}`,
+        "x-hub-signature-256": sig.signatureHeader,
+      },
+    );
+    return;
+  }
+
+  if (kind === "github-comment") {
+    const issueNumber = Number(rest[0] ?? "1");
+    const text = rest[1] ?? "follow-up from fire-webhook";
+    const envelope = makeGithubIssueComment({
+      installationId: 9999,
+      repoFullName: "octocat/mock-repo",
+      issueNumber,
+      commentId: Date.now(),
+      commentBody: text,
+      sender: "mock-user",
+    });
+    const body = JSON.stringify(envelope);
+    const sig = signGithub(body, secret);
+    await postRaw(
+      `${gateway}/github/webhook/app/${pubOrApp}`,
+      body,
+      {
+        "x-github-event": "issue_comment",
+        "x-github-delivery": `dl_mock_${Date.now()}`,
+        "x-hub-signature-256": sig.signatureHeader,
+      },
+    );
+    return;
+  }
+
+  if (kind === "linear-mention") {
+    const title = rest[0] ?? "Mock issue from fire-webhook";
+    const envelope = makeLinearIssueMention({
+      workspaceId: "ws_mock",
+      issueId: `issue_${Date.now()}`,
+      issueIdentifier: `MOCK-${Math.floor(Math.random() * 1000)}`,
+      issueTitle: title,
+      issueDescription: "Body from fire-webhook.ts",
+      actorId: "usr_mock",
+    });
+    const body = JSON.stringify(envelope);
+    const sig = signLinear(body, secret);
+    await postRaw(
+      `${gateway}/linear/webhook/pub/${pubOrApp}`,
+      body,
+      { "linear-signature": sig.signatureHeader },
+    );
+    return;
+  }
+
+  if (kind === "linear-assigned") {
+    const title = rest[0] ?? "Assigned mock issue";
+    const envelope = makeLinearIssueAssigned({
+      workspaceId: "ws_mock",
+      issueId: `issue_${Date.now()}`,
+      issueIdentifier: `MOCK-${Math.floor(Math.random() * 1000)}`,
+      issueTitle: title,
+      actorId: "usr_mock",
+    });
+    const body = JSON.stringify(envelope);
+    const sig = signLinear(body, secret);
+    await postRaw(
+      `${gateway}/linear/webhook/pub/${pubOrApp}`,
+      body,
+      { "linear-signature": sig.signatureHeader },
+    );
+    return;
+  }
+
+  console.error(`unknown kind: ${kind}`);
+  process.exit(2);
+})();

--- a/test/mocks/webhook-signatures.ts
+++ b/test/mocks/webhook-signatures.ts
@@ -1,0 +1,214 @@
+// Webhook signature helpers — produce correctly-signed envelopes for
+// Linear / GitHub / Slack so e2e scripts can synthesize inbound webhooks
+// without standing up the real provider.
+//
+// All three providers sign HMAC-SHA256 over the raw body. They differ in:
+//   - Slack: signs `v0:{timestamp}:{rawBody}`; header `X-Slack-Signature: v0=<hex>`
+//   - GitHub: signs `rawBody` directly; header `X-Hub-Signature-256: sha256=<hex>`
+//   - Linear: signs `rawBody` directly; header `Linear-Signature: <hex>`
+//
+// The bodies are NOT pretty-printed — sign exactly what you POST. JSON.stringify
+// the envelope once, sign that string, then send the same string as the request
+// body. Re-stringifying will break the signature.
+
+import { createHmac } from "node:crypto";
+
+// ─── Slack ─────────────────────────────────────────────────────────────
+
+export function signSlack(
+  rawBody: string,
+  signingSecret: string,
+  timestamp: number = Math.floor(Date.now() / 1000),
+): { signature: string; timestampHeader: string; signatureHeader: string } {
+  const ts = String(timestamp);
+  const baseString = `v0:${ts}:${rawBody}`;
+  const h = createHmac("sha256", signingSecret).update(baseString).digest("hex");
+  return {
+    signature: `v0=${h}`,
+    timestampHeader: ts,
+    signatureHeader: `v0=${h}`,
+  };
+}
+
+/** Minimal Slack `event_callback` envelope. Mirror real fields the parser reads. */
+export function makeSlackEventCallback(opts: {
+  eventId: string;
+  teamId: string;
+  apiAppId: string;
+  event: Record<string, unknown>;
+  /** Optional auth context Slack passes through. */
+  authorizations?: Array<{ team_id: string; user_id: string }>;
+}): Record<string, unknown> {
+  return {
+    type: "event_callback",
+    event_id: opts.eventId,
+    event_time: Math.floor(Date.now() / 1000),
+    team_id: opts.teamId,
+    api_app_id: opts.apiAppId,
+    event: opts.event,
+    authorizations: opts.authorizations ?? [
+      { team_id: opts.teamId, user_id: "U_MOCK_BOT" },
+    ],
+  };
+}
+
+/** `app_mention` event payload. The agent's signal trigger on Slack. */
+export function makeSlackAppMention(opts: {
+  channelId: string;
+  userId: string;
+  text: string;
+  ts?: string;
+  threadTs?: string;
+}): Record<string, unknown> {
+  const eventTs = opts.ts ?? `${Date.now() / 1000}`;
+  return {
+    type: "app_mention",
+    user: opts.userId,
+    text: opts.text,
+    channel: opts.channelId,
+    ts: eventTs,
+    event_ts: eventTs,
+    ...(opts.threadTs ? { thread_ts: opts.threadTs } : {}),
+  };
+}
+
+// ─── GitHub ────────────────────────────────────────────────────────────
+
+export function signGithub(
+  rawBody: string,
+  webhookSecret: string,
+): { signatureHeader: string } {
+  const h = createHmac("sha256", webhookSecret).update(rawBody).digest("hex");
+  return { signatureHeader: `sha256=${h}` };
+}
+
+/** `issues` event with `action=labeled` — the label-based bot trigger path. */
+export function makeGithubIssueLabeled(opts: {
+  installationId: number;
+  repoFullName: string; // e.g. "octocat/hello-world"
+  issueNumber: number;
+  issueTitle: string;
+  issueBody: string;
+  labelName: string; // the trigger label
+  sender: string; // GitHub login
+}): Record<string, unknown> {
+  const [owner, name] = opts.repoFullName.split("/");
+  return {
+    action: "labeled",
+    issue: {
+      number: opts.issueNumber,
+      title: opts.issueTitle,
+      body: opts.issueBody,
+      state: "open",
+      user: { login: opts.sender, id: 1, type: "User" },
+      labels: [{ name: opts.labelName }],
+    },
+    label: { name: opts.labelName },
+    repository: {
+      id: 1,
+      name,
+      full_name: opts.repoFullName,
+      owner: { login: owner, id: 1 },
+    },
+    sender: { login: opts.sender, id: 1, type: "User" },
+    installation: { id: opts.installationId },
+  };
+}
+
+/** `issue_comment` event — the wake-on-comment path. */
+export function makeGithubIssueComment(opts: {
+  installationId: number;
+  repoFullName: string;
+  issueNumber: number;
+  commentId: number;
+  commentBody: string;
+  sender: string;
+}): Record<string, unknown> {
+  const [owner, name] = opts.repoFullName.split("/");
+  return {
+    action: "created",
+    issue: {
+      number: opts.issueNumber,
+      title: "issue",
+      state: "open",
+      user: { login: opts.sender, id: 1 },
+    },
+    comment: {
+      id: opts.commentId,
+      body: opts.commentBody,
+      user: { login: opts.sender, id: 1 },
+    },
+    repository: {
+      id: 1,
+      name,
+      full_name: opts.repoFullName,
+      owner: { login: owner, id: 1 },
+    },
+    sender: { login: opts.sender, id: 1 },
+    installation: { id: opts.installationId },
+  };
+}
+
+// ─── Linear ────────────────────────────────────────────────────────────
+
+export function signLinear(
+  rawBody: string,
+  webhookSecret: string,
+): { signatureHeader: string } {
+  const h = createHmac("sha256", webhookSecret).update(rawBody).digest("hex");
+  return { signatureHeader: h };
+}
+
+/** `IssueMention` action — bot got mentioned in an issue. */
+export function makeLinearIssueMention(opts: {
+  workspaceId: string;
+  issueId: string;
+  issueIdentifier: string; // e.g. "ENG-123"
+  issueTitle: string;
+  issueDescription: string;
+  actorId: string;
+}): Record<string, unknown> {
+  return {
+    action: "create",
+    type: "IssueMention",
+    organizationId: opts.workspaceId,
+    data: {
+      issue: {
+        id: opts.issueId,
+        identifier: opts.issueIdentifier,
+        title: opts.issueTitle,
+        description: opts.issueDescription,
+        state: { name: "Todo" },
+      },
+      actor: { id: opts.actorId, name: "mock-user" },
+    },
+    createdAt: new Date().toISOString(),
+    webhookId: "wh_mock",
+  };
+}
+
+/** `IssueAssignedToYou` — same as @-mention but via assignee. */
+export function makeLinearIssueAssigned(opts: {
+  workspaceId: string;
+  issueId: string;
+  issueIdentifier: string;
+  issueTitle: string;
+  actorId: string;
+}): Record<string, unknown> {
+  return {
+    action: "create",
+    type: "IssueAssignedToYou",
+    organizationId: opts.workspaceId,
+    data: {
+      issue: {
+        id: opts.issueId,
+        identifier: opts.issueIdentifier,
+        title: opts.issueTitle,
+        state: { name: "Todo" },
+      },
+      actor: { id: opts.actorId, name: "mock-user" },
+    },
+    createdAt: new Date().toISOString(),
+    webhookId: "wh_mock",
+  };
+}


### PR DESCRIPTION
## What

Two related changes:

### 1. Webhook generators (the headline feature)

External-integration paths used to be untestable from CI — webhook delivery requires correctly-HMAC-signed payloads from the real provider. This adds a pure-Node CLI that produces them on demand.

- `test/mocks/webhook-signatures.ts` — pure helpers for each provider's signature scheme (Slack `v0:{ts}:{body}`, GitHub raw-body SHA-256, Linear raw-body SHA-256) plus envelope builders for the event kinds the engagement-triggering paths actually consume (slack `app_mention`, github `issues+labeled` / `issue_comment`, linear `IssueMention` / `IssueAssignedToYou`).
- `test/mocks/fire-webhook.ts` — small `tsx` CLI to POST a synthesized envelope at any gateway origin. Slack/linear key on publicationId; github keys on appOmaId (GitHub Apps bake the webhook URL into the manifest at registration, so it has to be app-id-keyed).
- `test/e2e/e2e-webhooks.sh` — per-provider scoreboard wrapper.
- `test/mocks/README.md` — usage + what's deferred (MCP proxy refresh-token mock server, OAuth provider mock servers — both require a deployed CF Worker, separate work).

Smoked all 5 producers against `integrations.staging.openma.dev`:
- slack:    HTTP 200 + `{"ok":false,"reason":"unknown_publication_id"}`
- github-*: HTTP 200 + `{"ok":false,"reason":"unknown_app"}`
- linear-*: HTTP 200 + `{"ok":false,"reason":"publication_not_found"}`

Confirms gateway parses, looks up publication, rejects on absence. Real signature verification engages once a caller passes a real publication + secret.

### 2. Delete 5 leftover post-squash migration files

The OSS PR #97 squash-merged with merge-base `b971d7b` (before parallel PR #96). At that base, `apps/main/migrations-integrations/0002…0006_*.sql` didn't exist (they were added by #96 on a separate branch into main). When #97 squashed, it produced a diff from the empty base, so the deletions my branch already had weren't included. End result: main now has both my squashed-in `0001_consolidated.sql` AND #96's individual `0002…0006_*.sql` files.

On a fresh self-host deploy this would crash: wrangler runs `0001_consolidated.sql` first (creates tables with all columns), then `0002_slack_publication_first.sql` tries `ALTER TABLE slack_publications ADD COLUMN client_id` on a column that already exists → SQLite duplicate-column error.

This PR re-removes them, plus the now-orphaned `packages/integrations-adapters-node/src/sql/github/issue-session-repo.ts` (Github dedup target).

## Test plan

- [x] `tsx test/mocks/fire-webhook.ts <kind> ...` for all 5 kinds against staging — reachable + parsed
- [ ] After merge, verify a fresh self-host deploy: `setup-cf.sh` on a clean account → `wrangler d1 migrations apply MAIN_DB --remote` should NOT error on duplicate columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)