### PR TITLE
fix(runtime): settle MCP tools before idle

### DIFF
--- a/apps/agent/src/runtime/session-do.ts
+++ b/apps/agent/src/runtime/session-do.ts
@@ -4244,6 +4244,12 @@ export class SessionDO extends DurableObject<Env> {
     // polling). Tracked via this flag — finally emits if no earlier
     // path did.
     let idleEmitted = false;
+    // A successful turn knows its precise stop reason before tool disposal,
+    // but `status_idle` is the externally visible lifecycle boundary. Hold
+    // the event until every turn-scoped tool (including remote MCP sessions)
+    // has finished closing so clients cannot observe idle while resources are
+    // still live.
+    let completedIdleEvent: SessionEvent | undefined;
 
     // Reuse session-level sandbox (singleton) — files persist across turns.
     // Returned object is a lazy proxy: the underlying container is warmed up
@@ -4814,9 +4820,7 @@ export class SessionDO extends DurableObject<Env> {
         type: "session.status_idle",
         stop_reason: stopReason,
       };
-      history.append(idleEvent);
-      this.broadcastEvent(idleEvent);
-      idleEmitted = true;
+      completedIdleEvent = idleEvent;
     } catch (err) {
       const errorMessage = this.describeError(err);
 
@@ -4901,16 +4905,14 @@ export class SessionDO extends DurableObject<Env> {
       if (this._threadAbortControllers.get(turnThreadId) === abortController) {
         this._threadAbortControllers.delete(turnThreadId);
       }
-      // Catch-all status_idle emit. Pairs with the status_running emit
-      // at the start of this function so Console's status pill never
-      // hangs at "Running" after the turn dies in any non-AbortError
-      // way (model crash, transient retries exhausted, anything that
-      // hits the catch block above without already setting idleEmitted).
-      // No stop_reason — error paths don't have a meaningful one and
-      // the field is optional in SessionStatusEvent.
+      // Emit status_idle only after turn-scoped resources have settled. On a
+      // successful turn this preserves its precise stop_reason; error paths
+      // use the generic event because they have no meaningful stop reason.
+      // This also pairs with status_running so Console never remains stuck at
+      // "Running" after a model/tool failure.
       if (!idleEmitted) {
         try {
-          const idleEvent: SessionEvent = { type: "session.status_idle" };
+          const idleEvent: SessionEvent = completedIdleEvent ?? { type: "session.status_idle" };
           history.append(idleEvent);
           this.broadcastEvent(idleEvent);
         } catch (err) {

--- a/test/integration/mcp-managed-turn.test.ts
+++ b/test/integration/mcp-managed-turn.test.ts
@@ -152,6 +152,14 @@ function installExternalMocks() {
       return new Response("missing managed bearer", { status: 401 });
     }
 
+    // Keep remote session termination observably asynchronous. The turn is
+    // only lifecycle-complete once the runtime publishes status_idle after
+    // awaiting MCP cleanup; waiting merely for the final agent.message is a
+    // race that fast local machines can hide.
+    if (request.method === "DELETE") {
+      await new Promise((resolve) => setTimeout(resolve, 250));
+    }
+
     return mcp.fetch(request);
   };
 
@@ -166,7 +174,7 @@ function installExternalMocks() {
 
 async function waitForCompletedTurn(sessionId: string) {
   for (let attempt = 0; attempt < 100; attempt += 1) {
-    const response = await api(`/v1/oma/sessions/${sessionId}/events?limit=100`, {
+    const response = await api(`/v1/oma/sessions/${sessionId}/events?limit=100&order=asc`, {
       headers: HEADERS,
     });
     expect(response.status).toBe(200);
@@ -175,9 +183,13 @@ async function waitForCompletedTurn(sessionId: string) {
       row.data && typeof row.data === "object"
         ? row.data as Record<string, unknown>
         : row);
-    if (events.some((event) =>
+    const completedMessageIndex = events.findIndex((event) =>
       event.type === "agent.message"
-      && JSON.stringify(event.content ?? "").includes("MCP echo completed."))) {
+      && JSON.stringify(event.content ?? "").includes("MCP echo completed."));
+    const settledAfterMessage = completedMessageIndex >= 0
+      && events.slice(completedMessageIndex + 1).some((event) =>
+        event.type === "session.status_idle");
+    if (settledAfterMessage) {
       return events;
     }
     await new Promise((resolve) => setTimeout(resolve, 25));


### PR DESCRIPTION
## Summary
- treat session.status_idle as the completed turn lifecycle boundary
- preserve successful stop_reason while deferring idle until MCP/tool disposal finishes
- add a deterministic delayed-MCP-close regression test

## Verification
- focused regression repeated 10/10 times
- MCP matrix: 6 files, 29 tests
- protocol coverage: 12 tests; 100% lines, 92.43% branches
- pnpm typecheck
- pnpm test (root workerd 294 files / 2285 tests plus all package, Node, Console, and Web suites)
- console, docs, SDK, and CLI release builds