### PR TITLE
test: isolate provider calls from integration suite

### DIFF
--- a/test/integration/api.test.ts
+++ b/test/integration/api.test.ts
@@ -568,7 +568,15 @@ describe("Session isolation", () => {
     const agentRes = await api("/v1/agents", {
       method: "POST",
       headers: HEADERS,
-      body: JSON.stringify({ name: "Shared", model: "claude-sonnet-4-6", system: "ok" }),
+      body: JSON.stringify({
+        name: "Shared",
+        model: "claude-sonnet-4-6",
+        system: "ok",
+        // This test exercises event-log isolation, not the provider adapter.
+        // Keep it on the in-process harness so posting an event never reaches
+        // the real Anthropic API.
+        harness: "test",
+      }),
     });
     const agent = (await agentRes.json()) as any;
     const envRes = await api("/v1/environments", {

--- a/test/integration/auth-tenant.test.ts
+++ b/test/integration/auth-tenant.test.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
 import { env, exports } from "cloudflare:workers";
-import { describe, it, expect, beforeAll } from "vitest";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 
 const HEADERS = {
   "x-api-key": "test-key",
@@ -10,6 +10,34 @@ const HEADERS = {
 function api(path: string, init?: RequestInit) {
   return exports.default.fetch(new Request(`http://localhost${path}`, init));
 }
+
+const realFetch = globalThis.fetch;
+
+function mockInvalidProviderKey(origin: string) {
+  vi.spyOn(globalThis, "fetch").mockImplementation((input, init) => {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url;
+
+    if (url.startsWith(origin)) {
+      return Promise.resolve(
+        new Response(JSON.stringify({ error: { message: "invalid API key" } }), {
+          status: 401,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+    }
+
+    return realFetch(input, init);
+  });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 // ============================================================
 // Auth middleware
@@ -282,6 +310,8 @@ describe("models list endpoint", () => {
   });
 
   it("returns 502 for invalid Anthropic key", async () => {
+    mockInvalidProviderKey("https://api.anthropic.com/");
+
     const res = await api("/v1/models/list", {
       method: "POST",
       headers: HEADERS,
@@ -291,6 +321,8 @@ describe("models list endpoint", () => {
   });
 
   it("returns 502 for invalid OpenAI key", async () => {
+    mockInvalidProviderKey("https://api.openai.com/");
+
     const res = await api("/v1/models/list", {
       method: "POST",
       headers: HEADERS,


### PR DESCRIPTION
## Summary
- keep the session-isolation test on the registered in-process harness
- mock invalid Anthropic/OpenAI key responses at the outbound fetch boundary
- prevent integration tests from depending on live provider availability or credentials

## Verification
- `pnpm exec vitest run test/integration/api.test.ts test/integration/auth-tenant.test.ts` (67 passed, 2 skipped)
- `pnpm test` (all suites passed: 1646 Workers tests plus package and console suites)