### PR TITLE
feat(blog): rename slugs anthropic-managed-agents → claude-managed-agents

### DIFF
--- a/apps/web/src/content/blog/architecture-durable-objects-r2-brain-sandbox-split.md
+++ b/apps/web/src/content/blog/architecture-durable-objects-r2-brain-sandbox-split.md
@@ -307,12 +307,12 @@ are deliberate:
   cheaper, supports object versioning, and doesn't count against DO
   storage quotas.
 
-If you'd like the side-by-side comparison with Anthropic's hosted
-Managed Agents, the [technical
-comparison](/blog/anthropic-managed-agents-vs-open-managed-agents/)
+If you'd like the side-by-side comparison with the hosted
+Claude Managed Agents, the [technical
+comparison](/blog/claude-managed-agents-vs-open-managed-agents/)
 post goes through the architectural differences in detail. If you want
 to migrate from the closed product, [the migration
-guide](/blog/migrate-from-anthropic-managed-agents/) walks through the
+guide](/blog/migrate-from-claude-managed-agents/) walks through the
 practical steps.
 
 ## Try it

--- a/apps/web/src/content/blog/claude-managed-agents-vs-open-managed-agents.md
+++ b/apps/web/src/content/blog/claude-managed-agents-vs-open-managed-agents.md
@@ -1,9 +1,10 @@
 ---
-title: "Anthropic Managed Agents vs Open Managed Agents: A Technical Comparison"
-description: "Side-by-side technical comparison of Anthropic's Managed Agents and the open-source Open Managed Agents project. API surface, runtime model, sandbox, billing, and where each one actually fits."
+title: "Claude Managed Agents vs Open Managed Agents: A Technical Comparison"
+description: "Side-by-side technical comparison of Claude Managed Agents and the open-source Open Managed Agents project. API surface, runtime model, sandbox, billing, and where each one actually fits."
 publishedAt: 2026-05-09
+updatedAt: 2026-05-26
 author: openma
-tags: ["comparison", "anthropic", "managed-agents", "architecture"]
+tags: ["comparison", "claude", "managed-agents", "architecture"]
 ---
 
 If you're shopping for an agent platform that handles the boring parts —
@@ -56,7 +57,7 @@ implementation aims to ship it in the same release window.
 
 This is the biggest structural difference.
 
-**Anthropic's Managed Agents** owns the agent loop end-to-end. You define
+**Claude Managed Agents** owns the agent loop end-to-end. You define
 an agent, hit `/sessions`, send a message, and watch events stream back.
 The decisions inside the loop — how to engineer the context window, when
 to trigger prompt caching, when to compact, how to retry a failed tool
@@ -96,7 +97,7 @@ matters.
 Both platforms run model-generated code in an isolated sandbox. The
 implementations differ, and so do the trade-offs.
 
-**Anthropic's Managed Agents** runs sandboxes on Anthropic-managed
+**Claude Managed Agents** runs sandboxes on Anthropic-managed
 infrastructure. Implementation details aren't documented; effectively
 it's a black box with quotas.
 
@@ -134,7 +135,7 @@ can rebuild from an event log can pick up where another left off.
 
 ## Storage and data residency
 
-**Anthropic's Managed Agents** stores session data in Anthropic's
+**Claude Managed Agents** stores session data in Anthropic's
 chosen regions. Region selection is limited; data residency for
 regulated industries is a coordination problem.
 
@@ -153,7 +154,7 @@ the self-host story is the answer.
 
 ## LLM key handling — BYOK
 
-**Anthropic's Managed Agents** is locked to Anthropic models. Your bill
+**Claude Managed Agents** is locked to Anthropic models. Your bill
 is one combined line item: tokens + platform fees.
 
 **Open Managed Agents** is BYOK by default — you supply the LLM key and
@@ -175,7 +176,7 @@ This means two things:
 
 ## Pricing
 
-| | Open Managed Agents (self-host) | Open Managed Agents (hosted) | Anthropic Managed Agents |
+| | Open Managed Agents (self-host) | Open Managed Agents (hosted) | Claude Managed Agents |
 |---|---|---|---|
 | Platform fee | $0 | Subscription, $0–$100/mo | Bundled in token markup |
 | LLM tokens | You pay provider directly | You pay provider directly (BYOK) | Anthropic-rated, no BYOK |
@@ -204,7 +205,7 @@ private workspaces.
 
 ## When each one fits
 
-**Pick Anthropic's Managed Agents when:**
+**Pick Claude Managed Agents when:**
 
 - You want zero infrastructure decisions.
 - Anthropic's pricing model fits your usage shape.

--- a/apps/web/src/content/blog/migrate-from-claude-managed-agents.md
+++ b/apps/web/src/content/blog/migrate-from-claude-managed-agents.md
@@ -1,12 +1,13 @@
 ---
-title: "Migrating from Anthropic Managed Agents to Open Managed Agents"
+title: "Migrating from Claude Managed Agents to Open Managed Agents"
 description: "Practical migration guide. What stays the same, what changes, and the exact steps to switch your client code, sessions, vaults, and integrations to the open-source platform."
 publishedAt: 2026-05-12
+updatedAt: 2026-05-26
 author: openma
-tags: ["migration", "anthropic", "managed-agents", "guide"]
+tags: ["migration", "claude", "managed-agents", "guide"]
 ---
 
-If you're already running on Anthropic's Managed Agents and considering
+If you're already running on Claude Managed Agents and considering
 the move to the open-source equivalent, this is the migration guide.
 The good news first: the API surface is identical, so your client code
 is the cheapest part of the migration. The work is mostly in
@@ -285,9 +286,9 @@ rewriting clients.
   `docker compose up`, not a rewrite.
 
 See [the side-by-side technical
-comparison](/blog/anthropic-managed-agents-vs-open-managed-agents/) for
+comparison](/blog/claude-managed-agents-vs-open-managed-agents/) for
 the architectural differences, and the [open-source alternatives
-landscape](/blog/open-source-alternatives-to-anthropic-managed-agents-2026/)
+landscape](/blog/open-source-alternatives-to-claude-managed-agents-2026/)
 for context on where this sits in the broader space.
 
 ## Get started

--- a/apps/web/src/content/blog/open-source-alternatives-to-claude-managed-agents-2026.md
+++ b/apps/web/src/content/blog/open-source-alternatives-to-claude-managed-agents-2026.md
@@ -1,12 +1,13 @@
 ---
-title: "Open Source Alternatives to Anthropic Managed Agents in 2026"
-description: "What's actually shipping in 2026 if you want an open-source alternative to Anthropic's Managed Agents. Honest comparison: Open Managed Agents, LangGraph, AutoGen, CrewAI, plus what's still missing."
+title: "Open Source Alternatives to Claude Managed Agents in 2026"
+description: "What's actually shipping in 2026 if you want an open-source alternative to Claude Managed Agents. Honest comparison: Open Managed Agents, LangGraph, AutoGen, CrewAI, plus what's still missing."
 publishedAt: 2026-05-10
+updatedAt: 2026-05-26
 author: openma
-tags: ["alternatives", "open-source", "comparison", "anthropic"]
+tags: ["alternatives", "open-source", "comparison", "claude"]
 ---
 
-Anthropic's Managed Agents is the cleanest hosted-agent product on the
+Claude Managed Agents is the cleanest hosted-agent product on the
 market right now. The trade-off is the obvious one: closed source,
 hosted-only, no BYOK, no self-host story, no way to inspect what the
 agent loop is actually doing on a hard turn.
@@ -63,7 +64,7 @@ custom context engineering without leaving the platform.
 What's still in flight: detection coverage for some less-common LLM
 providers, the Postgres adapter is newer than the Cloudflare adapter
 and has fewer hours in production. See [the technical
-comparison](/blog/anthropic-managed-agents-vs-open-managed-agents/) for
+comparison](/blog/claude-managed-agents-vs-open-managed-agents/) for
 the side-by-side.
 
 ## LangGraph (LangChain)
@@ -178,12 +179,12 @@ Ask three questions:
 
 1. **Do you need a managed platform, or do you want to build one?**
    Frameworks (LangGraph, AutoGen, CrewAI) require you to assemble
-   the platform. Platforms (Open Managed Agents, hosted Anthropic)
-   give you one.
+   the platform. Platforms (Open Managed Agents, hosted Claude Managed
+   Agents) give you one.
 
 2. **Is BYOK + cost separation important?** All open-source options
    support BYOK by definition (you're the one calling the model). The
-   hosted Anthropic offering doesn't.
+   hosted Claude Managed Agents offering doesn't.
 
 3. **Do you need self-host, or is a hosted runtime acceptable?** Open
    Managed Agents and the framework projects support self-host. Some
@@ -191,17 +192,17 @@ Ask three questions:
    — read the license carefully.
 
 If your answer is "I want a self-hostable, drop-in compatible
-alternative to Anthropic's Managed Agents," there's currently one
+alternative to Claude Managed Agents," there's currently one
 project that fits all three constraints. If your answer is "I want a
 framework I'll wrap myself," LangGraph and AutoGen are mature picks.
 
 ## Quick comparison
 
-| | Open Managed Agents | LangGraph | AutoGen | CrewAI | Anthropic Managed Agents |
+| | Open Managed Agents | LangGraph | AutoGen | CrewAI | Claude Managed Agents |
 |---|---|---|---|---|---|
 | Open source | ✓ Apache 2.0 | ✓ MIT | ✓ CC-BY | ✓ MIT | ✗ |
 | Managed-platform shape | ✓ | △ runtime is paid | ✗ framework | ✗ framework | ✓ |
-| Drop-in compat with Anthropic API | ✓ | ✗ | ✗ | ✗ | ✓ (it _is_ the API) |
+| Drop-in compat with Claude Managed Agents API | ✓ | ✗ | ✗ | ✗ | ✓ (it _is_ the API) |
 | Self-host (no license fee) | ✓ | △ paid tier | ✓ DIY | ✓ DIY | ✗ |
 | BYOK | ✓ | ✓ | ✓ | ✓ | ✗ |
 | First-party workspace integrations | ✓ | ✗ | ✗ | ✗ | ✗ |

--- a/apps/web/src/content/blog/self-host-agent-platform-cloudflare-workers.md
+++ b/apps/web/src/content/blog/self-host-agent-platform-cloudflare-workers.md
@@ -255,7 +255,7 @@ matters.
 If you can't be on Cloudflare — data residency, compliance, existing
 AWS commitment — there's a Postgres + Node deployment that uses the
 same harness, same API, same Console. See
-[the migration guide](/blog/migrate-from-anthropic-managed-agents/)
+[the migration guide](/blog/migrate-from-claude-managed-agents/)
 for how that fits together.
 
 ## Try the hosted version first

--- a/apps/web/src/pages/index.astro
+++ b/apps/web/src/pages/index.astro
@@ -156,7 +156,7 @@ curl localhost:8787/v1/agents -d '&#123;"name":"hello", \
       the agent loop; here you can write your own. We ship a sensible default
       harness, and you swap in custom context engineering, caching, compaction,
       or tool-delivery logic without touching the platform. Read more in
-      <a href="/blog/anthropic-managed-agents-vs-open-managed-agents/">the technical comparison</a>.
+      <a href="/blog/claude-managed-agents-vs-open-managed-agents/">the technical comparison</a>.
     </p>
   </section>
 
@@ -262,7 +262,7 @@ curl localhost:8787/v1/agents -d '&#123;"name":"hello", \
       see the
       <a href="https://github.com/open-ma/open-managed-agents">repo</a> for the
       current matrix, or
-      <a href="/blog/migrate-from-anthropic-managed-agents/">the migration
+      <a href="/blog/migrate-from-claude-managed-agents/">the migration
       guide</a> for the practical steps.
     </p>
   </section>


### PR DESCRIPTION
## Summary

Final piece of the AMA → CMA rebrand started in #108. Slugs deferred there because rename = URL change; user confirmed no existing backlinks to preserve, so going ahead without redirects.

### Renames (`git mv` preserves history)

- `anthropic-managed-agents-vs-open-managed-agents.md` → `claude-managed-agents-vs-open-managed-agents.md`
- `migrate-from-anthropic-managed-agents.md` → `migrate-from-claude-managed-agents.md`
- `open-source-alternatives-to-anthropic-managed-agents-2026.md` → `open-source-alternatives-to-claude-managed-agents-2026.md`

### Body + frontmatter sweep

Each renamed file: `replace_all` of "Anthropic's Managed Agents" + "Anthropic Managed Agents" → "Claude Managed Agents". Titles + descriptions rewritten with the new anchor. Tag `"anthropic"` → `"claude"`. `updatedAt: 2026-05-26` added.

### Internal cross-references fixed

- `apps/web/src/pages/index.astro` — 2 links into blog
- `apps/web/src/content/blog/self-host-agent-platform-cloudflare-workers.md` — 1 link
- `apps/web/src/content/blog/architecture-durable-objects-r2-brain-sandbox-split.md` — 2 links
- Cross-references within the 3 renamed posts also updated

### What I did NOT change

- "Anthropic" by itself as a company name in provider lists (`Anthropic, OpenAI, OpenRouter`), env var names (`ANTHROPIC_API_KEY`), or literal SDK package names (`@anthropic-ai/sdk`). Those are factually about the company / SDK package, not the product.

### Sitemap

Regenerated with the new URLs:

```
https://openma.dev/blog/claude-managed-agents-vs-open-managed-agents/
https://openma.dev/blog/migrate-from-claude-managed-agents/
https://openma.dev/blog/open-source-alternatives-to-claude-managed-agents-2026/
```

Old URLs will 404. No redirects added (none needed — no backlinks).

## Test plan

- [x] `grep -rE "[Aa]nthropic.s.\s+[Mm]anaged\s+[Aa]gents" apps/web/src apps/docs/src README.md README.zh-CN.md` returns no hits
- [x] `grep -rn "anthropic-managed-agents" apps/web/src apps/docs/src README.md README.zh-CN.md` returns no hits
- [x] `pnpm --filter @open-managed-agents/web build` — 9 pages clean
- [x] `apps/web/dist/blog/` contains the 3 new slug directories, none of the old ones
- [x] `apps/web/dist/sitemap-0.xml` contains the new URLs, not the old ones
- [ ] After deploy: `https://openma.dev/blog/claude-managed-agents-vs-open-managed-agents/` returns 200
- [ ] After deploy: `https://openma.dev/blog/anthropic-managed-agents-vs-open-managed-agents/` returns 404 (expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)