### PR TITLE
fix(web): drop FOIT body-opacity gate that blocked Lighthouse + Googlebot

### DIFF
--- a/apps/web/src/layouts/Base.astro
+++ b/apps/web/src/layouts/Base.astro
@@ -86,24 +86,6 @@ const allSchemas = [organizationSchema(), websiteSchema(), ...schemas];
       }
     </script>
 
-    <!-- Font-readiness gate. Brand fonts arrive ~200-500ms after first
-         paint; without this the page renders in system-ui, then visibly
-         swaps to DM Sans / Source Serif 4 ("FOUT"). Hide body via CSS
-         until document.fonts.ready resolves, then fade in. 1500ms hard
-         timeout covers font-load failure (offline, blocked CDN). -->
-    <script is:inline>
-      const FONT_TIMEOUT_MS = 1500;
-      const reveal = () => document.documentElement.classList.add("fonts-loaded");
-      if ("fonts" in document) {
-        Promise.race([
-          document.fonts.ready,
-          new Promise((r) => setTimeout(r, FONT_TIMEOUT_MS)),
-        ]).then(reveal);
-      } else {
-        reveal();
-      }
-    </script>
-
     <!-- Fonts: same set Console uses, so cross-domain feels consistent.
          Trimmed to weights actually used (no italics, no opsz axis): Source
          Serif 4 needs 400/600/700, DM Sans needs 400/500/600, JetBrains Mono

--- a/apps/web/src/styles/global.css
+++ b/apps/web/src/styles/global.css
@@ -109,20 +109,6 @@ html {
   box-shadow: 0 8px 24px -10px rgba(0, 0, 0, 0.6);
 }
 
-/* Hide body until brand fonts are ready. Eliminates the FOUT swap from
-   system-ui → DM Sans / Source Serif 4. Reveal class is added by the
-   inline script in Base.astro head (with a 1500ms safety timeout). */
-html:not(.fonts-loaded) body {
-  opacity: 0;
-}
-body {
-  opacity: 1;
-  transition: opacity 150ms ease-out;
-}
-@media (prefers-reduced-motion: reduce) {
-  body { transition: none; }
-}
-
 /* Anchor defaults — color is `inherit` by default so nav/breadcrumb/
    footer links pick up the surrounding text color instead of being
    loud-red everywhere. The body-link coral is opt-in via the prose


### PR DESCRIPTION
## The bug

`apps/web/src/styles/global.css` had `html:not(.fonts-loaded) body { opacity: 0 }`, with `Base.astro` adding the `fonts-loaded` class via `document.fonts.ready` + 1500ms fallback timer. The intent was FOIT — hide body until brand fonts swap in so visitors don't see a system-ui → DM Sans visible swap.

## Why it's actively bad in prod

| Audience | What they get with the gate |
|---|---|
| Headless Chrome (Lighthouse, Googlebot) | `document.fonts.ready` is slow / never resolves → 1.5s blank body → Lighthouse fails with `NO_FCP`, page is uncrawlable from an audit perspective |
| **Google PageSpeed Insights** (same engine as Lighthouse) | Same failure → **GSC Core Web Vitals stays empty / shows artificially-bad LCP**, which is a ranking factor |
| Real first-time users | 1.5s of **black screen** instead of the ~50ms FOUT swap this rule was meant to hide. Worse perceived perf than the problem it 'solved'. |

Lighthouse `NO_FCP` was the discoverability symptom — diagnosed by trying to baseline both sites and getting:

```
docs.openma.dev:  performance 100  (no opacity gate, no problem)
openma.dev:       Runtime error encountered: The page did not paint any content. (NO_FCP)
```

The Google Fonts URL already has `display=swap`, which is the industry-standard mechanism for this. Swap is ~50ms and imperceptible at normal connection speeds. The CSS opacity-gate was actively defeating `display=swap` by hiding the swap.

## Fix

- `global.css`: drop the `html:not(.fonts-loaded) body { opacity: 0 }` rule + the paired body `opacity:1` transition.
- `Base.astro`: drop the `FONT_TIMEOUT_MS` / `document.fonts.ready` reveal script.

## Verification

Local lighthouse on the rebuilt dist served via `python3 -m http.server`:

```
performance       : 100/100
accessibility     :  96/100
best-practices    : 100/100
seo               : 100/100
```

(was: NO_FCP / can't even score)

Net behavior: first visit may show ~50ms of system-ui before swap. Brand fonts arrive, swap happens (display=swap), done. Worth trading the unnoticeable swap for unblocking the whole audit/crawl pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)