### PR TITLE
Node-path fixes found while evaluating self-hosted openma

### DIFF
--- a/apps/main-node/src/index.ts
+++ b/apps/main-node/src/index.ts
@@ -1007,7 +1007,16 @@ v1.route("/environments", buildEnvironmentRoutes({
   environments: environmentsService,
   sessions: sessionsService,
 }));
-v1.route("/model_cards", buildModelCardRoutes({ modelCards: modelCardsService }));
+// internalSecret gates GET /model_cards/:id/key, which serves a decrypted API
+// key. Read from the environment directly rather than the
+// `integrationsInternalToken` const, which is declared further down this file.
+v1.route(
+  "/model_cards",
+  buildModelCardRoutes({
+    modelCards: modelCardsService,
+    internalSecret: process.env.INTEGRATIONS_INTERNAL_TOKEN ?? null,
+  }),
+);
 v1.get("/models/list", (c) =>
   c.json({
     data: [

--- a/apps/main-node/src/index.ts
+++ b/apps/main-node/src/index.ts
@@ -222,6 +222,30 @@ await ensureEventLogSchema(sql, dialect);
 // wiring, not schema bootstrap.
 const platformRootSecret = process.env.PLATFORM_ROOT_SECRET;
 
+// Fail closed. Without this secret, createSqliteModelCardService falls back to
+// model-cards-store's `identityCrypto` (a no-op cipher) and every model-card
+// API key is written to the database in PLAINTEXT — with no error, no warning,
+// and a /health that still reports "ok". That is not a state a server should be
+// able to reach silently, so refuse to boot instead.
+//
+// Ephemeral local dev that genuinely wants throwaway plaintext credentials can
+// opt in explicitly; there is deliberately no way to reach it by omission.
+if (!platformRootSecret) {
+  if (process.env.OMA_ALLOW_PLAINTEXT_CREDENTIALS === "1") {
+    console.warn(
+      "[startup] PLATFORM_ROOT_SECRET is unset and OMA_ALLOW_PLAINTEXT_CREDENTIALS=1: " +
+        "model-card API keys will be stored UNENCRYPTED. Never use this outside throwaway dev.",
+    );
+  } else {
+    throw new Error(
+      "PLATFORM_ROOT_SECRET is required: it encrypts model-card API keys and integration " +
+        "OAuth tokens at rest. Without it credentials are stored in plaintext. " +
+        "Generate one with `openssl rand -base64 32`, or set " +
+        "OMA_ALLOW_PLAINTEXT_CREDENTIALS=1 to accept plaintext storage in throwaway dev.",
+    );
+  }
+}
+
 // ─── Auth ───────────────────────────────────────────────────────────────
 
 const authDisabled = process.env.AUTH_DISABLED === "1";

--- a/apps/main-node/src/index.ts
+++ b/apps/main-node/src/index.ts
@@ -598,7 +598,22 @@ const sessionRegistry = new SessionRegistry({
       toMarkdown: toMarkdownProvider,
     });
   },
-  buildHarness: () => {
+  // Honour `agent.harness`. Previously this always built DefaultHarness, so on
+  // the Node path AgentConfig.harness was silently ignored and every agent got
+  // the default loop regardless of its stored config.
+  //
+  // Registration is explicit here rather than imported from apps/agent's worker
+  // entrypoint, so the Node shell doesn't pull Cloudflare-only bindings in.
+  // AcpProxyHarness is deliberately NOT registered: it requires env.RUNTIME_ROOM,
+  // a Durable Object namespace that does not exist outside Workers.
+  buildHarness: (agent) => {
+    const name = agent.harness?.trim() || "default";
+    if (name !== "default") {
+      throw new Error(
+        `Unknown harness "${name}" on the Node runtime. Registered: default. ` +
+          `(acp-proxy is Workers-only — it needs the RUNTIME_ROOM Durable Object binding.)`,
+      );
+    }
     const h = new DefaultHarness();
     return { run: (ctx: unknown) => h.run(ctx as HarnessContext) };
   },

--- a/apps/main-node/src/registry.ts
+++ b/apps/main-node/src/registry.ts
@@ -81,7 +81,7 @@ export interface SessionRegistryDeps {
 
   /** Build harness instance + context. Each is platform-neutral so the
    *  machine just calls .run(ctx). */
-  buildHarness(): { run: (ctx: unknown) => Promise<void> };
+  buildHarness(agent: AgentConfig): { run: (ctx: unknown) => Promise<void> };
   buildHarnessContext(input: {
     agent: AgentConfig;
     userMessage: UserMessageEvent;
@@ -265,7 +265,7 @@ export class SessionRegistry {
       mountSessionOutputs: async () => {},
       buildModel: (agent) => this.deps.buildModel(agent, tenantId),
       buildTools: (agent, sb) => this.deps.buildTools(agent, sb, tenantId),
-      buildHarness: () => this.deps.buildHarness(),
+      buildHarness: (agent) => this.deps.buildHarness(agent),
       buildHarnessContext: (input) =>
         this.deps.buildHarnessContext({
           ...input,

--- a/apps/main-node/test/crash-recovery.test.ts
+++ b/apps/main-node/test/crash-recovery.test.ts
@@ -72,6 +72,9 @@ async function startMainNode(opts: { dataDir: string }): Promise<ProcessHandle> 
         MEMORY_BLOB_DIR: join(opts.dataDir, "memory-blobs"),
         AUTH_DISABLED: "1",
         BETTER_AUTH_SECRET: "test-secret-only-for-vitest-do-not-deploy",
+        // Required since main-node fails closed without it; without a value here
+        // the spawned server exits at boot and the test times out on /health.
+        PLATFORM_ROOT_SECRET: "dGVzdC1vbmx5LXJvb3Qtc2VjcmV0LWZvci12aXRlc3Q=",
         // Quiet — too much log noise in test output otherwise.
         NODE_ENV: "test",
       },

--- a/apps/main-node/test/dreams-route.test.ts
+++ b/apps/main-node/test/dreams-route.test.ts
@@ -111,6 +111,9 @@ async function startMainNode(opts: { dataDir: string }): Promise<ProcessHandle> 
       SESSION_OUTPUTS_DIR: join(opts.dataDir, "outputs"),
       AUTH_DISABLED: "1",
       BETTER_AUTH_SECRET: "test-secret-only-for-vitest",
+      // Required since main-node fails closed without it; without a value here
+      // the spawned server exits at boot and the test times out on /health.
+      PLATFORM_ROOT_SECRET: "dGVzdC1vbmx5LXJvb3Qtc2VjcmV0LWZvci12aXRlc3Q=",
       DREAM_CURATOR_MODE: "dedup",
       NODE_ENV: "test",
     },

--- a/apps/main-node/test/promote-sandbox-file.test.ts
+++ b/apps/main-node/test/promote-sandbox-file.test.ts
@@ -40,6 +40,9 @@ async function startMainNode(opts: { dataDir: string }): Promise<ProcessHandle> 
       SESSION_OUTPUTS_DIR: join(opts.dataDir, "outputs"),
       AUTH_DISABLED: "1",
       BETTER_AUTH_SECRET: "test-secret-only-for-vitest",
+      // Required since main-node fails closed without it; without a value here
+      // the spawned server exits at boot and the test times out on /health.
+      PLATFORM_ROOT_SECRET: "dGVzdC1vbmx5LXJvb3Qtc2VjcmV0LWZvci12aXRlc3Q=",
       NODE_ENV: "test",
     },
     stdio: ["ignore", "pipe", "pipe"],

--- a/docker-compose.postgres.yml
+++ b/docker-compose.postgres.yml
@@ -43,6 +43,11 @@ services:
       SANDBOX_WORKDIR: /app/data/sandboxes
       MEMORY_BLOB_DIR: /app/data/memory-blobs
       SESSION_OUTPUTS_DIR: /app/data/session-outputs
+      # Absolute, like its three siblings above: the server's cwd is
+      # /app/apps/main-node, so the "./data/files-blobs" default in
+      # apps/main-node/src/index.ts resolves outside the /app/data mount and
+      # into a root-owned dir, and the server crash-loops on EACCES.
+      FILES_BLOB_DIR: /app/data/files-blobs
       OMA_VAULT_PROXY_URL: http://oma-vault:14322
       OMA_VAULT_CA_CERT: /app/data/oma-vault-ca/ca.crt
       BETTER_AUTH_SECRET: ${BETTER_AUTH_SECRET:-}

--- a/packages/http-routes/src/model-cards/index.ts
+++ b/packages/http-routes/src/model-cards/index.ts
@@ -18,6 +18,23 @@ interface Vars {
   Variables: { tenant_id: string };
 }
 
+/**
+ * Constant-time string compare. Hand-rolled rather than node:crypto's
+ * timingSafeEqual because this package also runs on Workers.
+ *
+ * Length is not secret here (the secret is operator-configured, not
+ * attacker-chosen), but we still compare over a fixed number of iterations so
+ * an early mismatch doesn't return faster than a late one.
+ */
+function timingSafeEqualStr(a: string, b: string): boolean {
+  let diff = a.length ^ b.length;
+  const n = Math.max(a.length, b.length);
+  for (let i = 0; i < n; i++) {
+    diff |= (a.charCodeAt(i) || 0) ^ (b.charCodeAt(i) || 0);
+  }
+  return diff === 0;
+}
+
 function toApiShape(card: ModelCardRow) {
   return {
     id: card.id,
@@ -132,11 +149,21 @@ function parsePageQuery(c: {
 
 export interface ModelCardRoutesDeps {
   modelCards: ModelCardService;
+  /**
+   * Shared secret required by `GET /:id/key`, which returns a decrypted API key
+   * in cleartext. Without this, any caller holding a tenant-scoped API key or a
+   * console session can read every model-card credential in the tenant — and
+   * `membership.role` is stored but never enforced, so "any member" means "any
+   * member". Wire it from INTEGRATIONS_INTERNAL_TOKEN.
+   *
+   * When unset the route fails closed (503) rather than serving cleartext.
+   */
+  internalSecret?: string | null;
 }
 
 export function buildModelCardRoutes(deps: ModelCardRoutesDeps) {
   const app = new Hono<Vars>();
-  const { modelCards } = deps;
+  const { modelCards, internalSecret } = deps;
 
   // POST / — create
   app.post("/", async (c) => {
@@ -316,8 +343,17 @@ export function buildModelCardRoutes(deps: ModelCardRoutesDeps) {
     }
   });
 
-  // GET /:id/key — cleartext key (agent / internal consumers)
+  // GET /:id/key — cleartext key (agent / internal consumers only).
+  // Gated: see ModelCardRoutesDeps.internalSecret. Timing-safe compare so the
+  // secret can't be recovered a byte at a time.
   app.get("/:id/key", async (c) => {
+    if (!internalSecret) {
+      return c.json({ error: "Key retrieval is not enabled on this deployment" }, 503);
+    }
+    const presented = c.req.header("x-internal-secret") ?? "";
+    if (!timingSafeEqualStr(presented, internalSecret)) {
+      return c.json({ error: "Forbidden" }, 403);
+    }
     const apiKey = await modelCards.getApiKey({
       tenantId: c.var.tenant_id,
       cardId: c.req.param("id"),

--- a/packages/session-runtime/src/machine.ts
+++ b/packages/session-runtime/src/machine.ts
@@ -95,7 +95,10 @@ export interface SessionMachineDeps {
    *  Async because shells often need to warm up state (e.g. read the
    *  event log into the harness's history cache) before harness.run
    *  reads from it. */
-  buildHarness(): { run: (ctx: unknown) => Promise<void> };
+  /** Receives the resolved agent so the shell can honour `agent.harness`.
+   *  Zero-arg implementations stay assignable, so existing shells that always
+   *  build one harness keep working unchanged. */
+  buildHarness(agent: AgentConfig): { run: (ctx: unknown) => Promise<void> };
   buildHarnessContext(input: {
     agent: AgentConfig;
     userMessage: UserMessageEvent;
@@ -176,7 +179,7 @@ export class SessionStateMachine {
         model,
       });
 
-      const harness = this.deps.buildHarness();
+      const harness = this.deps.buildHarness(agent);
       await harness.run(ctx);
     } finally {
       this.activeTurnId = null;


### PR DESCRIPTION
Closed — this was opened prematurely and isn't ready for review. Please disregard.

While evaluating openma for self-hosted use I ran into a few issues on the Node path, mostly around deployment configuration and defaults. I'd rather raise them properly than in a drive-by PR.

Some of what I found is better handled privately than in a public thread. If a maintainer wants the details, I'm happy to send them through whatever channel you prefer — a security contact, a private advisory draft, or email. Let me know what works and I'll write it up properly.

Apologies for the noise.