### PR TITLE
fix: local-runtime sessions use SANDBOX service binding + tenant-key trace

### DIFF
--- a/apps/main/src/lib/cf-session-router.ts
+++ b/apps/main/src/lib/cf-session-router.ts
@@ -365,13 +365,15 @@ export class CfSessionRouter implements SessionRouter {
 
   // ── helpers ─────────────────────────────────────────────────────────
 
-  /** Resolve the sandbox lane for an environment. Local-runtime sessions
-   *  go through the SESSION_DO direct fetcher; cloud sessions go through
-   *  the SANDBOX_sandbox_default service binding. Mirrors the legacy
-   *  getSandboxBinding in apps/main/src/routes/sessions.ts. */
-  private async bindingFor(environmentId: string): Promise<Fetcher | null> {
+  /** Resolve the sandbox lane for an environment. Both local-runtime
+   *  and cloud sessions reach SessionDO via the SANDBOX_sandbox_default
+   *  service binding (which forwards to the agent worker that hosts
+   *  SessionDO). The doFallbackFetcher path is only used by the
+   *  combined-worker test mode where SESSION_DO is bound locally.
+   *  Mirrors the legacy getSandboxBinding in apps/main/src/routes/
+   *  sessions.ts. */
+  private async bindingFor(_environmentId: string): Promise<Fetcher | null> {
     const { env } = this.deps;
-    if (environmentId === LOCAL_RUNTIME_ENV_ID) return doFallbackFetcher(env);
     const svc = (env as unknown as Record<string, unknown>)["SANDBOX_sandbox_default"] as Fetcher | undefined;
     if (svc) return svc;
     return doFallbackFetcher(env);

--- a/packages/cli/src/bridge/lib/session-manager.ts
+++ b/packages/cli/src/bridge/lib/session-manager.ts
@@ -234,6 +234,13 @@ export class SessionManager {
       });
       return;
     }
+    // Diagnostic line — helps operators trace per-session tenant routing
+    // in multi-tenant setups. Tenant id is logged for debuggability; the
+    // key plaintext is NEVER logged (only its presence is implicit from
+    // not erroring out above).
+    process.stderr.write(
+      `  → tenant-key selected sid=${p.session_id.slice(0, 8)} tenant=${tenantId.slice(0, 14)}\n`,
+    );
     // Idempotent: if we already have this session, just re-ack ready.
     const existing = this.#sessions.get(p.session_id);
     if (existing) {


### PR DESCRIPTION
Follow-up to #103 — two surgical fixes uncovered during end-to-end multi-tenant verification on staging.

## 1. cf-session-router routing for LOCAL_RUNTIME_ENV_ID

`bindingFor(LOCAL_RUNTIME_ENV_ID)` short-circuited to `doFallbackFetcher`, which requires `env.SESSION_DO`. The main worker never binds `SESSION_DO` in prod or staging — SessionDO lives in the `sandbox-default` agent worker and is reached via the `SANDBOX_sandbox_default` service binding. The short-circuit meant every `/v1/sessions/<sid>/events` call against a local-runtime session returned 503 "sandbox binding unavailable".

Fix: drop the special case. Both local and cloud sessions now go through `SANDBOX_sandbox_default`; the agent worker behind it dispatches either way (cloud → Sandbox class, local → SessionDO direct). `doFallbackFetcher` stays as the combined-worker test-mode fallback for vitest.

Bug pre-dates the multi-tenant work (commit `0837af1e`, May 13) but local-runtime sessions were apparently never exercised through this code path against a real deployment until I tried to verify the multi-tenant key selection.

## 2. SessionManager tenant-key trace log

Adds a one-line stderr log when `SessionManager.start()` resolves the per-tenant `oma_*` key for an incoming `session.start`:

```
→ tenant-key selected sid=sess-u4x1 tenant=tn_89205e7eb04
```

Tenant id is logged for operational debuggability — the key plaintext is **never** logged. Used during staging verification to prove distinct tenants resolve to distinct keys.

## Verification on staging

Two parallel sessions from different tenants demonstrably select distinct keys:

```
session.start sid=sess-u4x agent=claude-acp
  → tenant-key selected sid=sess-u4x tenant=tn_89205e7eb04   # tenant 0 key
session.start sid=sess-k88 agent=claude-acp
  → tenant-key selected sid=sess-k88 tenant=tn_L3JvpX0U0u0   # tenant 1 key
```

End-to-end chain confirmed: client API key auth → SessionDO captures tenant_id → harness opens WS to RuntimeRoom with `x-harness-tenant` → RuntimeRoom forwards `session.start {tenant_id}` to daemon → SessionManager `#tenantKeys.get(tenant_id)` resolves the right key → ACP child spawned with per-tenant `oma_*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)