### PR TITLE
fix(main-node): implement /v1/stats endpoint for dashboard parity & fix dev dockerfile path

### DIFF
--- a/apps/agent/wrangler.dev.jsonc
+++ b/apps/agent/wrangler.dev.jsonc
@@ -8,7 +8,7 @@
   "containers": [
     {
       "class_name": "Sandbox",
-      "image": "../../node_modules/@cloudflare/sandbox/Dockerfile",
+      "image": "./node_modules/@cloudflare/sandbox/Dockerfile",
       "instance_type": "lite",
       "max_instances": 5
     }

--- a/apps/main-node/src/index.ts
+++ b/apps/main-node/src/index.ts
@@ -951,6 +951,34 @@ v1.route("/evals", buildEvalRoutes({
 // Stubs for routes the console hits but main-node doesn't yet implement.
 v1.get("/runtimes", (c) => c.json({ data: [] }));
 v1.get("/skills", (c) => c.json({ data: [] }));
+v1.get("/stats", async (c) => {
+  const tenantId = c.get("tenant_id");
+  const [
+    agents,
+    sessions,
+    environments,
+    vaults,
+    modelCards,
+    apiKeys,
+  ] = await Promise.all([
+    agentsService.count({ tenantId }),
+    sessionsService.count({ tenantId }),
+    environmentsService.count({ tenantId }),
+    vaultService.count({ tenantId }),
+    modelCardsService.list({ tenantId }),
+    apiKeyStorage.listByTenant(tenantId),
+  ]);
+
+  return c.json({
+    agents,
+    sessions,
+    environments,
+    vaults,
+    skills: 0,
+    model_cards: modelCards.filter((card) => card.archived_at === null).length,
+    api_keys: apiKeys.length,
+  });
+});
 v1.route("/environments", buildEnvironmentRoutes({
   environments: environmentsService,
   sessions: sessionsService,


### PR DESCRIPTION
### Problem
1. **Dashboard Metrics Missing on Self-Host (`main-node`)**: When running `apps/main-node` for local dev or self-hosting, the Console Dashboard's headline metric cards (Agents, Sessions, Environments, Vaults, Skills, Model Cards) all display `—` because `GET /v1/stats` was implemented in `apps/main` (Cloudflare Worker runtime) but missing in `apps/main-node` (Node runtime).
2. **Dev Dockerfile Path Resolution**: In `apps/agent/wrangler.dev.jsonc`, the sandbox container image path was set to `../../node_modules/@cloudflare/sandbox/Dockerfile`, which fails in monorepo layouts.

### Changes
- **`apps/main-node/src/index.ts`**: Added `v1.get("/stats", ...)` aggregate count endpoint matching the schema and behavior of `apps/main/src/routes/stats.ts`.
- **`apps/agent/wrangler.dev.jsonc`**: Fixed sandbox Dockerfile relative path to `./node_modules/@cloudflare/sandbox/Dockerfile`.

### Verification
- Ran `pnpm run typecheck` (all packages passed with 0 errors).
- Verified `GET /v1/stats` returns accurate counts for active tenant.
- Verified in Console (`apps/console`) that the Dashboard metric cards now render actual numbers instead of `—`.