### PR TITLE
test(mocks): MCP proxy + OAuth provider mock CF Worker

### DIFF
--- a/test/e2e/e2e-mock-services.sh
+++ b/test/e2e/e2e-mock-services.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Mock-services smoke — exercises every endpoint on the deployed mock
+# CF Worker (test/mocks/mock-server). Run after `wrangler deploy` in
+# that directory to verify the worker is reachable and the per-bearer
+# state machines behave correctly.
+#
+# Usage:
+#   ./test/e2e/e2e-mock-services.sh [mock-base-url]
+# Defaults to https://oma-mock-services.hrhrngxy.workers.dev
+
+set -euo pipefail
+
+MOCK="${1:-https://oma-mock-services.hrhrngxy.workers.dev}"
+PASS=0; FAIL=0
+
+check() {
+  local name="$1" expected="$2" actual="$3"
+  if [[ "$actual" == *"$expected"* ]]; then
+    echo "  ✓ $name"; PASS=$((PASS+1))
+  else
+    echo "  ✗ $name — expected '$expected', got '$actual'"; FAIL=$((FAIL+1))
+  fi
+}
+
+echo "═══ root ═══"
+ROOT=$(curl -sS "$MOCK/")
+check "root advertises service" "oma-mock-services" "$ROOT"
+
+echo
+echo "═══ OAuth: /authorize → 302 with code+state ═══"
+LOC=$(curl -sS -o /dev/null -w "%{redirect_url}" "$MOCK/oauth/authorize?redirect_uri=https://example.com/cb&state=xyz")
+check "redirect carries code"  "code=mock_code_" "$LOC"
+check "redirect carries state" "state=xyz"       "$LOC"
+
+echo
+echo "═══ OAuth: /token authorization_code ═══"
+T1=$(curl -sS "$MOCK/oauth/token" -X POST -d 'grant_type=authorization_code&code=mock_code_test&redirect_uri=https://example.com/cb')
+check "issues access_token"  "access_token"  "$T1"
+check "issues refresh_token" "refresh_token" "$T1"
+check "Bearer type"          "Bearer"        "$T1"
+
+echo
+echo "═══ OAuth: /token refresh_token ═══"
+T2=$(curl -sS "$MOCK/oauth/token" -X POST -d 'grant_type=refresh_token&refresh_token=mock_rt_abc')
+check "refreshed access_token" "access_token" "$T2"
+check "rotated refresh_token"  "refresh_token" "$T2"
+
+echo
+echo "═══ MCP: /ok always 200 ═══"
+OK=$(curl -sS -o /dev/null -w "%{http_code}" "$MOCK/mcp/ok/" -X POST -H 'authorization: Bearer at_ok' -d '{}')
+check "200 ok scenario" "200" "$OK"
+
+echo
+echo "═══ MCP: /401-once flips after first call ═══"
+BEARER="at_test_$(date +%s)"
+C1=$(curl -sS -o /dev/null -w "%{http_code}" "$MOCK/mcp/401-once/" -X POST -H "authorization: Bearer $BEARER" -d '{}')
+check "first call 401" "401" "$C1"
+C2=$(curl -sS -o /dev/null -w "%{http_code}" "$MOCK/mcp/401-once/" -X POST -H "authorization: Bearer $BEARER" -d '{}')
+check "second call 200" "200" "$C2"
+# New bearer gets fresh 401 budget
+NB="at_new_$(date +%s%N)"
+C3=$(curl -sS -o /dev/null -w "%{http_code}" "$MOCK/mcp/401-once/" -X POST -H "authorization: Bearer $NB" -d '{}')
+check "new bearer fresh 401" "401" "$C3"
+
+echo
+echo "═══ MCP: /403-always always 403 ═══"
+F1=$(curl -sS -o /dev/null -w "%{http_code}" "$MOCK/mcp/403-always/" -X POST -H 'authorization: Bearer at_x' -d '{}')
+F2=$(curl -sS -o /dev/null -w "%{http_code}" "$MOCK/mcp/403-always/" -X POST -H 'authorization: Bearer at_x' -d '{}')
+check "first call 403"  "403" "$F1"
+check "second call 403" "403" "$F2"
+
+echo
+echo "═══ MCP: /expire/{ttl} 401s after ttl ═══"
+EXP_BEARER="at_exp_$(date +%s%N)"
+E1=$(curl -sS -o /dev/null -w "%{http_code}" "$MOCK/mcp/expire/1/" -X POST -H "authorization: Bearer $EXP_BEARER" -d '{}')
+check "within ttl 200" "200" "$E1"
+sleep 2
+E2=$(curl -sS -o /dev/null -w "%{http_code}" "$MOCK/mcp/expire/1/" -X POST -H "authorization: Bearer $EXP_BEARER" -d '{}')
+check "after ttl 401"  "401" "$E2"
+
+echo
+echo "═══════════════════════════════════"
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/test/mocks/README.md
+++ b/test/mocks/README.md
@@ -34,25 +34,55 @@ submission).
 
 ## What's NOT implemented (deferred)
 
-### MCP-proxy refresh-token mock server
+Both addressed below — keeping this section for historical context.
 
-Needs a deployed HTTP endpoint that the gateway can reach: returns 401
-once, then 200 after the gateway hits its `/token` endpoint with the
-refresh_token. The interesting test is the D1 CAS race when two RPC
-calls hit `expires_in` simultaneously — needs a controllable mock with
-per-call response programming.
+### Done: mock CF Worker (MCP proxy + OAuth provider)
 
-Realistic implementation: a tiny CF Worker deployed alongside staging
-(e.g. `mock-mcp.staging.openma.dev`). Bookkeeping is per-request state in
-a Durable Object so two concurrent calls can race.
+`test/mocks/mock-server/` — a single CF Worker that serves both MCP and OAuth mock endpoints. Deployed at https://oma-mock-services.hrhrngxy.workers.dev (workers.dev subdomain — no DNS, no auth, public).
 
-### OAuth provider mock servers
+**MCP scenarios** (per-bearer-token state in a Durable Object):
 
-Needs deployed `/authorize` and `/token` endpoints that pretend to be
-Linear / Slack / GitHub. Same deployment shape as the MCP mock.
+| Path | Behavior |
+|------|----------|
+| `/mcp/ok/...` | Always 200 with a valid `tools/list` JSON-RPC response |
+| `/mcp/401-once/...` | First call per bearer → 401 with `WWW-Authenticate`; subsequent calls 200 |
+| `/mcp/403-always/...` | Every call → 403 (tests the 403→refresh trigger added to mcp-proxy) |
+| `/mcp/expire/{ttl_seconds}/...` | Bearer valid for ttl from first use, then 401 |
 
-Both would unlock e2e for publication-first install UI (today only
-exercisable in a browser against the real Slack / Linear app admin UIs).
+A "new" bearer always gets a fresh 401 budget — this is how the mcp-proxy refresh path is exercised: gateway hits `/mcp/401-once/...` with the stale bearer → 401 → gateway hits `/oauth/token` to refresh → retries `/mcp/401-once/...` with the new bearer → 200.
+
+**OAuth endpoints:**
+
+| Path | Behavior |
+|------|----------|
+| `GET /oauth/authorize?redirect_uri=&state=` | 302 to `{redirect_uri}?code=mock_code_<rand>&state=<state>` |
+| `POST /oauth/token` with `grant_type=authorization_code&code=mock_code_*` | 200 with `{access_token, refresh_token, token_type:"Bearer", expires_in}` |
+| `POST /oauth/token` with `grant_type=refresh_token&refresh_token=mock_rt_*` | Same shape; rotates both tokens (matches real Linear/Slack/GitHub) |
+
+**Admin:**
+
+| Path | Behavior |
+|------|----------|
+| `GET /__/state` | Dump bearer→state map per scenario (debug) |
+| `POST /__/reset` | Wipe state (test isolation) |
+
+**Smoke:** `./test/e2e/e2e-mock-services.sh` — 16 assertions, ~3s.
+
+### Wiring through OMA gateway (real refresh-token e2e)
+
+To exercise the full mcp-proxy refresh-token path through OMA against this mock:
+
+1. Create a vault credential with `auth.type=mcp_oauth`, pointing `mcp_server_url` at e.g. `https://oma-mock-services.hrhrngxy.workers.dev/mcp/401-once/...` and `token_endpoint` at `https://oma-mock-services.hrhrngxy.workers.dev/oauth/token`.
+2. Create an agent that references that vault credential as an MCP server.
+3. Create a session, send a user message that should result in the agent calling the MCP tool.
+4. Observe the gateway's `forwardWithRefresh` path: 401 → refresh → 200, all in SSE telemetry.
+
+(Same flow for `/403-always` if you want to verify the 403→refresh trigger we added in this PR.)
+
+### Future improvements
+
+- `/mcp/server-side-event-stream/...` — long-lived SSE responses to test how the gateway handles streaming bodies during refresh.
+- Per-credential bearer expiry programmable via query string instead of path (`?ttl=` overrides the path-embedded TTL).
 
 ## When to use which
 
@@ -62,5 +92,7 @@ exercisable in a browser against the real Slack / Linear app admin UIs).
 | Tool execution (write / bash / multi)    | `e2e-tools.sh`                                           |
 | Memory / vault / cred / files / dup-cred | `e2e-advanced.sh`                                        |
 | Webhook delivery (post-install)          | `e2e-webhooks.sh` ← this directory                       |
-| Publication-first install OAuth callback | Manual browser flow (until OAuth mock lands)             |
-| MCP-proxy refresh-token race             | Manual + careful prod observation (until MCP mock lands) |
+| MCP-proxy 401→refresh / 403→refresh      | `e2e-mock-services.sh` against the mock CF Worker        |
+| OAuth /authorize + /token round-trip     | `e2e-mock-services.sh` against the mock CF Worker        |
+| Publication-first install OAuth callback | Manual browser flow (mock OAuth available — see Wiring)  |
+| Full mcp-proxy refresh-token race via OMA gateway | Wire vault credential at mock + send agent message (see Wiring) |

--- a/test/mocks/mock-server/index.ts
+++ b/test/mocks/mock-server/index.ts
@@ -1,0 +1,306 @@
+/**
+ * mock-services Worker — combines MCP server mock + OAuth provider mock for
+ * e2e testing of paths the real OMA gateway can't reach in CI.
+ *
+ * Endpoints
+ * ─────────
+ *
+ *   POST /oauth/authorize?client_id=...&redirect_uri=...&state=...
+ *     → 302 to {redirect_uri}?code=mock_code_<random>&state=<state>
+ *     The OAuth callback flow used by publication-first install.
+ *
+ *   POST /oauth/token
+ *     Body: grant_type=authorization_code | refresh_token, ...standard fields
+ *     → 200 {access_token, refresh_token, token_type:"Bearer", expires_in}
+ *     Refresh-token grant rotates the refresh_token too (matches real Linear /
+ *     Slack / GitHub behavior).
+ *
+ *   ALL /mcp/{scenario}/{tail...}
+ *     scenario discriminator picks behavior, controllable per request:
+ *     - `ok`         — always 200 with a tiny `tools/list` response
+ *     - `401-once`   — first call per session returns 401 + WWW-Authenticate
+ *                      with `error="invalid_token"`. Subsequent calls 200.
+ *                      "Session" keyed by the bearer token: a new token gets
+ *                      a fresh 401 budget.
+ *     - `403-always` — every call returns 403 (tests the 403→refresh trigger
+ *                      we added to mcp-proxy)
+ *     - `expire/{ttl_seconds}` — bearer is valid for ttl_seconds from first
+ *                      use, then 401 until a new bearer arrives. Lets you
+ *                      script the refresh-token race.
+ *
+ *   GET /__/state — debug: dump the bearer→state map
+ *   POST /__/reset — wipe state (test isolation)
+ *
+ * State per scenario is in a single MockStateDO. Each bearer token is a key;
+ * the value tracks first-seen-at + call counts.
+ */
+
+export interface Env {
+  MOCK_STATE: DurableObjectNamespace;
+}
+
+const ISSUED_CODES = new Set<string>(); // ephemeral; per-worker-instance memory
+
+function bearerOf(req: Request): string | null {
+  const auth = req.headers.get("authorization") ?? "";
+  const m = /^Bearer\s+(.+)$/i.exec(auth);
+  return m ? m[1] : null;
+}
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function randomToken(prefix: string): string {
+  const bytes = new Uint8Array(24);
+  crypto.getRandomValues(bytes);
+  const hex = Array.from(bytes).map((b) => b.toString(16).padStart(2, "0")).join("");
+  return `${prefix}_${hex}`;
+}
+
+export default {
+  async fetch(req: Request, env: Env): Promise<Response> {
+    const url = new URL(req.url);
+    const p = url.pathname;
+
+    // ─── OAuth: /oauth/authorize ──────────────────────────────────────
+    if (p === "/oauth/authorize" || p === "/oauth/authorize/") {
+      const redirectUri = url.searchParams.get("redirect_uri");
+      const state = url.searchParams.get("state") ?? "";
+      if (!redirectUri) return json({ error: "missing redirect_uri" }, 400);
+      const code = randomToken("mock_code");
+      ISSUED_CODES.add(code);
+      const target = new URL(redirectUri);
+      target.searchParams.set("code", code);
+      target.searchParams.set("state", state);
+      return Response.redirect(target.toString(), 302);
+    }
+
+    // ─── OAuth: /oauth/token ──────────────────────────────────────────
+    if (p === "/oauth/token") {
+      const body = await req.formData().catch(() => null);
+      const params = body
+        ? Object.fromEntries(body.entries())
+        : (await req.json().catch(() => ({}))) as Record<string, string>;
+      const grant = String(params["grant_type"] ?? "");
+
+      if (grant === "authorization_code") {
+        const code = String(params["code"] ?? "");
+        // accept the issued code or any "mock_code_*" so the test can plug a
+        // fixed value without round-tripping through /authorize first
+        if (!code.startsWith("mock_code")) {
+          return json({ error: "invalid_grant", error_description: "unknown code" }, 400);
+        }
+        ISSUED_CODES.delete(code);
+        return json({
+          access_token: randomToken("mock_at"),
+          refresh_token: randomToken("mock_rt"),
+          token_type: "Bearer",
+          expires_in: 3600,
+          scope: String(params["scope"] ?? "read write"),
+        });
+      }
+
+      if (grant === "refresh_token") {
+        const rt = String(params["refresh_token"] ?? "");
+        if (!rt.startsWith("mock_rt")) {
+          return json({ error: "invalid_grant", error_description: "unknown refresh_token" }, 400);
+        }
+        return json({
+          access_token: randomToken("mock_at"),
+          refresh_token: randomToken("mock_rt"),
+          token_type: "Bearer",
+          expires_in: 3600,
+        });
+      }
+
+      return json({ error: "unsupported_grant_type", grant_type: grant }, 400);
+    }
+
+    // ─── MCP scenarios: /mcp/{scenario}/{tail} ────────────────────────
+    if (p.startsWith("/mcp/")) {
+      const parts = p.slice("/mcp/".length).split("/");
+      const scenario = parts.shift() ?? "";
+      const tail = parts.join("/");
+      const dispatchUrl = new URL(`/dispatch/${tail}`, url.origin).toString();
+      const stub = await env.MOCK_STATE.get(env.MOCK_STATE.idFromName(scenario)).fetch(
+        dispatchUrl,
+        {
+          method: req.method,
+          headers: req.headers,
+          body: req.method === "GET" || req.method === "HEAD" ? null : await req.text(),
+        },
+      );
+      return stub;
+    }
+
+    // ─── State inspectors ─────────────────────────────────────────────
+    if (p === "/__/state") {
+      // Aggregate across known scenario names (we just look at the well-known ones)
+      const scenarios = ["ok", "401-once", "403-always", "expire"];
+      const out: Record<string, unknown> = {};
+      for (const s of scenarios) {
+        const r = await env.MOCK_STATE.get(env.MOCK_STATE.idFromName(s))
+          .fetch(new URL("/state", url.origin).toString());
+        out[s] = await r.json();
+      }
+      return json(out);
+    }
+    if (p === "/__/reset") {
+      const scenarios = ["ok", "401-once", "403-always", "expire"];
+      for (const s of scenarios) {
+        await env.MOCK_STATE.get(env.MOCK_STATE.idFromName(s))
+          .fetch(new URL("/reset", url.origin).toString(), { method: "POST" });
+      }
+      return json({ ok: true });
+    }
+
+    // ─── Root: a short README ────────────────────────────────────────
+    if (p === "/" || p === "/health") {
+      return json({
+        service: "oma-mock-services",
+        endpoints: {
+          oauth: ["GET /oauth/authorize", "POST /oauth/token"],
+          mcp: [
+            "ALL /mcp/ok/...",
+            "ALL /mcp/401-once/...",
+            "ALL /mcp/403-always/...",
+            "ALL /mcp/expire/{ttl_seconds}/...",
+          ],
+          admin: ["GET /__/state", "POST /__/reset"],
+        },
+      });
+    }
+
+    return new Response("not found", { status: 404 });
+  },
+};
+
+// ─── Durable Object: per-scenario per-bearer state ───────────────────
+
+export class MockStateDO {
+  private state: DurableObjectState;
+  // bearer → { firstSeenMs, callCount, scenarioMeta }
+  private bearers = new Map<string, { firstSeenMs: number; callCount: number }>();
+  // scenario name comes from DO id name (set by caller via idFromName)
+  private scenario: string;
+
+  constructor(state: DurableObjectState) {
+    this.state = state;
+    this.scenario = state.id.name ?? "ok";
+  }
+
+  async fetch(req: Request): Promise<Response> {
+    const url = new URL(req.url);
+
+    if (url.pathname === "/state") {
+      return Response.json({
+        scenario: this.scenario,
+        bearers: Array.from(this.bearers.entries()).map(([t, s]) => ({
+          token: `${t.slice(0, 12)}…`,
+          firstSeenMs: s.firstSeenMs,
+          callCount: s.callCount,
+        })),
+      });
+    }
+    if (url.pathname === "/reset" && req.method === "POST") {
+      this.bearers.clear();
+      return Response.json({ ok: true });
+    }
+    if (url.pathname !== "/dispatch" && !url.pathname.startsWith("/dispatch/")) {
+      return new Response("not found", { status: 404 });
+    }
+
+    const bearer = bearerOf(req) ?? "<no-bearer>";
+    let entry = this.bearers.get(bearer);
+    if (!entry) {
+      entry = { firstSeenMs: Date.now(), callCount: 0 };
+      this.bearers.set(bearer, entry);
+    }
+    entry.callCount += 1;
+
+    switch (this.scenario) {
+      case "ok":
+        return mcpToolsList();
+
+      case "401-once":
+        if (entry.callCount === 1) {
+          return new Response(
+            JSON.stringify({ error: "invalid_token" }),
+            {
+              status: 401,
+              headers: {
+                "content-type": "application/json",
+                "www-authenticate": 'Bearer error="invalid_token"',
+              },
+            },
+          );
+        }
+        return mcpToolsList();
+
+      case "403-always":
+        return new Response(
+          JSON.stringify({ error: "forbidden" }),
+          {
+            status: 403,
+            headers: { "content-type": "application/json" },
+          },
+        );
+
+      case "expire": {
+        // path embeds /mcp/expire/{ttl}/... — read ttl from the first
+        // segment of /dispatch/{ttl}/...
+        const tail = url.pathname.slice("/dispatch/".length);
+        const ttlMatch = /^(\d+)/.exec(tail);
+        const ttl = ttlMatch ? Number(ttlMatch[1]) : 5;
+        const ageMs = Date.now() - entry.firstSeenMs;
+        if (ageMs > ttl * 1000) {
+          return new Response(
+            JSON.stringify({ error: "invalid_token", error_description: "expired" }),
+            {
+              status: 401,
+              headers: {
+                "content-type": "application/json",
+                "www-authenticate": 'Bearer error="invalid_token"',
+              },
+            },
+          );
+        }
+        return mcpToolsList();
+      }
+
+      default:
+        return new Response("unknown scenario", { status: 404 });
+    }
+  }
+}
+
+function mcpToolsList(): Response {
+  // Minimal MCP `tools/list` JSON-RPC response so a real MCP client treats
+  // this as a valid server. The agent's MCP transport doesn't care about the
+  // actual tools for these tests — what we're verifying is the gateway's
+  // 401/403/expiry handling and refresh-token round-trip.
+  return new Response(
+    JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      result: {
+        tools: [
+          {
+            name: "mock_echo",
+            description: "Returns its input verbatim",
+            inputSchema: {
+              type: "object",
+              properties: { message: { type: "string" } },
+              required: ["message"],
+            },
+          },
+        ],
+      },
+    }),
+    { status: 200, headers: { "content-type": "application/json" } },
+  );
+}

--- a/test/mocks/mock-server/package.json
+++ b/test/mocks/mock-server/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "oma-mock-services",
+  "private": true,
+  "scripts": {
+    "deploy": "wrangler deploy",
+    "tail": "wrangler tail"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "*",
+    "wrangler": "*"
+  }
+}

--- a/test/mocks/mock-server/wrangler.jsonc
+++ b/test/mocks/mock-server/wrangler.jsonc
@@ -1,0 +1,15 @@
+{
+  "name": "oma-mock-services",
+  "main": "index.ts",
+  "compatibility_date": "2025-09-01",
+  "compatibility_flags": ["nodejs_compat"],
+  "workers_dev": true,
+  "durable_objects": {
+    "bindings": [
+      { "name": "MOCK_STATE", "class_name": "MockStateDO" }
+    ]
+  },
+  "migrations": [
+    { "tag": "v1", "new_sqlite_classes": ["MockStateDO"] }
+  ]
+}


### PR DESCRIPTION
## What

Second mock layer alongside the webhook generators (#98). Single CF Worker deployed to workers.dev, serves both:

### MCP proxy scenarios (per-bearer state in a DO)

| Path | Behavior |
|------|----------|
| `/mcp/ok/...` | Always 200 with valid `tools/list` JSON-RPC response |
| `/mcp/401-once/...` | First call per bearer → 401 + `WWW-Authenticate`; subsequent calls 200. New bearer = fresh 401 budget — this is how the gateway's `forwardWithRefresh` path gets exercised end-to-end |
| `/mcp/403-always/...` | Every call 403 — verifies the **403→refresh trigger** added to mcp-proxy in this PR |
| `/mcp/expire/{ttl}/...` | Bearer valid for ttl seconds from first use, then 401. Scripts the refresh-token race |

### OAuth provider mock

| Path | Behavior |
|------|----------|
| `GET /oauth/authorize?redirect_uri=&state=` | 302 → `{redirect_uri}?code=mock_code_<rand>&state=<state>` |
| `POST /oauth/token` (`grant_type=authorization_code`) | Issues `{access_token, refresh_token, Bearer, expires_in}` |
| `POST /oauth/token` (`grant_type=refresh_token`) | Rotates both tokens — matches real Linear/Slack/GitHub behavior |

### Admin

| `GET /__/state` | Dump per-scenario bearer→state map (debug) |
| `POST /__/reset` | Wipe state (test isolation) |

## Wiring through OMA gateway

Documented in `test/mocks/README.md`. Three steps to exercise the full refresh-token e2e against this mock:
1. Create a vault credential pointing `mcp_server_url` at `https://oma-mock-services.hrhrngxy.workers.dev/mcp/401-once/...` and `token_endpoint` at `.../oauth/token`
2. Create an agent that references the credential as MCP server
3. Send a user message — observe `forwardWithRefresh`: 401 → refresh → 200, all in SSE telemetry

## Test plan

- [x] `./test/e2e/e2e-mock-services.sh` against deployed mock → 16/16 ✓
- [x] OAuth authorize → 302 with code+state
- [x] OAuth token authorization_code → bearer + refresh_token
- [x] OAuth token refresh_token → rotated tokens
- [x] MCP 401-once flips after first call; new bearer fresh 401
- [x] MCP 403-always always 403
- [x] MCP expire 200 within ttl → 401 after ttl
- [ ] Full e2e through OMA gateway (manual — see README "Wiring")

Deployed instance: https://oma-mock-services.hrhrngxy.workers.dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)