### PR TITLE
fix(docker-compose): avoid empty ANTHROPIC_BASE_URL defaults

### DIFF
--- a/docker-compose.postgres.yml
+++ b/docker-compose.postgres.yml
@@ -31,8 +31,10 @@ services:
         required: false
     environment:
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
-      ANTHROPIC_BASE_URL: ${ANTHROPIC_BASE_URL:-}
-      ANTHROPIC_CUSTOM_HEADERS: ${ANTHROPIC_CUSTOM_HEADERS:-}
+      # Optional Anthropic-compat proxy settings belong in .env
+      # (ANTHROPIC_BASE_URL / ANTHROPIC_CUSTOM_HEADERS). Do NOT default
+      # them to "" here — @ai-sdk/anthropic validates baseURL on
+      # module init and rejects empty string.
       # Main store: postgres. main-node detects postgres:// scheme on
       # DATABASE_URL and routes every store package through the PG adapter.
       DATABASE_URL: postgres://oma:oma@postgres:5432/oma

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,10 +26,10 @@ services:
     environment:
       # Required for harness turns. Put it in .env or pass via shell env.
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
-      # Optional: when pointing at an Anthropic-compat proxy that needs
-      # /v1 in the base URL or custom headers.
-      ANTHROPIC_BASE_URL: ${ANTHROPIC_BASE_URL:-}
-      ANTHROPIC_CUSTOM_HEADERS: ${ANTHROPIC_CUSTOM_HEADERS:-}
+      # Optional Anthropic-compat proxy settings belong in .env
+      # (ANTHROPIC_BASE_URL / ANTHROPIC_CUSTOM_HEADERS). Do NOT default
+      # them to "" here — @ai-sdk/anthropic validates baseURL on
+      # module init and rejects empty string.
       # Storage paths inside the container — mapped to ./data on host.
       # All absolute so they don't surprise-resolve relative to pnpm's
       # cwd (which becomes /app/apps/main-node under `pnpm --filter ... start`).


### PR DESCRIPTION
## Summary
- Stop injecting `ANTHROPIC_BASE_URL` / `ANTHROPIC_CUSTOM_HEADERS` as empty strings from compose when unset
- Optional Anthropic-compat proxy settings stay in `.env` via existing `env_file`
- Fixes crash from `@ai-sdk/anthropic` `validateBaseURL("")` on self-host docker starts without a proxy

Closes #145

## Test plan
- [ ] `.env` with only `ANTHROPIC_API_KEY` → `docker compose -f docker-compose.yml up` starts; session turn reaches Anthropic default base URL
- [ ] Same check with `docker-compose.postgres.yml`
- [ ] `.env` with real `ANTHROPIC_BASE_URL` (+ optional `ANTHROPIC_CUSTOM_HEADERS`) still reaches the proxy


Made with [Cursor](https://cursor.com)