### PR TITLE
fix(sprites): certify live duplex lifecycle

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git
+**/node_modules
+**/dist
+**/coverage
+artifacts
+.DS_Store

--- a/Dockerfile.sprites-certification
+++ b/Dockerfile.sprites-certification
@@ -1,0 +1,11 @@
+FROM node:24-bookworm-slim
+
+RUN apt-get update \
+    && apt-get install --yes --no-install-recommends python3 make g++ \
+    && rm -rf /var/lib/apt/lists/*
+RUN npm install --global pnpm@11.0.8
+WORKDIR /workspace
+COPY . .
+RUN pnpm install --filter @open-managed-agents/managed-runtime-sprites... --frozen-lockfile
+
+CMD ["pnpm", "--filter", "@open-managed-agents/managed-runtime-sprites", "test:certification"]

--- a/packages/managed-runtime-sprites/package.json
+++ b/packages/managed-runtime-sprites/package.json
@@ -3,11 +3,15 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
-  "exports": { ".": "./src/index.ts" },
+  "exports": {
+    ".": "./src/index.ts"
+  },
   "scripts": {
     "test": "vitest run --config vitest.config.ts",
+    "test:certification": "OMA_SPRITES_CERTIFICATION=1 vitest run --config vitest.certification.config.ts",
     "test:certification:offline": "vitest run --config vitest.config.ts",
     "test:coverage": "vitest run --config vitest.coverage.config.ts",
+    "typecheck:certification": "tsc --noEmit -p tsconfig.certification.json",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
@@ -16,9 +20,16 @@
     "@open-managed-agents/runtime-resource-contract": "workspace:*",
     "@open-managed-agents/sandbox": "workspace:*"
   },
-  "peerDependencies": { "@fly/sprites": "^0.2.2" },
-  "peerDependenciesMeta": { "@fly/sprites": { "optional": true } },
+  "peerDependencies": {
+    "@fly/sprites": "^0.2.2"
+  },
+  "peerDependenciesMeta": {
+    "@fly/sprites": {
+      "optional": true
+    }
+  },
   "devDependencies": {
+    "@fly/sprites": "0.2.2",
     "@types/node": "^26.2.0",
     "vitest": "^4.1.3"
   }

--- a/packages/managed-runtime-sprites/src/sprites.ts
+++ b/packages/managed-runtime-sprites/src/sprites.ts
@@ -44,7 +44,7 @@ export interface SpriteCommandPort {
   readonly stdin: Writable;
   readonly stdout: Readable;
   readonly stderr: Readable;
-  start(): Promise<void>;
+  once(event: "spawn" | "error", listener: (...args: unknown[]) => void): this;
   wait(): Promise<number>;
   kill(signal?: string): void;
   close(): void;
@@ -345,7 +345,10 @@ export class SpritesRuntime
         maxRunAfterDisconnect: "1h",
       },
     );
-    await command.start();
+    await new Promise<void>((resolve, reject) => {
+      command.once("spawn", () => resolve());
+      command.once("error", (error) => reject(error));
+    });
     return {
       stdin: Writable.toWeb(command.stdin) as WritableStream<Uint8Array>,
       stdout: Readable.toWeb(command.stdout) as unknown as ReadableStream<Uint8Array>,

--- a/packages/managed-runtime-sprites/test/fixtures/sprites-sdk.ts
+++ b/packages/managed-runtime-sprites/test/fixtures/sprites-sdk.ts
@@ -41,7 +41,14 @@ function createSprite(name: string, options: SpritesCreateOptions = {}): SpriteS
       const stderr = new PassThrough();
       return {
         stdin, stdout, stderr,
-        async start() { stdout.end(); stderr.end(); },
+        once(event: "spawn" | "error", listener: (...args: unknown[]) => void) {
+          if (event === "spawn") queueMicrotask(() => {
+            stdout.end();
+            stderr.end();
+            listener();
+          });
+          return this;
+        },
         async wait() { return 0; },
         kill() {}, close() {},
       };

--- a/packages/managed-runtime-sprites/test/sprites-boundaries.test.ts
+++ b/packages/managed-runtime-sprites/test/sprites-boundaries.test.ts
@@ -30,17 +30,20 @@ class Filesystem implements SpriteFilesystemPort {
   readonly mkdir = vi.fn(async () => undefined);
 }
 
-function command(input: { code?: number; start?: () => void | Promise<void> } = {}): SpriteCommandPort {
+function command(input: { code?: number } = {}): SpriteCommandPort {
   const stdin = new PassThrough();
   const stdout = new PassThrough();
   const stderr = new PassThrough();
+  queueMicrotask(() => {
+    stdout.end("out");
+    stderr.end("err");
+  });
   return {
     stdin, stdout, stderr,
-    start: vi.fn(async () => {
-      await input.start?.();
-      stdout.end("out");
-      stderr.end("err");
-    }),
+    once(event: "spawn" | "error", listener: (...args: unknown[]) => void) {
+      if (event === "spawn") queueMicrotask(listener);
+      return this;
+    },
     wait: vi.fn(async () => input.code ?? 0),
     kill: vi.fn(),
     close: vi.fn(),

--- a/packages/managed-runtime-sprites/test/sprites-certification.e2e.test.ts
+++ b/packages/managed-runtime-sprites/test/sprites-certification.e2e.test.ts
@@ -1,0 +1,123 @@
+import { createHash, randomUUID } from "node:crypto";
+import { describe, expect, it } from "vitest";
+
+import {
+  createSpritesProvider,
+  type SpritesClientPort,
+  type SpritesRuntime,
+} from "../src/sprites";
+
+const enabled = process.env.OMA_SPRITES_CERTIFICATION === "1";
+const token = process.env.SPRITES_TOKEN ?? "";
+
+function stableName(sessionId: string): string {
+  return `oma-${createHash("sha256").update(sessionId).digest("hex").slice(0, 32)}`;
+}
+
+async function stage<T>(label: string, task: Promise<T>, timeoutMs = 30_000): Promise<T> {
+  console.info(`[sprites-live] ${label}: start`);
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    const value = await Promise.race([
+      task,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new Error(`${label} timed out after ${timeoutMs}ms`)), timeoutMs);
+      }),
+    ]);
+    console.info(`[sprites-live] ${label}: pass`);
+    return value;
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}
+
+describe.runIf(enabled)("Sprites live certification", () => {
+  it("covers create, exec, duplex IO, retained filesystem reattach, and cleanup", async () => {
+    expect(token, "SPRITES_TOKEN must be set for live certification").not.toBe("");
+    const sessionId = `cert-${randomUUID()}`;
+    const name = stableName(sessionId);
+    const scope = {
+      workspaceId: "sprites-live-certification",
+      environmentId: "sprites-live-certification",
+      sessionId,
+      workId: `work-${randomUUID()}`,
+    };
+    const fence = {
+      ...scope,
+      ownerId: "sprites-live-certification",
+      generation: 1,
+      token: "not-a-runtime-secret",
+      expiresAt: new Date(Date.now() + 300_000).toISOString(),
+    };
+    const plan = {
+      workspaceStrategy: "retained_runtime" as const,
+      outputStrategy: null,
+      runtimeCheckpoint: null,
+      driver: { type: "ama_worker" as const, process: { command: "true" } },
+    };
+    const context = { sessionId, workdir: "/workspace" };
+    const module = await import("@fly/sprites");
+    const client = new module.SpritesClient(token, { controlMode: true }) as SpritesClientPort;
+    const provider = createSpritesProvider({
+      client,
+      createOptions: () => ({
+        config: { ramMB: 1024, cpus: 1, storageGB: 5 },
+        waitForCapacity: true,
+      }),
+    });
+    const acquisition = {
+      scope,
+      fence,
+      plan,
+      workspace: { bindingId: `workspace-${sessionId}`, mountPath: "/workspace" as const },
+      outputs: null,
+      credentialEgress: null,
+      signal: new AbortController().signal,
+    };
+    let runtime: SpritesRuntime | undefined;
+    let resumed: SpritesRuntime | undefined;
+    let primaryFailure: unknown;
+
+    try {
+      runtime = await stage("create", provider.create(context, {}, acquisition), 60_000);
+      expect(runtime.runtimeHandle()).toEqual({ provider: "sprites", runtimeId: name });
+      expect(await stage("exec", runtime.exec("printf openma-sprites-ready"))).toBe("openma-sprites-ready");
+      await stage("write", runtime.writeFile("/workspace/certification.txt", "retained-state"));
+
+      const child = await stage("spawn duplex", runtime.spawnDuplexProcess({
+        command: "/bin/sh",
+        args: ["-lc", "read value; printf 'duplex:%s' \"$value\""],
+        cwd: "/workspace",
+      }));
+      const writer = child.stdin.getWriter();
+      await writer.write(new TextEncoder().encode("certified\n"));
+      await writer.close();
+      const [stdout, stderr, exited] = await stage("collect duplex", Promise.all([
+        new Response(child.stdout).text(),
+        new Response(child.stderr).text(),
+        child.exited,
+      ]));
+      expect(stdout).toBe("duplex:certified");
+      expect(stderr).toBe("");
+      expect(exited).toMatchObject({ code: 0 });
+
+      const handle = runtime.runtimeHandle();
+      await stage("suspend", runtime.suspend({ kind: "filesystem" }));
+      resumed = await stage("reattach", provider.resume(handle, context, {}, acquisition), 60_000);
+      expect(await stage("read retained", resumed.readFile("/workspace/certification.txt"))).toBe("retained-state");
+    } catch (error) {
+      primaryFailure = error;
+    } finally {
+      await stage("destroy", (resumed ?? runtime)?.destroy() ?? client.deleteSprite(name), 30_000)
+        .catch(() => undefined);
+      let cleanupFailure: unknown;
+      try {
+        await expect(stage("verify cleanup", client.getSprite(name))).rejects.toMatchObject({ statusCode: 404 });
+      } catch (error) {
+        cleanupFailure = error;
+      }
+      if (primaryFailure !== undefined) throw primaryFailure;
+      if (cleanupFailure !== undefined) throw cleanupFailure;
+    }
+  }, 180_000);
+});

--- a/packages/managed-runtime-sprites/test/sprites.test.ts
+++ b/packages/managed-runtime-sprites/test/sprites.test.ts
@@ -53,7 +53,14 @@ class FakeSprite implements SpriteSdkPort {
       stdin,
       stdout,
       stderr,
-      start: vi.fn(async () => { stdout.end("worker output"); stderr.end(); }),
+      once(event: "spawn" | "error", listener: (...args: unknown[]) => void) {
+        if (event === "spawn") queueMicrotask(() => {
+          stdout.end("worker output");
+          stderr.end();
+          listener();
+        });
+        return this;
+      },
       wait: vi.fn(async () => 0),
       kill: vi.fn(),
       close: vi.fn(),

--- a/packages/managed-runtime-sprites/tsconfig.certification.json
+++ b/packages/managed-runtime-sprites/tsconfig.certification.json
@@ -1,6 +1,5 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": { "composite": false, "noEmit": true, "types": ["node"] },
-  "include": ["src/**/*.ts", "test/**/*.ts"],
-  "exclude": ["test/**/*-certification.e2e.test.ts"]
+  "include": ["src/**/*.ts", "test/sprites-certification.e2e.test.ts"]
 }

--- a/packages/managed-runtime-sprites/vitest.certification.config.ts
+++ b/packages/managed-runtime-sprites/vitest.certification.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["test/sprites-certification.e2e.test.ts"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2602,6 +2602,9 @@ importers:
         specifier: workspace:*
         version: link:../sandbox
     devDependencies:
+      '@fly/sprites':
+        specifier: 0.2.2
+        version: 0.2.2
       '@types/node':
         specifier: ^26.2.0
         version: 26.3.0
@@ -5408,6 +5411,12 @@ packages:
 
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
+
+  '@fly/sprites@0.2.2':
+    resolution: {integrity: sha512-qlVLIvBBmS/c/i8Ah9ydcdkho/kEW2w5pX7UaUjp4Ye5mBD3eJi53lXBg33F0Rwna+U6fuEELLrDWxGe/Vk97A==}
+    engines: {node: '>=24.0.0'}
+    bundledDependencies:
+      - '@fly/client-signals'
 
   '@fontsource-variable/geist@5.2.8':
     resolution: {integrity: sha512-cJ6m9e+8MQ5dCYJsLylfZrgBh6KkG4bOLckB35Tr9J/EqdkEM6QllH5PxqP1dhTvFup+HtMRPuz9xOjxXJggxw==}
@@ -14738,6 +14747,8 @@ snapshots:
       react-dom: 19.2.8(react@19.2.8)
 
   '@floating-ui/utils@0.2.11': {}
+
+  '@fly/sprites@0.2.2': {}
 
   '@fontsource-variable/geist@5.2.8': {}
 

--- a/scripts/deepseek-live-certification.mjs
+++ b/scripts/deepseek-live-certification.mjs
@@ -41,7 +41,13 @@ export async function runDeepSeekCertification(options = {}) {
   const plan = buildDeepSeekCertificationPlan();
   const commands = new Map([
     ["pi-harness-out", ["pnpm", ["--filter", "@open-managed-agents/main-node", "test:e2e:pi-deepseek"]]],
-    ["pi-compaction-cache", ["pnpm", ["exec", "tsx", "scripts/probe-pi-deepseek-compaction-cache.ts"]]],
+    ["pi-compaction-cache", ["pnpm", [
+      "--filter",
+      "@open-managed-agents/main-node",
+      "exec",
+      "tsx",
+      "../../scripts/probe-pi-deepseek-compaction-cache.ts",
+    ]]],
     ["acp-native-resume-cache", ["pnpm", ["--filter", "@open-managed-agents/main-node", "test:e2e:acp-deepseek-cache"]]],
     ["pi-acp-docker", ["pnpm", ["--filter", "@open-managed-agents/main-node", "test:e2e:pi-acp-docker"]]],
   ]);

--- a/scripts/deepseek-live-certification.test.mjs
+++ b/scripts/deepseek-live-certification.test.mjs
@@ -1,9 +1,13 @@
 import assert from "node:assert/strict";
+import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import test from "node:test";
 
 import {
   buildDeepSeekCertificationPlan,
   parseDeepSeekCredential,
+  runDeepSeekCertification,
 } from "./deepseek-live-certification.mjs";
 
 test("DeepSeek certification covers Pi both outside and inside a real Docker sandbox", () => {
@@ -13,6 +17,33 @@ test("DeepSeek certification covers Pi both outside and inside a real Docker san
     { id: "acp-native-resume-cache", mode: "harness-in-sandbox" },
     { id: "pi-acp-docker", mode: "harness-in-sandbox" },
   ]);
+});
+
+test("DeepSeek certification resolves the compaction probe through the package that owns tsx", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "openma-deepseek-cert-"));
+  const callsPath = join(directory, "calls.jsonl");
+  const fakePnpm = join(directory, "pnpm");
+  await writeFile(fakePnpm, [
+    "#!/bin/sh",
+    `printf '%s\\n' \"$*\" >> ${JSON.stringify(callsPath)}`,
+  ].join("\n"));
+  await chmod(fakePnpm, 0o755);
+  try {
+    await runDeepSeekCertification({
+      env: {
+        ...process.env,
+        DEEPSEEK_API_KEY: "fixture-key",
+        PATH: `${directory}:${process.env.PATH ?? ""}`,
+      },
+    });
+    const calls = (await readFile(callsPath, "utf8")).trim().split("\n");
+    assert.equal(
+      calls[1],
+      "--filter @open-managed-agents/main-node exec tsx ../../scripts/probe-pi-deepseek-compaction-cache.ts",
+    );
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
 });
 
 test("DeepSeek credential parser accepts DSH yaml without retaining surrounding syntax", () => {


### PR DESCRIPTION
## Summary
- fix Sprites duplex spawn lifecycle by waiting for the SDK-owned spawn event instead of starting commands twice
- add credential-gated live Sprites lifecycle certification with cleanup assertions
- fix the DeepSeek compaction certification entrypoint to use the package-owned tsx runtime

## Verification
- pnpm typecheck
- pnpm test (314 root files / 2457 root tests plus all packages, Console, docs, and web)
- real DeepSeek certification: harness-out, compaction/cache, ACP native resume/cache, Pi ACP in Docker
- real harness-in-sandbox certification: Pi ACP, Codex ACP, MCode
- real Fly-hosted Sprites lifecycle: create, exec, write, duplex spawn/collect, suspend, reattach, retained file, destroy, post-destroy 404
- cleanup verified: zero remaining Fly Machines and destroyed temporary remote builder app
