### PR TITLE
fix(release): let changesets derive beta tag

### DIFF
--- a/scripts/check-vitest-discovery.mjs
+++ b/scripts/check-vitest-discovery.mjs
@@ -7,7 +7,7 @@ import { fileURLToPath } from "node:url";
 
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
 
-test("release planning pins prerelease packages to their prerelease npm tag", async () => {
+test("release planning lets Changesets derive the prerelease npm tag", async () => {
   const releaseModule = await import("./publish-changesets.mjs").catch(() => ({}));
   assert.equal(
     typeof releaseModule.changesetPublishArgs,
@@ -15,15 +15,7 @@ test("release planning pins prerelease packages to their prerelease npm tag", as
     "publish-changesets.mjs must export changesetPublishArgs",
   );
 
-  assert.deepEqual(
-    releaseModule.changesetPublishArgs({ mode: "pre", tag: "beta" }),
-    ["publish", "--tag", "beta"],
-  );
-  assert.deepEqual(
-    releaseModule.changesetPublishArgs({ mode: "exit", tag: "beta" }),
-    ["publish"],
-  );
-  assert.deepEqual(releaseModule.changesetPublishArgs(undefined), ["publish"]);
+  assert.deepEqual(releaseModule.changesetPublishArgs(), ["publish"]);
 });
 
 test("root Cloudflare runtime aliases stay inside the repository checkout", async () => {

--- a/scripts/publish-changesets.mjs
+++ b/scripts/publish-changesets.mjs
@@ -1,32 +1,16 @@
 import { spawnSync } from "node:child_process";
-import { readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 
 const repoRoot = fileURLToPath(new URL("..", import.meta.url));
-const preStatePath = new URL("../.changeset/pre.json", import.meta.url);
 
-export function changesetPublishArgs(preState) {
-  if (
-    preState?.mode === "pre" &&
-    typeof preState.tag === "string" &&
-    preState.tag.length > 0
-  ) {
-    return ["publish", "--tag", preState.tag];
-  }
+export function changesetPublishArgs() {
+  // Changesets reads .changeset/pre.json itself. In pre mode it derives the
+  // npm dist-tag from that file and rejects an explicit --tag argument.
   return ["publish"];
 }
 
-async function readPreState() {
-  try {
-    return JSON.parse(await readFile(preStatePath, "utf8"));
-  } catch (error) {
-    if (error?.code === "ENOENT") return undefined;
-    throw error;
-  }
-}
-
 async function main() {
-  const args = changesetPublishArgs(await readPreState());
+  const args = changesetPublishArgs();
   if (process.argv.includes("--plan")) {
     console.log(JSON.stringify({ command: "changeset", args }));
     return;


### PR DESCRIPTION
## Summary
- remove the custom prerelease --tag argument that Changesets rejects in pre mode
- let Changesets read .changeset/pre.json and derive the beta dist-tag itself
- update the release-plan regression test

## Evidence
- failing run 33615201084 stopped before any npm upload with: Releasing under custom tag is not allowed in pre mode
- RED: updated contract failed against the old implementation
- GREEN: pnpm test:discovery (3/3)
- plan: changeset publish (no custom tag)

No package version bump is needed: 1.0.0-beta.1 and 0.6.0-beta.1 remain unpublished.