### PR TITLE
fix(main-node): wire model cards/environments and surface harness errors

### DIFF
--- a/apps/main-node/package.json
+++ b/apps/main-node/package.json
@@ -40,6 +40,7 @@
     "@open-managed-agents/linear": "workspace:*",
     "@open-managed-agents/markdown": "workspace:*",
     "@open-managed-agents/memory-store": "workspace:*",
+    "@open-managed-agents/model-cards-store": "workspace:*",
     "@open-managed-agents/observability": "workspace:*",
     "@open-managed-agents/oma-cap-adapter": "workspace:*",
     "@open-managed-agents/queue": "workspace:*",

--- a/apps/main-node/src/index.ts
+++ b/apps/main-node/src/index.ts
@@ -50,6 +50,7 @@ import { createSqliteSessionService } from "@open-managed-agents/sessions-store"
 import { createSqliteFileService } from "@open-managed-agents/files-store";
 import { createSqliteEvalRunService } from "@open-managed-agents/evals-store";
 import { createSqliteEnvironmentService } from "@open-managed-agents/environments-store";
+import { createSqliteModelCardService } from "@open-managed-agents/model-cards-store";
 import { toFileRecord } from "@open-managed-agents/files-store";
 import { SqlEventLog } from "@open-managed-agents/event-log/sql";
 import type { SessionEvent } from "@open-managed-agents/shared";
@@ -65,6 +66,8 @@ import { ensureSchema as ensureEventLogSchema } from "@open-managed-agents/event
 import {
   buildAgentRoutes,
   buildVaultRoutes,
+  buildModelCardRoutes,
+  buildEnvironmentRoutes,
   buildSessionRoutes,
   buildMemoryRoutes,
   buildDreamRoutes,
@@ -275,6 +278,14 @@ const sessionsService = createSqliteSessionService({ db: drizzleDb });
 const filesService = createSqliteFileService({ db: drizzleDb });
 const evalsService = createSqliteEvalRunService({ db: drizzleDb });
 const environmentsService = createSqliteEnvironmentService({ db: drizzleDb });
+const modelCardsService = createSqliteModelCardService(
+  { db: drizzleDb },
+  {
+    crypto: platformRootSecret
+      ? new WebCryptoAesGcm(platformRootSecret, "model.cards.keys")
+      : undefined,
+  },
+);
 
 let memoryBlobs: import("@open-managed-agents/memory-store").BlobStore;
 let memoryBlobDescription: string;
@@ -474,6 +485,58 @@ async function buildSandbox(
 
 // ─── Session registry ───────────────────────────────────────────────────
 
+/** Resolve agent.model (a model_id handle) → wire model + credentials.
+ *  Prefer a matching model card; fall back to ANTHROPIC_* env vars. */
+async function resolveNodeModelCreds(
+  tenantId: string,
+  agentModel: string | { id: string; speed?: string },
+): Promise<{
+  wireModel: string;
+  apiKey: string;
+  baseURL?: string;
+  apiCompat?: "ant" | "ant-compatible" | "oai" | "oai-compatible";
+  customHeaders?: Record<string, string>;
+}> {
+  const handle = typeof agentModel === "string" ? agentModel : agentModel.id;
+  try {
+    const card = await modelCardsService.findByModelId({ tenantId, modelId: handle });
+    if (card && !card.archived_at) {
+      const key = await modelCardsService.getApiKey({ tenantId, cardId: card.id });
+      if (key) {
+        const OAI = new Set(["oai", "oai-compatible"]);
+        const ANT = new Set(["ant", "ant-compatible"]);
+        const apiCompat =
+          OAI.has(card.provider) || ANT.has(card.provider)
+            ? (card.provider as "ant" | "ant-compatible" | "oai" | "oai-compatible")
+            : undefined;
+        return {
+          wireModel: card.model,
+          apiKey: key,
+          baseURL: card.base_url ?? undefined,
+          apiCompat,
+          customHeaders: card.custom_headers ?? undefined,
+        };
+      }
+    }
+  } catch (err) {
+    console.warn(
+      `[model-card] lookup failed, falling back to env: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) {
+    throw new Error(
+      "No model card matched and ANTHROPIC_API_KEY is unset — configure a model card or set the env var",
+    );
+  }
+  return {
+    wireModel: handle,
+    apiKey,
+    baseURL: process.env.ANTHROPIC_BASE_URL,
+    customHeaders: parseCustomHeaders(process.env.ANTHROPIC_CUSTOM_HEADERS),
+  };
+}
+
 const sessionRegistry = new SessionRegistry({
   sql,
   hub,
@@ -484,23 +547,21 @@ const sessionRegistry = new SessionRegistry({
   buildSandbox,
   sandboxWorkdirRoot: process.env.SANDBOX_WORKDIR ?? "./data/sandboxes",
   sqlDialect: dialect,
-  buildModel: (agent) => {
-    const apiKey = process.env.ANTHROPIC_API_KEY;
-    if (!apiKey) throw new Error("ANTHROPIC_API_KEY env var required for harness turns");
+  buildModel: async (agent, tenantId) => {
+    const creds = await resolveNodeModelCreds(tenantId, agent.model);
     return resolveModel(
-      agent.model,
-      apiKey,
-      process.env.ANTHROPIC_BASE_URL,
-      undefined,
-      parseCustomHeaders(process.env.ANTHROPIC_CUSTOM_HEADERS),
+      creds.wireModel,
+      creds.apiKey,
+      creds.baseURL,
+      creds.apiCompat,
+      creds.customHeaders,
     );
   },
-  buildTools: async (agent, sandbox) => {
-    const apiKey = process.env.ANTHROPIC_API_KEY;
-    if (!apiKey) throw new Error("ANTHROPIC_API_KEY env var required for harness turns");
+  buildTools: async (agent, sandbox, tenantId) => {
+    const creds = await resolveNodeModelCreds(tenantId, agent.model);
     return buildTools(agent, sandbox, {
-      ANTHROPIC_API_KEY: apiKey,
-      ANTHROPIC_BASE_URL: process.env.ANTHROPIC_BASE_URL,
+      ANTHROPIC_API_KEY: creds.apiKey,
+      ANTHROPIC_BASE_URL: creds.baseURL,
       toMarkdown: toMarkdownProvider,
     });
   },
@@ -509,8 +570,7 @@ const sessionRegistry = new SessionRegistry({
     return { run: (ctx: unknown) => h.run(ctx as HarnessContext) };
   },
   buildHarnessContext: async (input) => {
-    const apiKey = process.env.ANTHROPIC_API_KEY;
-    if (!apiKey) throw new Error("ANTHROPIC_API_KEY env var required for harness turns");
+    const creds = await resolveNodeModelCreds(input.tenantId, input.agent.model);
     const runtime = new NodeHarnessRuntime({
       sessionId: input.sessionId,
       log: input.eventLog,
@@ -528,8 +588,8 @@ const sessionRegistry = new SessionRegistry({
       systemPrompt: composeSystemPrompt(rawSystemPrompt),
       rawSystemPrompt,
       env: {
-        ANTHROPIC_API_KEY: apiKey,
-        ANTHROPIC_BASE_URL: process.env.ANTHROPIC_BASE_URL,
+        ANTHROPIC_API_KEY: creds.apiKey,
+        ANTHROPIC_BASE_URL: creds.baseURL,
       },
       runtime,
     } satisfies HarnessContext;
@@ -851,15 +911,17 @@ v1.route("/api_keys", buildApiKeyRoutes({ storage: apiKeyStorage }));
 v1.route("/evals", buildEvalRoutes({
   evals: evalsService,
   agents: agentsService,
-  // Node has no per-tenant cloud environments yet — leave the optional
-  // dep undefined so the route accepts any environment_id without 404ing.
+  environments: environmentsService,
 }));
 
 // Stubs for routes the console hits but main-node doesn't yet implement.
-v1.get("/environments", (c) => c.json({ data: [] }));
 v1.get("/runtimes", (c) => c.json({ data: [] }));
 v1.get("/skills", (c) => c.json({ data: [] }));
-v1.get("/model_cards", (c) => c.json({ data: [] }));
+v1.route("/environments", buildEnvironmentRoutes({
+  environments: environmentsService,
+  sessions: sessionsService,
+}));
+v1.route("/model_cards", buildModelCardRoutes({ modelCards: modelCardsService }));
 v1.get("/models/list", (c) =>
   c.json({
     data: [
@@ -869,6 +931,48 @@ v1.get("/models/list", (c) =>
     ],
   }),
 );
+// Console ModelCardsList fetches suggestions via POST /v1/models/list with
+// the user's key — proxy through to Anthropic/OpenAI when possible.
+v1.post("/models/list", async (c) => {
+  const body = await c.req.json<{ provider?: string; api_key?: string }>();
+  const provider = body.provider || "ant";
+  const apiKey = body.api_key || "";
+  if (!apiKey) return c.json({ error: "api_key is required" }, 400);
+  try {
+    if (provider === "ant") {
+      const res = await fetch("https://api.anthropic.com/v1/models?limit=100", {
+        headers: { "x-api-key": apiKey, "anthropic-version": "2023-06-01" },
+      });
+      if (!res.ok) throw new Error(`Anthropic API ${res.status}`);
+      const data = (await res.json()) as {
+        data: Array<{ id: string; display_name: string }>;
+      };
+      return c.json({
+        data: data.data.map((m) => ({ id: m.id, name: m.display_name || m.id })),
+      });
+    }
+    if (provider === "oai") {
+      const res = await fetch("https://api.openai.com/v1/models", {
+        headers: { Authorization: `Bearer ${apiKey}` },
+      });
+      if (!res.ok) throw new Error(`OpenAI API ${res.status}`);
+      const data = (await res.json()) as { data: Array<{ id: string }> };
+      const chatPrefixes = ["gpt-", "o1", "o3", "o4", "chatgpt-"];
+      return c.json({
+        data: data.data
+          .filter((m) => chatPrefixes.some((p) => m.id.startsWith(p)))
+          .sort((a, b) => a.id.localeCompare(b.id))
+          .map((m) => ({ id: m.id, name: m.id })),
+      });
+    }
+    return c.json({ data: [] });
+  } catch (err) {
+    return c.json(
+      { error: `Failed to fetch models: ${(err as Error).message}` },
+      502,
+    );
+  }
+});
 v1.get("/integrations/github/credentials", (c) => c.json({ data: [] }));
 v1.get("/integrations/linear/credentials", (c) => c.json({ data: [] }));
 v1.get("/integrations/slack/credentials", (c) => c.json({ data: [] }));

--- a/apps/main-node/src/lib/node-session-router.ts
+++ b/apps/main-node/src/lib/node-session-router.ts
@@ -84,8 +84,27 @@ export class NodeSessionRouter implements SessionRouter {
             row.agent_id,
             event as import("@open-managed-agents/shared").UserMessageEvent,
           )
-          .catch((err) => {
-            moduleLog.error({ err, op: "node_session_router.harness_turn_failed", session_id: sessionId }, "harness turn failed");
+          .catch(async (err) => {
+            const message = err instanceof Error ? err.message : String(err);
+            moduleLog.error(
+              { err, op: "node_session_router.harness_turn_failed", session_id: sessionId },
+              "harness turn failed",
+            );
+            try {
+              const errorEv = {
+                type: "session.error",
+                error: "harness_turn_failed",
+                message,
+              } as SessionEvent;
+              await log.appendAsync(errorEv);
+              const stored = await log.getEventsAsync();
+              this.deps.hub.publish(sessionId, stored[stored.length - 1]);
+            } catch (appendErr) {
+              moduleLog.error(
+                { err: appendErr, op: "node_session_router.error_append_failed", session_id: sessionId },
+                "failed to append session.error",
+              );
+            }
           });
       }
     }

--- a/apps/main-node/src/registry.ts
+++ b/apps/main-node/src/registry.ts
@@ -64,14 +64,19 @@ export interface SessionRegistryDeps {
    *  LocalSubprocess / E2B / Daytona / etc., the machine doesn't. */
   buildSandbox(sessionId: string, workdir: string): Promise<SandboxExecutor>;
 
-  /** Build the LanguageModel for the agent. Reads env, applies custom
-   *  headers, picks the right provider. */
-  buildModel(agent: AgentConfig): LanguageModel;
+  /** Build the LanguageModel for the agent. Reads env / model cards,
+   *  applies custom headers, picks the right provider. Async when the
+   *  shell looks up a model card by handle. */
+  buildModel(
+    agent: AgentConfig,
+    tenantId: string,
+  ): LanguageModel | Promise<LanguageModel>;
 
   /** Build harness tools. Returns the tools dict the harness expects. */
   buildTools(
     agent: AgentConfig,
     sandbox: SandboxExecutor,
+    tenantId: string,
   ): Promise<unknown>;
 
   /** Build harness instance + context. Each is platform-neutral so the
@@ -84,6 +89,7 @@ export interface SessionRegistryDeps {
     tools: unknown;
     model: LanguageModel;
     sessionId: string;
+    tenantId: string;
     eventLog: SqlEventLog;
   }): Promise<unknown>;
 
@@ -257,13 +263,14 @@ export class SessionRegistry {
       // Node passes no-ops since the work has already been done.
       mountMemoryStores: async () => {},
       mountSessionOutputs: async () => {},
-      buildModel: (agent) => this.deps.buildModel(agent),
-      buildTools: (agent, sb) => this.deps.buildTools(agent, sb),
+      buildModel: (agent) => this.deps.buildModel(agent, tenantId),
+      buildTools: (agent, sb) => this.deps.buildTools(agent, sb, tenantId),
       buildHarness: () => this.deps.buildHarness(),
       buildHarnessContext: (input) =>
         this.deps.buildHarnessContext({
           ...input,
           sessionId,
+          tenantId,
           eventLog,
         }),
       publish: (event: SessionEvent) => this.deps.hub.publish(sessionId, event),

--- a/docs/self-host.md
+++ b/docs/self-host.md
@@ -542,12 +542,14 @@ Endpoints main-node implements for the console:
 - `/v1/agents` CRUD, `/v1/sessions` CRUD + events + SSE stream
 - `/v1/memory_stores` + `/memories` + per-session bindings
 - `/v1/vaults` + `/credentials`
-- `/v1/models/list`
+- `/v1/model_cards` CRUD (+ `/key` for cleartext; capability probe on create)
+- `/v1/environments` CRUD (+ archive; packages apply at session warmup)
+- `/v1/models/list` (GET catalog stub + POST provider key probe)
 - `/v1/integrations/{linear,github,slack}/{installations,publications,...}` — read + persona/capability PATCH + dispatch-rule CRUD. Active when `PLATFORM_ROOT_SECRET` env var is set. Publication-create endpoints (`start-a1`, `credentials`, `handoff-link`, `personal-token`) now run in-process via `NodeInstallBridge.startInstallation` — wire shape matches the CF gateway verbatim. The OAuth callback / setup-page / webhook / Linear MCP / GitHub refresh-by-vault routes are all in-process via `buildIntegrationsGatewayRoutes`.
 
 Endpoints stubbed (return empty `data: []` so the UI degrades gracefully):
-- `/v1/environments`, `/v1/api_keys`, `/v1/me/cli-tokens`,
-  `/v1/runtimes`, `/v1/skills`, `/v1/model_cards`
+- `/v1/api_keys`, `/v1/me/cli-tokens`,
+  `/v1/runtimes`, `/v1/skills`
 
 These pages render an "empty" state in the console; their CF counterparts
 will land in main-node as follow-up work.

--- a/packages/http-routes/package.json
+++ b/packages/http-routes/package.json
@@ -20,6 +20,7 @@
     "@open-managed-agents/integrations-core": "workspace:*",
     "@open-managed-agents/kv-store": "workspace:*",
     "@open-managed-agents/memory-store": "workspace:*",
+    "@open-managed-agents/model-cards-store": "workspace:*",
     "@open-managed-agents/observability": "workspace:*",
     "@open-managed-agents/quotas": "workspace:*",
     "@open-managed-agents/session-runtime": "workspace:*",

--- a/packages/http-routes/src/environments/index.ts
+++ b/packages/http-routes/src/environments/index.ts
@@ -1,0 +1,255 @@
+// Environments — CRUD + archive.
+//
+// Sourced from apps/main/src/routes/environments.ts post-setup-on-warmup.
+// Same wire shape so the Console Environments page works against CF and
+// main-node without branching. Limits validation is optional (CF passes
+// its Anthropic-aligned caps; Node may omit).
+
+import { Hono } from "hono";
+import type { EnvironmentConfig } from "@open-managed-agents/shared";
+import {
+  EnvironmentNotFoundError,
+  toEnvironmentConfig,
+  type EnvironmentService,
+} from "@open-managed-agents/environments-store";
+import type { SessionService } from "@open-managed-agents/sessions-store";
+
+interface Vars {
+  Variables: { tenant_id: string };
+}
+
+function parsePageQuery(c: {
+  req: { query: (k: string) => string | undefined };
+}): {
+  limit?: number;
+  cursor?: string;
+  q?: string;
+} {
+  const limitParam = c.req.query("limit");
+  const cursor = c.req.query("cursor") || c.req.query("page") || undefined;
+  const limit = limitParam ? parseInt(limitParam, 10) : undefined;
+  const qRaw = c.req.query("q");
+  const q = qRaw && qRaw.trim() ? qRaw.trim() : undefined;
+  return {
+    limit: limit !== undefined && !isNaN(limit) ? limit : undefined,
+    cursor,
+    q,
+  };
+}
+
+export interface EnvironmentRoutesDeps {
+  environments: EnvironmentService;
+  /** When provided, DELETE refuses while sessions still reference the env. */
+  sessions?: SessionService;
+  /** Optional field-size caps (CF wires apps/main/src/lib/limits). */
+  validateLimits?: (body: unknown) => { ok: boolean; error?: string };
+}
+
+export function buildEnvironmentRoutes(deps: EnvironmentRoutesDeps) {
+  const app = new Hono<Vars>();
+  const { environments, sessions, validateLimits } = deps;
+
+  // POST / — create
+  app.post("/", async (c) => {
+    const t = c.var.tenant_id;
+    const body = (await c.req.json()) as {
+      name: string;
+      description?: string;
+      config: EnvironmentConfig["config"];
+    };
+
+    if (!body.name) {
+      return c.json({ error: "name is required" }, 400);
+    }
+
+    if (validateLimits) {
+      const limitCheck = validateLimits(body);
+      if (!limitCheck.ok) {
+        return c.json({ error: limitCheck.error }, 400);
+      }
+    }
+
+    const row = await environments.create({
+      tenantId: t,
+      name: body.name,
+      description: body.description,
+      config: body.config || { type: "cloud" },
+      // Setup-on-warmup means env is immediately usable — no async build.
+      status: "ready",
+      sandboxWorkerName: "sandbox-default",
+      imageStrategy: null,
+    });
+
+    return c.json(toEnvironmentConfig(row), 201);
+  });
+
+  // GET / — list (cursor-paginated)
+  app.get("/", async (c) => {
+    const statusRaw = c.req.query("status");
+    let status: "active" | "archived" | "any" | undefined;
+    if (statusRaw !== undefined) {
+      if (
+        statusRaw === "active" ||
+        statusRaw === "archived" ||
+        statusRaw === "any"
+      ) {
+        status = statusRaw;
+      } else {
+        return c.json(
+          {
+            error: {
+              type: "invalid_request_error",
+              code: "invalid_status",
+              message: `Invalid status '${statusRaw}'; expected one of active|archived|any.`,
+            },
+          },
+          400,
+        );
+      }
+    }
+
+    const parseMs = (
+      raw: string | undefined,
+      field: string,
+    ): { value: number | undefined; err?: Response } => {
+      if (raw === undefined) return { value: undefined };
+      const ms = Date.parse(raw);
+      if (Number.isNaN(ms)) {
+        return {
+          value: undefined,
+          err: c.json(
+            {
+              error: {
+                type: "invalid_request_error",
+                code: "invalid_timestamp",
+                message: `Invalid ${field} '${raw}'; expected ISO-8601 timestamp.`,
+              },
+            },
+            400,
+          ),
+        };
+      }
+      return { value: ms };
+    };
+    const createdAfterRes = parseMs(c.req.query("created_after"), "created_after");
+    if (createdAfterRes.err) return createdAfterRes.err;
+    const createdBeforeRes = parseMs(
+      c.req.query("created_before"),
+      "created_before",
+    );
+    if (createdBeforeRes.err) return createdBeforeRes.err;
+
+    const page = await environments.listPage({
+      tenantId: c.var.tenant_id,
+      ...parsePageQuery(c),
+      ...(status !== undefined ? { status } : {}),
+      ...(createdAfterRes.value !== undefined
+        ? { createdAfter: createdAfterRes.value }
+        : {}),
+      ...(createdBeforeRes.value !== undefined
+        ? { createdBefore: createdBeforeRes.value }
+        : {}),
+    });
+    const data = page.items.map(toEnvironmentConfig);
+    if (!page.nextCursor) return c.json({ data });
+    return c.json({
+      data,
+      next_page: page.nextCursor,
+      next_cursor: page.nextCursor,
+    });
+  });
+
+  // GET /:id
+  app.get("/:id", async (c) => {
+    const row = await environments.get({
+      tenantId: c.var.tenant_id,
+      environmentId: c.req.param("id"),
+    });
+    if (!row) return c.json({ error: "Environment not found" }, 404);
+    return c.json(toEnvironmentConfig(row));
+  });
+
+  // POST /:id/archive — register before generic POST /:id update
+  app.post("/:id/archive", async (c) => {
+    try {
+      const row = await environments.archive({
+        tenantId: c.var.tenant_id,
+        environmentId: c.req.param("id"),
+      });
+      return c.json(toEnvironmentConfig(row));
+    } catch (err) {
+      if (err instanceof EnvironmentNotFoundError) {
+        return c.json({ error: "Environment not found" }, 404);
+      }
+      throw err;
+    }
+  });
+
+  // PUT + POST /:id — update (Anthropic SDK uses POST)
+  app.on(["PUT", "POST"], "/:id", async (c) => {
+    const t = c.var.tenant_id;
+    const id = c.req.param("id");
+
+    const existing = await environments.get({ tenantId: t, environmentId: id });
+    if (!existing) return c.json({ error: "Environment not found" }, 404);
+
+    const body = (await c.req.json()) as {
+      name?: string;
+      description?: string;
+      config?: EnvironmentConfig["config"];
+      metadata?: Record<string, unknown>;
+    };
+
+    if (validateLimits) {
+      const limitCheck = validateLimits(body);
+      if (!limitCheck.ok) {
+        return c.json({ error: limitCheck.error }, 400);
+      }
+    }
+
+    const patch: Parameters<typeof environments.update>[0] = {
+      tenantId: t,
+      environmentId: id,
+    };
+    if (body.name !== undefined) patch.name = body.name;
+    if (body.description !== undefined) patch.description = body.description;
+    if (body.config !== undefined) patch.config = body.config;
+    if (body.metadata !== undefined) patch.metadata = body.metadata;
+
+    const row = await environments.update(patch);
+    return c.json(toEnvironmentConfig(row));
+  });
+
+  // DELETE /:id
+  app.delete("/:id", async (c) => {
+    const t = c.var.tenant_id;
+    const id = c.req.param("id");
+    try {
+      if (sessions) {
+        const hasActiveSessions = await sessions.hasActiveByEnvironment({
+          tenantId: t,
+          environmentId: id,
+        });
+        if (hasActiveSessions) {
+          return c.json(
+            {
+              error:
+                "Cannot delete environment with active sessions. Archive or delete sessions first.",
+            },
+            409,
+          );
+        }
+      }
+
+      await environments.delete({ tenantId: t, environmentId: id });
+      return c.json({ type: "environment_deleted", id });
+    } catch (err) {
+      if (err instanceof EnvironmentNotFoundError) {
+        return c.json({ error: "Environment not found" }, 404);
+      }
+      throw err;
+    }
+  });
+
+  return app;
+}

--- a/packages/http-routes/src/index.ts
+++ b/packages/http-routes/src/index.ts
@@ -19,6 +19,12 @@ export type { AgentRoutesDeps } from "./agents";
 export { buildVaultRoutes } from "./vaults";
 export type { VaultRoutesDeps } from "./vaults";
 
+export { buildModelCardRoutes } from "./model-cards";
+export type { ModelCardRoutesDeps } from "./model-cards";
+
+export { buildEnvironmentRoutes } from "./environments";
+export type { EnvironmentRoutesDeps } from "./environments";
+
 export { buildSessionRoutes } from "./sessions";
 export type {
   SessionRoutesDeps,

--- a/packages/http-routes/src/model-cards/index.ts
+++ b/packages/http-routes/src/model-cards/index.ts
@@ -1,0 +1,329 @@
+// Model cards — CRUD + capability probe.
+//
+// Sourced from apps/main/src/routes/model-cards.ts. Same wire shape so the
+// Console Model Cards page works against CF and main-node without branching.
+
+import { Hono } from "hono";
+import {
+  ModelCardDuplicateModelIdError,
+  ModelCardNotFoundError,
+  type ModelCardRow,
+  type ModelCardService,
+} from "@open-managed-agents/model-cards-store";
+
+interface Vars {
+  Variables: { tenant_id: string };
+}
+
+function toApiShape(card: ModelCardRow) {
+  return {
+    id: card.id,
+    model_id: card.model_id,
+    model: card.model,
+    provider: card.provider,
+    api_key_preview: card.api_key_preview,
+    base_url: card.base_url ?? undefined,
+    custom_headers: card.custom_headers ?? undefined,
+    is_default: card.is_default,
+    created_at: card.created_at,
+    updated_at: card.updated_at ?? undefined,
+    archived_at: card.archived_at,
+  };
+}
+
+/**
+ * Best-effort capability probe for a freshly-created model card. Calls the
+ * provider's smallest available endpoint with the user-supplied api_key /
+ * base_url / custom_headers and returns ok=true on 2xx, otherwise ok=false
+ * with the upstream's own error message.
+ *
+ * Bounded to 6s. Failures NEVER roll back the card (it's already persisted).
+ */
+async function probeModelCard(opts: {
+  provider: string;
+  model: string;
+  apiKey: string;
+  baseUrl: string | null;
+  customHeaders: Record<string, string> | null;
+}): Promise<{ ok: boolean; message?: string } | { ok: null; reason: "unsupported_provider" }> {
+  const provider = opts.provider.toLowerCase();
+  const isAnt = /^(ant|anthropic|ant-compatible)$/.test(provider);
+  const isOai = /^(oai|openai|oai-compatible)$/.test(provider);
+  if (!isAnt && !isOai) return { ok: null, reason: "unsupported_provider" };
+
+  const url = isAnt
+    ? `${opts.baseUrl ?? "https://api.anthropic.com"}/v1/messages`
+    : `${opts.baseUrl ?? "https://api.openai.com"}/v1/chat/completions`;
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+    ...(opts.customHeaders ?? {}),
+  };
+  let body: string;
+  if (isAnt) {
+    headers["x-api-key"] = opts.apiKey;
+    headers["anthropic-version"] = "2023-06-01";
+    body = JSON.stringify({
+      model: opts.model,
+      max_tokens: 1,
+      messages: [{ role: "user", content: "hi" }],
+    });
+  } else {
+    headers["authorization"] = `Bearer ${opts.apiKey}`;
+    body = JSON.stringify({
+      model: opts.model,
+      max_completion_tokens: 1,
+      messages: [{ role: "user", content: "hi" }],
+    });
+  }
+
+  try {
+    const ac = new AbortController();
+    const timer = setTimeout(() => ac.abort(), 6000);
+    let res: Response;
+    try {
+      res = await fetch(url, { method: "POST", headers, body, signal: ac.signal });
+    } finally {
+      clearTimeout(timer);
+    }
+    if (res.status >= 200 && res.status < 300) return { ok: true };
+    const upstream = await res.text().catch(() => "");
+    let detail = upstream.slice(0, 240).trim();
+    try {
+      const j = JSON.parse(upstream) as { error?: { message?: string } | string };
+      const m =
+        typeof j.error === "string"
+          ? j.error
+          : typeof j.error === "object" && j.error?.message
+            ? j.error.message
+            : "";
+      if (m) detail = m.slice(0, 240);
+    } catch {
+      /* keep raw */
+    }
+    return {
+      ok: false,
+      message: `Provider returned HTTP ${res.status}${detail ? `: ${detail}` : ""}`,
+    };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { ok: false, message: `Probe failed: ${msg.slice(0, 120)}` };
+  }
+}
+
+function parsePageQuery(c: {
+  req: { query: (k: string) => string | undefined };
+}): {
+  limit?: number;
+  cursor?: string;
+  q?: string;
+} {
+  const limitParam = c.req.query("limit");
+  const cursor = c.req.query("cursor") || c.req.query("page") || undefined;
+  const limit = limitParam ? parseInt(limitParam, 10) : undefined;
+  const qRaw = c.req.query("q");
+  const q = qRaw && qRaw.trim() ? qRaw.trim() : undefined;
+  return {
+    limit: limit !== undefined && !isNaN(limit) ? limit : undefined,
+    cursor,
+    q,
+  };
+}
+
+export interface ModelCardRoutesDeps {
+  modelCards: ModelCardService;
+}
+
+export function buildModelCardRoutes(deps: ModelCardRoutesDeps) {
+  const app = new Hono<Vars>();
+  const { modelCards } = deps;
+
+  // POST / — create
+  app.post("/", async (c) => {
+    const t = c.var.tenant_id;
+    const body = await c.req.json<{
+      model_id: string;
+      model?: string;
+      provider: string;
+      api_key: string;
+      base_url?: string;
+      custom_headers?: Record<string, string>;
+      is_default?: boolean;
+    }>();
+
+    if (!body.model_id || !body.provider || !body.api_key) {
+      return c.json({ error: "model_id, provider, and api_key are required" }, 400);
+    }
+    try {
+      const card = await modelCards.create({
+        tenantId: t,
+        modelId: body.model_id,
+        provider: body.provider,
+        model: body.model,
+        apiKey: body.api_key,
+        baseUrl: body.base_url ?? null,
+        customHeaders: body.custom_headers ?? null,
+        makeDefault: !!body.is_default,
+      });
+      const probe = await probeModelCard({
+        provider: body.provider,
+        model: body.model ?? body.model_id,
+        apiKey: body.api_key,
+        baseUrl: body.base_url ?? null,
+        customHeaders: body.custom_headers ?? null,
+      });
+      return c.json({ ...toApiShape(card), probe }, 201);
+    } catch (err) {
+      if (err instanceof ModelCardDuplicateModelIdError) {
+        return c.json({ error: err.message }, 409);
+      }
+      throw err;
+    }
+  });
+
+  // GET / — list (cursor-paginated)
+  app.get("/", async (c) => {
+    const providerRaw = c.req.query("provider");
+    const PROVIDERS = ["ant", "ant-compatible", "oai", "oai-compatible"] as const;
+    let provider: (typeof PROVIDERS)[number] | undefined;
+    if (providerRaw !== undefined) {
+      if ((PROVIDERS as readonly string[]).includes(providerRaw)) {
+        provider = providerRaw as (typeof PROVIDERS)[number];
+      } else {
+        return c.json(
+          {
+            error: {
+              type: "invalid_request_error",
+              code: "invalid_provider",
+              message: `Invalid provider '${providerRaw}'; expected one of ${PROVIDERS.join("|")}.`,
+            },
+          },
+          400,
+        );
+      }
+    }
+
+    const parseMs = (
+      raw: string | undefined,
+      field: string,
+    ): { value: number | undefined; err?: Response } => {
+      if (raw === undefined) return { value: undefined };
+      const ms = Date.parse(raw);
+      if (Number.isNaN(ms)) {
+        return {
+          value: undefined,
+          err: c.json(
+            {
+              error: {
+                type: "invalid_request_error",
+                code: "invalid_timestamp",
+                message: `Invalid ${field} '${raw}'; expected ISO-8601 timestamp.`,
+              },
+            },
+            400,
+          ),
+        };
+      }
+      return { value: ms };
+    };
+    const createdAfterRes = parseMs(c.req.query("created_after"), "created_after");
+    if (createdAfterRes.err) return createdAfterRes.err;
+    const createdBeforeRes = parseMs(c.req.query("created_before"), "created_before");
+    if (createdBeforeRes.err) return createdBeforeRes.err;
+
+    const page = await modelCards.listPage({
+      tenantId: c.var.tenant_id,
+      ...parsePageQuery(c),
+      ...(provider !== undefined ? { provider } : {}),
+      ...(createdAfterRes.value !== undefined
+        ? { createdAfter: createdAfterRes.value }
+        : {}),
+      ...(createdBeforeRes.value !== undefined
+        ? { createdBefore: createdBeforeRes.value }
+        : {}),
+    });
+    const filteredItems = page.items.filter((card) => card.archived_at === null);
+    const data = filteredItems.map(toApiShape);
+    if (!page.nextCursor) return c.json({ data });
+    return c.json({
+      data,
+      next_page: page.nextCursor,
+      next_cursor: page.nextCursor,
+    });
+  });
+
+  // GET /:id
+  app.get("/:id", async (c) => {
+    const card = await modelCards.get({
+      tenantId: c.var.tenant_id,
+      cardId: c.req.param("id"),
+    });
+    if (!card) return c.json({ error: "Model card not found" }, 404);
+    return c.json(toApiShape(card));
+  });
+
+  // POST /:id — update
+  app.post("/:id", async (c) => {
+    const id = c.req.param("id");
+    const body = await c.req.json<{
+      model_id?: string;
+      model?: string;
+      provider?: string;
+      api_key?: string;
+      base_url?: string | null;
+      custom_headers?: Record<string, string> | null;
+      is_default?: boolean;
+    }>();
+    try {
+      const updated = await modelCards.update({
+        tenantId: c.var.tenant_id,
+        cardId: id,
+        modelId: body.model_id,
+        model: body.model,
+        provider: body.provider,
+        baseUrl:
+          body.base_url === undefined ? undefined : body.base_url || null,
+        customHeaders:
+          body.custom_headers === undefined
+            ? undefined
+            : body.custom_headers || null,
+        apiKey: body.api_key,
+        isDefault: body.is_default,
+      });
+      return c.json(toApiShape(updated));
+    } catch (err) {
+      if (err instanceof ModelCardNotFoundError) {
+        return c.json({ error: "Model card not found" }, 404);
+      }
+      if (err instanceof ModelCardDuplicateModelIdError) {
+        return c.json({ error: err.message }, 409);
+      }
+      throw err;
+    }
+  });
+
+  // DELETE /:id
+  app.delete("/:id", async (c) => {
+    const id = c.req.param("id");
+    try {
+      await modelCards.delete({ tenantId: c.var.tenant_id, cardId: id });
+      return c.json({ type: "model_card_deleted", id });
+    } catch (err) {
+      if (err instanceof ModelCardNotFoundError) {
+        return c.json({ error: "Model card not found" }, 404);
+      }
+      throw err;
+    }
+  });
+
+  // GET /:id/key — cleartext key (agent / internal consumers)
+  app.get("/:id/key", async (c) => {
+    const apiKey = await modelCards.getApiKey({
+      tenantId: c.var.tenant_id,
+      cardId: c.req.param("id"),
+    });
+    if (apiKey === null) return c.json({ error: "Key not found" }, 404);
+    return c.json({ api_key: apiKey });
+  });
+
+  return app;
+}

--- a/packages/session-runtime/src/machine.ts
+++ b/packages/session-runtime/src/machine.ts
@@ -79,8 +79,9 @@ export interface SessionMachineDeps {
   mountSessionOutputs?(opts: { sandbox: SandboxExecutor }): Promise<void>;
 
   /** Build the LanguageModel for this turn. CF reads env from
-   *  bindings; Node from process.env. */
-  buildModel(agent: AgentConfig): LanguageModel;
+   *  bindings; Node from process.env (and optionally a model card).
+   *  May be async when the shell needs to look up credentials. */
+  buildModel(agent: AgentConfig): LanguageModel | Promise<LanguageModel>;
 
   /** Build harness tools. The harness package owns the tool list; the
    *  machine doesn't know which tools exist, just hands the result to
@@ -166,7 +167,7 @@ export class SessionStateMachine {
       }
 
       const tools = await this.deps.buildTools(agent, this.deps.sandbox);
-      const model = this.deps.buildModel(agent);
+      const model = await this.deps.buildModel(agent);
       const ctx = await this.deps.buildHarnessContext({
         agent,
         userMessage,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,7 @@ importers:
         version: 7.0.42(zod@4.3.6)
       better-auth:
         specifier: ^1.6.3
-        version: 1.6.3(@cloudflare/workers-types@5.20260728.1)(@opentelemetry/api@1.9.0)(better-sqlite3@11.10.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260728.1)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@11.10.0)(kysely@0.28.16)(pg@8.20.0)(postgres@3.4.9))(pg@8.20.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.1.4(@opentelemetry/api@1.9.0)(@types/node@26.1.2)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@26.1.2)(typescript@5.9.3))(vite@8.0.8(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.4)))
+        version: 1.6.3(@cloudflare/workers-types@5.20260728.1)(@opentelemetry/api@1.9.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260728.1)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(kysely@0.28.16)(pg@8.20.0)(postgres@3.4.9))(pg@8.20.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.1.4(@opentelemetry/api@1.9.0)(@types/node@26.1.2)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@26.1.2)(typescript@5.9.3))(vite@8.0.8(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.4)))
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2(@cloudflare/workers-types@5.20260728.1)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@11.10.0)(kysely@0.28.16)(pg@8.20.0)(postgres@3.4.9)
@@ -617,6 +617,9 @@ importers:
       '@open-managed-agents/memory-store':
         specifier: workspace:*
         version: link:../../packages/memory-store
+      '@open-managed-agents/model-cards-store':
+        specifier: workspace:*
+        version: link:../../packages/model-cards-store
       '@open-managed-agents/observability':
         specifier: workspace:*
         version: link:../../packages/observability
@@ -1097,6 +1100,9 @@ importers:
       '@open-managed-agents/memory-store':
         specifier: workspace:*
         version: link:../memory-store
+      '@open-managed-agents/model-cards-store':
+        specifier: workspace:*
+        version: link:../model-cards-store
       '@open-managed-agents/observability':
         specifier: workspace:*
         version: link:../observability
@@ -12284,7 +12290,7 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/semantic-conventions': 1.40.0
       '@standard-schema/spec': 1.1.0
-      better-call: 1.3.5(zod@4.3.6)
+      better-call: 1.3.5(zod@4.4.3)
       jose: 6.2.2
       kysely: 0.28.16
       nanostores: 1.2.0
@@ -12292,7 +12298,7 @@ snapshots:
     optionalDependencies:
       '@cloudflare/workers-types': 5.20260728.1
 
-  '@better-auth/drizzle-adapter@1.6.3(@better-auth/core@1.6.3(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@5.20260728.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.2.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260728.1)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@11.10.0)(kysely@0.28.16)(pg@8.20.0)(postgres@3.4.9))':
+  '@better-auth/drizzle-adapter@1.6.3(@better-auth/core@1.6.3(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@5.20260728.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.2.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260728.1)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(kysely@0.28.16)(pg@8.20.0)(postgres@3.4.9))':
     dependencies:
       '@better-auth/core': 1.6.3(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@5.20260728.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.2.0)
       '@better-auth/utils': 0.4.0
@@ -17180,7 +17186,7 @@ snapshots:
   better-auth@1.6.3(@cloudflare/workers-types@5.20260728.1)(@opentelemetry/api@1.9.0)(better-sqlite3@11.10.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260728.1)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@11.10.0)(kysely@0.28.16)(pg@8.20.0)(postgres@3.4.9))(pg@8.20.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.1.4(@opentelemetry/api@1.9.0)(@types/node@26.1.2)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@26.1.2)(typescript@5.9.3))(vite@6.4.2(@types/node@26.1.2)(jiti@2.6.1)(lightningcss@1.33.0)(tsx@4.21.0)(yaml@2.8.4))):
     dependencies:
       '@better-auth/core': 1.6.3(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@5.20260728.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.2.0)
-      '@better-auth/drizzle-adapter': 1.6.3(@better-auth/core@1.6.3(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@5.20260728.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.2.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260728.1)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@11.10.0)(kysely@0.28.16)(pg@8.20.0)(postgres@3.4.9))
+      '@better-auth/drizzle-adapter': 1.6.3(@better-auth/core@1.6.3(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@5.20260728.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.2.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260728.1)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(kysely@0.28.16)(pg@8.20.0)(postgres@3.4.9))
       '@better-auth/kysely-adapter': 1.6.3(@better-auth/core@1.6.3(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@5.20260728.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.2.0))(@better-auth/utils@0.4.0)(kysely@0.28.16)
       '@better-auth/memory-adapter': 1.6.3(@better-auth/core@1.6.3(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@5.20260728.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.2.0))(@better-auth/utils@0.4.0)
       '@better-auth/mongo-adapter': 1.6.3(@better-auth/core@1.6.3(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@5.20260728.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.2.0))(@better-auth/utils@0.4.0)
@@ -17211,7 +17217,38 @@ snapshots:
   better-auth@1.6.3(@cloudflare/workers-types@5.20260728.1)(@opentelemetry/api@1.9.0)(better-sqlite3@11.10.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260728.1)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@11.10.0)(kysely@0.28.16)(pg@8.20.0)(postgres@3.4.9))(pg@8.20.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.1.4(@opentelemetry/api@1.9.0)(@types/node@26.1.2)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@26.1.2)(typescript@5.9.3))(vite@8.0.8(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.4))):
     dependencies:
       '@better-auth/core': 1.6.3(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@5.20260728.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.2.0)
-      '@better-auth/drizzle-adapter': 1.6.3(@better-auth/core@1.6.3(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@5.20260728.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.2.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260728.1)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@11.10.0)(kysely@0.28.16)(pg@8.20.0)(postgres@3.4.9))
+      '@better-auth/drizzle-adapter': 1.6.3(@better-auth/core@1.6.3(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@5.20260728.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.2.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260728.1)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(kysely@0.28.16)(pg@8.20.0)(postgres@3.4.9))
+      '@better-auth/kysely-adapter': 1.6.3(@better-auth/core@1.6.3(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@5.20260728.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.2.0))(@better-auth/utils@0.4.0)(kysely@0.28.16)
+      '@better-auth/memory-adapter': 1.6.3(@better-auth/core@1.6.3(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@5.20260728.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.2.0))(@better-auth/utils@0.4.0)
+      '@better-auth/mongo-adapter': 1.6.3(@better-auth/core@1.6.3(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@5.20260728.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.2.0))(@better-auth/utils@0.4.0)
+      '@better-auth/prisma-adapter': 1.6.3(@better-auth/core@1.6.3(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@5.20260728.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.2.0))(@better-auth/utils@0.4.0)
+      '@better-auth/telemetry': 1.6.3(@better-auth/core@1.6.3(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@5.20260728.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.2.0))(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)
+      '@better-auth/utils': 0.4.0
+      '@better-fetch/fetch': 1.1.21
+      '@noble/ciphers': 2.2.0
+      '@noble/hashes': 2.2.0
+      better-call: 1.3.5(zod@4.4.3)
+      defu: 6.1.7
+      jose: 6.2.2
+      kysely: 0.28.16
+      nanostores: 1.2.0
+      zod: 4.3.6
+    optionalDependencies:
+      better-sqlite3: 11.10.0
+      drizzle-kit: 0.31.10
+      drizzle-orm: 0.45.2(@cloudflare/workers-types@5.20260728.1)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@11.10.0)(kysely@0.28.16)(pg@8.20.0)(postgres@3.4.9)
+      pg: 8.20.0
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      vitest: 4.1.4(@opentelemetry/api@1.9.0)(@types/node@26.1.2)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@26.1.2)(typescript@5.9.3))(vite@8.0.8(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.4))
+    transitivePeerDependencies:
+      - '@cloudflare/workers-types'
+      - '@opentelemetry/api'
+
+  better-auth@1.6.3(@cloudflare/workers-types@5.20260728.1)(@opentelemetry/api@1.9.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260728.1)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(kysely@0.28.16)(pg@8.20.0)(postgres@3.4.9))(pg@8.20.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.1.4(@opentelemetry/api@1.9.0)(@types/node@26.1.2)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@26.1.2)(typescript@5.9.3))(vite@8.0.8(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.4))):
+    dependencies:
+      '@better-auth/core': 1.6.3(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@5.20260728.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.2.0)
+      '@better-auth/drizzle-adapter': 1.6.3(@better-auth/core@1.6.3(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@5.20260728.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.2.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260728.1)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(kysely@0.28.16)(pg@8.20.0)(postgres@3.4.9))
       '@better-auth/kysely-adapter': 1.6.3(@better-auth/core@1.6.3(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@5.20260728.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.2.0))(@better-auth/utils@0.4.0)(kysely@0.28.16)
       '@better-auth/memory-adapter': 1.6.3(@better-auth/core@1.6.3(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@5.20260728.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.2.0))(@better-auth/utils@0.4.0)
       '@better-auth/mongo-adapter': 1.6.3(@better-auth/core@1.6.3(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@5.20260728.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.2.0))(@better-auth/utils@0.4.0)
@@ -17228,7 +17265,6 @@ snapshots:
       nanostores: 1.2.0
       zod: 4.3.6
     optionalDependencies:
-      better-sqlite3: 11.10.0
       drizzle-kit: 0.31.10
       drizzle-orm: 0.45.2(@cloudflare/workers-types@5.20260728.1)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@11.10.0)(kysely@0.28.16)(pg@8.20.0)(postgres@3.4.9)
       pg: 8.20.0
@@ -17247,6 +17283,15 @@ snapshots:
       set-cookie-parser: 3.1.0
     optionalDependencies:
       zod: 4.3.6
+
+  better-call@1.3.5(zod@4.4.3):
+    dependencies:
+      '@better-auth/utils': 0.4.0
+      '@better-fetch/fetch': 1.1.21
+      rou3: 0.7.12
+      set-cookie-parser: 3.1.0
+    optionalDependencies:
+      zod: 4.4.3
 
   better-path-resolve@1.0.0:
     dependencies:


### PR DESCRIPTION
## Summary
- Wire full `/v1/model_cards` CRUD into main-node (was GET stub → POST 404). Fixes #134
- Wire full `/v1/environments` CRUD (+ archive) into main-node (same stub gap). Fixes #135
- Resolve harness tool credentials from model cards; emit `session.error` on turn failure so Console is not silent when `ANTHROPIC_API_KEY` is unset. Fixes #136
- Update `docs/self-host.md` to list the newly implemented endpoints

## Test plan
- [ ] `pnpm --filter @open-managed-agents/main-node start` + `pnpm dev:console`
- [ ] Create a model card via Console → succeeds (probe may warn on bad key)
- [ ] Add Environment via Console → succeeds; list/archive/delete work
- [ ] With empty `ANTHROPIC_API_KEY`, agent bound to model card → session replies
- [ ] Force a harness failure → `session.error` appears in event stream
- [ ] `pnpm typecheck` (at least http-routes + main-node)


Made with [Cursor](https://cursor.com)