### PR TITLE
ci: upgrade pnpm setup action to v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Setup pnpm
         # No version pin — reads `packageManager` from root package.json.
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v7
@@ -109,7 +109,7 @@ jobs:
 
       - name: Setup pnpm
         # No version pin — reads `packageManager` from root package.json.
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v7


### PR DESCRIPTION
## Summary
- upgrade `pnpm/action-setup` from v4 to v6 in CI and release workflows
- run the action on Node.js 24 and add native pnpm 11 support
- remove the Node.js 20 action deprecation warning from CI

## Verification
- `git diff --check`
- PR `verify` must install with `pnpm/action-setup@v6`, typecheck, and pass the full test suite