### PR TITLE
fix: add FILES_BLOB_DIR to docker-compose and guard undefined array access in console

### DIFF
--- a/apps/console/src/pages/AgentsList.tsx
+++ b/apps/console/src/pages/AgentsList.tsx
@@ -98,21 +98,21 @@ export function AgentsList() {
     setAuxLoading(true);
     try {
       const all = await api<{ data: Agent[] }>("/v1/agents?limit=200&status=any");
-      setAllAgents(all.data);
+      setAllAgents(all.data ?? []);
       await Promise.allSettled([
         (async () => {
           const sk = await api<{
             data: Array<{ id: string; name: string; description: string }>;
           }>("/v1/skills");
-          setCustomSkills(sk.data);
+          setCustomSkills(sk.data ?? []);
         })().catch((e) => console.warn("[AgentsList] /v1/skills aux fetch failed", e)),
         (async () => {
           const mc = await api<{ data: ModelCard[] }>("/v1/model_cards?limit=200");
-          setModelCards(mc.data);
+          setModelCards(mc.data ?? []);
         })().catch((e) => console.warn("[AgentsList] /v1/model_cards aux fetch failed", e)),
         (async () => {
           const rt = await api<{ runtimes: Runtime[] }>("/v1/runtimes");
-          setRuntimes(rt.runtimes);
+          setRuntimes(rt.runtimes ?? []);
         })().catch((e) => console.warn("[AgentsList] /v1/runtimes aux fetch failed", e)),
       ]);
     } finally {

--- a/apps/console/src/pages/RuntimesList.tsx
+++ b/apps/console/src/pages/RuntimesList.tsx
@@ -171,11 +171,11 @@ export function RuntimesList() {
       },
       {
         id: "agents",
-        accessorFn: (r) => r.agents.map((a) => a.id).join(", "),
+        accessorFn: (r) => (r.agents ?? []).map((a) => a.id).join(", "),
         header: "Agents detected",
         cell: ({ row }) => (
           <span className="font-mono text-xs text-fg-muted">
-            {row.original.agents.length === 0 ? "—" : row.original.agents.map((a) => a.id).join(", ")}
+            {(row.original.agents ?? []).length === 0 ? "—" : (row.original.agents ?? []).map((a) => a.id).join(", ")}
           </span>
         ),
       },

--- a/apps/console/src/pages/agents/AgentFormDialog.tsx
+++ b/apps/console/src/pages/agents/AgentFormDialog.tsx
@@ -977,7 +977,7 @@ function BasicTab({
               {runtimes.map((r) => (
                 <SelectOption key={r.id} value={r.id} disabled={r.status !== "online"}>
                   {r.hostname} ({r.status}
-                  {r.status === "online" && r.agents.length
+                  {r.status === "online" && r.agents?.length
                     ? ` · ${r.agents.length} agents`
                     : ""}
                   )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,9 @@ services:
       # agent uses to deliver downloadable artefacts. Bind-mounted into
       # ./data so files survive `docker stop`.
       SESSION_OUTPUTS_DIR: /app/data/session-outputs
+      # Local FS blob store for uploaded files. When FILES_S3_ENDPOINT is
+      # set the S3 backend is used instead and this var is ignored.
+      FILES_BLOB_DIR: /app/data/files-blobs
       # Outbound credential injection via the oma-vault sidecar. When set,
       # LocalSubprocessSandbox.setOutboundContext wires the subprocess env
       # to route HTTPS traffic through oma-vault for header injection.


### PR DESCRIPTION
## Fixes

### 1. oma-server EACCES on startup (docker-compose)

`FILES_BLOB_DIR` was not set in docker-compose.yml, so the code fell back to the default relative path `./data/files-blobs`. Under `pnpm --filter`, this resolves to `/app/apps/main-node/data/files-blobs` — outside the bind mount and without write permissions.

**Fix:** Add `FILES_BLOB_DIR: /app/data/files-blobs` to the `oma-server` environment so it uses the bind-mounted volume.

### 2. "Cannot read properties of undefined (reading 'length')" on new agent

The `/v1/runtimes` API may return runtime objects without an `agents` field. Frontend code accessed `r.agents.length` and `r.agents.map()` without null guards.

**Fix:**
- `AgentFormDialog.tsx`: `r.agents.length` → `r.agents?.length`
- `AgentsList.tsx`: API response `.data` / `.runtimes` fields get `?? []` fallbacks
- `RuntimesList.tsx`: `r.agents` gets `?? []` fallbacks