### PR TITLE
revert(web,docs): drop self-managed CF Web Analytics beacon (zone-mode already injects)

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -11,11 +11,6 @@ import mdx from '@astrojs/mdx';
 const FONT_HREF =
   'https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700&family=Source+Serif+4:wght@500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap';
 
-// Cloudflare Web Analytics beacon. Token comes from PUBLIC_CF_WA_TOKEN
-// build env (deploy CI / wrangler overlay). Unset in local dev → no tag,
-// no localhost beacon noise.
-const CF_WA_TOKEN = process.env.PUBLIC_CF_WA_TOKEN;
-
 export default defineConfig({
   site: 'https://docs.openma.dev',
   integrations: [
@@ -54,18 +49,6 @@ export default defineConfig({
           tag: 'noscript',
           content: `<link rel="stylesheet" href="${FONT_HREF}">`,
         },
-        ...(CF_WA_TOKEN
-          ? [
-              {
-                tag: 'script',
-                attrs: {
-                  defer: true,
-                  src: 'https://static.cloudflareinsights.com/beacon.min.js',
-                  'data-cf-beacon': `{"token": "${CF_WA_TOKEN}"}`,
-                },
-              },
-            ]
-          : []),
       ],
       social: [
         {

--- a/apps/web/src/layouts/Base.astro
+++ b/apps/web/src/layouts/Base.astro
@@ -152,18 +152,6 @@ const allSchemas = [organizationSchema(), websiteSchema(), ...schemas];
     {allSchemas.map((schema) => (
       <script type="application/ld+json" set:html={JSON.stringify(schema)} />
     ))}
-
-    <!-- Cloudflare Web Analytics. Beacon token comes from PUBLIC_CF_WA_TOKEN
-         build env (set in deploy CI / wrangler overlay). When the env is
-         unset (e.g. local dev) the tag is omitted so we don't spam the
-         beacon with localhost noise. -->
-    {import.meta.env.PUBLIC_CF_WA_TOKEN && (
-      <script
-        defer
-        src="https://static.cloudflareinsights.com/beacon.min.js"
-        data-cf-beacon={`{"token": "${import.meta.env.PUBLIC_CF_WA_TOKEN}"}`}
-      />
-    )}
   </head>
   <body class="bg-bg text-fg">
     <!-- Skip-to-content for keyboard users. sr-only by default, becomes


### PR DESCRIPTION
## Summary

[PR #108](https://github.com/open-ma/open-managed-agents/pull/108) added a build-time-injected CF Web Analytics beacon gated on \`PUBLIC_CF_WA_TOKEN\`. Diagnostic on the live sites confirms Cloudflare's **zone-level Auto Inject is already injecting the beacon on both openma.dev and docs.openma.dev** —

\`\`\`
$ curl -sLA 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 ... Chrome/120 ...' \
    --compressed https://openma.dev/ | grep -c 'static.cloudflareinsights.com'
1
$ curl -sLA 'Mozilla/5.0 ... Chrome/120 ...' --compressed https://docs.openma.dev/ | grep -c 'static.cloudflareinsights.com'
1
\`\`\`

CF filters bot UAs out of the auto-inject pipeline, which is why earlier curl tests with default \`curl/X.Y.Z\` UA came back empty and led me to wrongly conclude zone-mode wasn't working. With browser headers the beacon is there. Both sites share the same auto-injected token (\`98888bdd...\`), so data already lands in the openma.dev Web Analytics dashboard.

Keeping the build-time injection would either duplicate the \`<script>\` (two beacons per page, two dashboards) or compete with zone-mode for the inject point. Cleaner to remove.

## Removes

- \`apps/web/src/layouts/Base.astro\` — the \`PUBLIC_CF_WA_TOKEN\`-gated beacon block
- \`apps/docs/astro.config.mjs\` — the \`CF_WA_TOKEN\` const and the conditional \`head[]\` entry

## Keeps

- All SEO fixes from #108 (H1 keyword wrap, docs browser title, etc.) — unaffected.

## Paired hosted PR

[openma-hosted#TBD] removes the matching \`PUBLIC_CF_WA_TOKEN\` env wiring from \`deploy.yml\` + \`deploy-docs.yml\`. Merge in either order; both are independent no-ops once auto-inject covers both sites.

## Test plan

- [x] \`pnpm --filter open-managed-agents-docs build\` — clean
- [x] \`pnpm --filter @open-managed-agents/web build\` — clean
- [ ] After deploy: \`view-source:openma.dev\` shows exactly **one** beacon \`<script>\` (the zone-mode one, token \`98888bdd...\`), not two
- [ ] Same on docs.openma.dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)