### PR TITLE
fix(release): pin prereleases to their npm tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "db:check": "pnpm db:check:cf-auth && pnpm db:check:cf-integrations && pnpm db:check:cf-router && pnpm db:check:node-pg && pnpm db:check:node-sqlite",
     "changeset": "changeset",
     "version-packages": "changeset version",
-    "release": "pnpm -r --filter='@openma/*' build && changeset publish"
+    "release": "pnpm -r --filter='@openma/*' build && node scripts/publish-changesets.mjs"
   },
   "devDependencies": {
     "@anthropic-ai/sdk": "0.120.0",

--- a/scripts/check-vitest-discovery.mjs
+++ b/scripts/check-vitest-discovery.mjs
@@ -7,6 +7,25 @@ import { fileURLToPath } from "node:url";
 
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
 
+test("release planning pins prerelease packages to their prerelease npm tag", async () => {
+  const releaseModule = await import("./publish-changesets.mjs").catch(() => ({}));
+  assert.equal(
+    typeof releaseModule.changesetPublishArgs,
+    "function",
+    "publish-changesets.mjs must export changesetPublishArgs",
+  );
+
+  assert.deepEqual(
+    releaseModule.changesetPublishArgs({ mode: "pre", tag: "beta" }),
+    ["publish", "--tag", "beta"],
+  );
+  assert.deepEqual(
+    releaseModule.changesetPublishArgs({ mode: "exit", tag: "beta" }),
+    ["publish"],
+  );
+  assert.deepEqual(releaseModule.changesetPublishArgs(undefined), ["publish"]);
+});
+
 test("root Cloudflare runtime aliases stay inside the repository checkout", async () => {
   const { default: config } = await import(join(repoRoot, "vitest.config.ts"));
 

--- a/scripts/publish-changesets.mjs
+++ b/scripts/publish-changesets.mjs
@@ -1,0 +1,46 @@
+import { spawnSync } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = fileURLToPath(new URL("..", import.meta.url));
+const preStatePath = new URL("../.changeset/pre.json", import.meta.url);
+
+export function changesetPublishArgs(preState) {
+  if (
+    preState?.mode === "pre" &&
+    typeof preState.tag === "string" &&
+    preState.tag.length > 0
+  ) {
+    return ["publish", "--tag", preState.tag];
+  }
+  return ["publish"];
+}
+
+async function readPreState() {
+  try {
+    return JSON.parse(await readFile(preStatePath, "utf8"));
+  } catch (error) {
+    if (error?.code === "ENOENT") return undefined;
+    throw error;
+  }
+}
+
+async function main() {
+  const args = changesetPublishArgs(await readPreState());
+  if (process.argv.includes("--plan")) {
+    console.log(JSON.stringify({ command: "changeset", args }));
+    return;
+  }
+
+  const pnpm = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
+  const result = spawnSync(pnpm, ["exec", "changeset", ...args], {
+    cwd: repoRoot,
+    stdio: "inherit",
+  });
+  if (result.error) throw result.error;
+  process.exitCode = result.status ?? 1;
+}
+
+if (process.argv[1] && import.meta.url === new URL(process.argv[1], "file:").href) {
+  await main();
+}


### PR DESCRIPTION
## Summary
- derive the Changesets publish tag from prerelease state
- force beta releases onto the beta dist-tag, including packages without a prior stable release
- cover prerelease, prerelease-exit, and stable release plans

## Verification
- pnpm test:discovery
- node scripts/publish-changesets.mjs --plan