### PR TITLE
fix(runtime): fence stale bridge daemon sockets

### DIFF
--- a/apps/main/src/runtime-room.ts
+++ b/apps/main/src/runtime-room.ts
@@ -59,11 +59,21 @@ import {
 type Side = "daemon" | "harness";
 
 const HARNESS_TAG_PREFIX = "harness:";
+const DAEMON_OWNER_TAG_PREFIX = "daemon-owner:";
+const ACTIVE_DAEMON_OWNER_KEY = "active_daemon_owner";
+const DAEMON_LEASE_TIMEOUT_SECONDS = 90;
 function harnessTag(sid: string): string {
   return `${HARNESS_TAG_PREFIX}${sid}`;
 }
 function sessionFromTag(tag: string): string | null {
   return tag.startsWith(HARNESS_TAG_PREFIX) ? tag.slice(HARNESS_TAG_PREFIX.length) : null;
+}
+function daemonOwnerTag(ownerId: string): string {
+  return `${DAEMON_OWNER_TAG_PREFIX}${ownerId}`;
+}
+function daemonOwnerFromTags(tags: string[]): string | null {
+  const tag = tags.find((candidate) => candidate.startsWith(DAEMON_OWNER_TAG_PREFIX));
+  return tag ? tag.slice(DAEMON_OWNER_TAG_PREFIX.length) : null;
 }
 
 export class RuntimeRoom extends DurableObject<Env> {
@@ -111,17 +121,17 @@ export class RuntimeRoom extends DurableObject<Env> {
       return new Response("missing runtime headers", { status: 400 });
     }
 
-    // One daemon per runtime. A reconnecting daemon needs the prior WS to be
-    // reaped first — CF should fire `webSocketClose` on the old TCP long
-    // before a fresh attempt arrives, but if not we 409 the new one and let
-    // the daemon retry after the close finally lands.
+    // One daemon per runtime. HibernatableWebSocket.send() only proves that
+    // workerd still owns a socket object; it does not prove the peer TCP is
+    // alive. Use the heartbeat observed by this control plane as the lease.
     const existing = this.ctx.getWebSockets("daemon");
     if (existing.length > 0) {
-      try {
-        existing[0].send(JSON.stringify({ type: "ping" }));
+      const leaseFresh = await this.isDaemonLeaseFresh(runtimeId);
+      if (leaseFresh !== false) {
         return new Response("daemon already attached", { status: 409 });
-      } catch {
-        try { existing[0].close(1011, "stale"); } catch { /* already closing */ }
+      }
+      for (const socket of existing) {
+        try { socket.close(1012, "daemon heartbeat lease expired"); } catch { /* already closing */ }
       }
     }
 
@@ -141,11 +151,31 @@ export class RuntimeRoom extends DurableObject<Env> {
 
     const pair = new WebSocketPair();
     const [client, server] = Object.values(pair);
-    this.ctx.acceptWebSocket(server, ["daemon"]);
+    const daemonOwnerId = crypto.randomUUID();
+    this.ctx.acceptWebSocket(server, ["daemon", daemonOwnerTag(daemonOwnerId)]);
+    await this.ctx.storage.put(ACTIVE_DAEMON_OWNER_KEY, daemonOwnerId);
     log({ op: "runtime_room.daemon_attach", runtime_id: runtimeId }, "daemon attached");
 
     await this.markOnline();
     return new Response(null, { status: 101, webSocket: client });
+  }
+
+  private async isDaemonLeaseFresh(runtimeId: string): Promise<boolean | null> {
+    try {
+      const row = await this.env.MAIN_DB
+        .prepare(`SELECT status, last_heartbeat FROM "runtimes" WHERE id = ?`)
+        .bind(runtimeId)
+        .first<{ status: string; last_heartbeat: number | null }>();
+      if (row?.status !== "online") return false;
+      if (row.last_heartbeat === null) return false;
+      return Math.floor(Date.now() / 1000) - row.last_heartbeat < DAEMON_LEASE_TIMEOUT_SECONDS;
+    } catch (error) {
+      logWarn(
+        { op: "runtime_room.daemon_lease_lookup_failed", err: String(error), runtime_id: runtimeId },
+        "daemon heartbeat lease lookup failed",
+      );
+      return null;
+    }
   }
 
   private async attachHarness(request: Request): Promise<Response> {
@@ -163,7 +193,7 @@ export class RuntimeRoom extends DurableObject<Env> {
     const [client, server] = Object.values(pair);
     this.ctx.acceptWebSocket(server, [harnessTag(sid)]);
 
-    const daemonUp = this.ctx.getWebSockets("daemon").length > 0;
+    const daemonUp = await this.activeDaemonSocket() !== null;
     try {
       server.send(JSON.stringify({ type: "attached", daemon_online: daemonUp }));
     } catch { /* race: harness already closed */ }
@@ -204,6 +234,14 @@ export class RuntimeRoom extends DurableObject<Env> {
     const isDaemon = tags.includes("daemon");
 
     if (isDaemon) {
+      if (!(await this.isActiveDaemonSocket(tags))) {
+        logWarn(
+          { op: "runtime_room.evicted_daemon_message", runtime_id: this.runtimeId },
+          "dropped message from evicted daemon",
+        );
+        try { ws.close(1008, "daemon lease lost"); } catch { /* already closed */ }
+        return;
+      }
       await this.onDaemonMessage(ws, parsed);
     } else {
       const sid = tags.map(sessionFromTag).find((s): s is string => !!s);
@@ -343,7 +381,7 @@ export class RuntimeRoom extends DurableObject<Env> {
     //   { type: "session.prompt", turn_id, text }            → forwards as-is
     //   { type: "session.cancel", turn_id }                  → forwards as-is
     //   { type: "session.dispose" }                          → forwards as-is
-    const daemon = this.ctx.getWebSockets("daemon")[0];
+    const daemon = await this.activeDaemonSocket();
     if (!daemon) {
       this.broadcastToHarness(sid, encodeSessionHostEvent({
         type: "session.error",
@@ -416,7 +454,7 @@ export class RuntimeRoom extends DurableObject<Env> {
   /** Tell the daemon to dispose a session. Called from internal route. */
   async sendToDaemon(msg: Record<string, unknown>): Promise<boolean> {
     await this.ensureIdentity();
-    const daemon = this.ctx.getWebSockets("daemon")[0];
+    const daemon = await this.activeDaemonSocket();
     if (!daemon) return false;
     try { daemon.send(JSON.stringify(msg)); return true; }
     catch { return false; }
@@ -426,6 +464,16 @@ export class RuntimeRoom extends DurableObject<Env> {
     await this.ensureIdentity();
     const tags = this.ctx.getTags(ws);
     if (tags.includes("daemon")) {
+      const activeOwnerId = await this.ctx.storage.get<string>(ACTIVE_DAEMON_OWNER_KEY);
+      const closingOwnerId = daemonOwnerFromTags(tags);
+      if (activeOwnerId && closingOwnerId !== activeOwnerId) {
+        log(
+          { op: "runtime_room.evicted_daemon_close", code, runtime_id: this.runtimeId },
+          "ignored close from evicted daemon",
+        );
+        return;
+      }
+      await this.ctx.storage.delete(ACTIVE_DAEMON_OWNER_KEY);
       log({ op: "runtime_room.daemon_close", code, reason: reason || "—", runtime_id: this.runtimeId }, "daemon closed");
       await this.markOffline();
       return;
@@ -443,9 +491,30 @@ export class RuntimeRoom extends DurableObject<Env> {
   async webSocketError(ws: WebSocket, error: unknown): Promise<void> {
     await this.ensureIdentity();
     logError({ op: "runtime_room.ws_error", err: String(error), runtime_id: this.runtimeId }, "ws error");
-    try { ws.close(1011, "ws error"); } catch { /* already closed */ }
     const tags = this.ctx.getTags(ws);
-    if (tags.includes("daemon")) await this.markOffline();
+    const activeDaemon = tags.includes("daemon") && await this.isActiveDaemonSocket(tags);
+    try { ws.close(1011, "ws error"); } catch { /* already closed */ }
+    if (activeDaemon) await this.markOffline();
+  }
+
+  private async isActiveDaemonSocket(tags: string[]): Promise<boolean> {
+    const activeOwnerId = await this.ctx.storage.get<string>(ACTIVE_DAEMON_OWNER_KEY);
+    if (!activeOwnerId) return true;
+    return daemonOwnerFromTags(tags) === activeOwnerId;
+  }
+
+  private async activeDaemonSocket(): Promise<WebSocket | null> {
+    const sockets = this.ctx.getWebSockets("daemon");
+    if (sockets.length === 0) return null;
+
+    const activeOwnerId = await this.ctx.storage.get<string>(ACTIVE_DAEMON_OWNER_KEY);
+    // Preserve compatibility with daemon sockets accepted before owner tags
+    // were introduced. A newly attached daemon always records an owner id.
+    if (!activeOwnerId) return sockets[0] ?? null;
+
+    return sockets.find((socket) =>
+      daemonOwnerFromTags(this.ctx.getTags(socket)) === activeOwnerId
+    ) ?? null;
   }
 
   private async ensureIdentity(): Promise<void> {

--- a/test/integration/runtimes-route.test.ts
+++ b/test/integration/runtimes-route.test.ts
@@ -338,6 +338,258 @@ describe("/agents/runtime/* — multi-tenant CLI bridge daemon (step 2)", () => 
       return { stub, runtimeId: rid, userId: uid };
     }
 
+    it("evicts a daemon socket whose server-observed heartbeat lease expired", async () => {
+      const { stub, runtimeId, userId } = await freshRoom(["tn_ws_stale"]);
+      await env.AUTH_DB
+        .prepare(`UPDATE "runtimes" SET last_heartbeat = ? WHERE id = ?`)
+        .bind(Math.floor(Date.now() / 1000) - 300, runtimeId)
+        .run();
+
+      let staleSocketClosed = false;
+      await runInDurableObject(stub, async (instance) => {
+        const room = instance as unknown as {
+          ctx: { getWebSockets(tag?: string): WebSocket[] };
+          attachDaemon(request: Request): Promise<Response>;
+        };
+        const originalGetWebSockets = room.ctx.getWebSockets.bind(room.ctx);
+        const staleSocket = {
+          send() {},
+          close() { staleSocketClosed = true; },
+        } as unknown as WebSocket;
+        room.ctx.getWebSockets = (tag?: string) =>
+          tag === "daemon" ? [staleSocket] : originalGetWebSockets(tag);
+
+        const response = await room.attachDaemon(
+          new Request("http://runtime-room/_attach_daemon", {
+            headers: {
+              Upgrade: "websocket",
+              "x-runtime-id": runtimeId,
+              "x-runtime-user": userId,
+            },
+          }),
+        );
+
+        expect(response.status).toBe(101);
+      });
+      expect(staleSocketClosed).toBe(true);
+    });
+
+    it("keeps the current daemon while its server-observed lease is fresh", async () => {
+      const { stub, runtimeId, userId } = await freshRoom(["tn_ws_fresh"]);
+      await env.AUTH_DB
+        .prepare(`UPDATE "runtimes" SET status = 'online', last_heartbeat = ? WHERE id = ?`)
+        .bind(Math.floor(Date.now() / 1000), runtimeId)
+        .run();
+
+      let currentSocketClosed = false;
+      await runInDurableObject(stub, async (instance) => {
+        const room = instance as unknown as {
+          ctx: { getWebSockets(tag?: string): WebSocket[] };
+          attachDaemon(request: Request): Promise<Response>;
+        };
+        const originalGetWebSockets = room.ctx.getWebSockets.bind(room.ctx);
+        const currentSocket = {
+          send() {},
+          close() { currentSocketClosed = true; },
+        } as unknown as WebSocket;
+        room.ctx.getWebSockets = (tag?: string) =>
+          tag === "daemon" ? [currentSocket] : originalGetWebSockets(tag);
+
+        const response = await room.attachDaemon(
+          new Request("http://runtime-room/_attach_daemon", {
+            headers: {
+              Upgrade: "websocket",
+              "x-runtime-id": runtimeId,
+              "x-runtime-user": userId,
+            },
+          }),
+        );
+
+        expect(response.status).toBe(409);
+      });
+      expect(currentSocketClosed).toBe(false);
+    });
+
+    it("evicts a daemon already marked offline even when its last heartbeat is recent", async () => {
+      const { stub, runtimeId, userId } = await freshRoom(["tn_ws_offline"]);
+      await env.AUTH_DB
+        .prepare(`UPDATE "runtimes" SET status = 'offline', last_heartbeat = ? WHERE id = ?`)
+        .bind(Math.floor(Date.now() / 1000), runtimeId)
+        .run();
+
+      let offlineSocketClosed = false;
+      await runInDurableObject(stub, async (instance) => {
+        const room = instance as unknown as {
+          ctx: { getWebSockets(tag?: string): WebSocket[] };
+          attachDaemon(request: Request): Promise<Response>;
+        };
+        const originalGetWebSockets = room.ctx.getWebSockets.bind(room.ctx);
+        const offlineSocket = {
+          send() {},
+          close() { offlineSocketClosed = true; },
+        } as unknown as WebSocket;
+        room.ctx.getWebSockets = (tag?: string) =>
+          tag === "daemon" ? [offlineSocket] : originalGetWebSockets(tag);
+
+        const response = await room.attachDaemon(
+          new Request("http://runtime-room/_attach_daemon", {
+            headers: {
+              Upgrade: "websocket",
+              "x-runtime-id": runtimeId,
+              "x-runtime-user": userId,
+            },
+          }),
+        );
+
+        expect(response.status).toBe(101);
+      });
+      expect(offlineSocketClosed).toBe(true);
+    });
+
+    it("does not let an evicted daemon close mark its replacement offline", async () => {
+      const { stub, runtimeId, userId } = await freshRoom(["tn_ws_fenced"]);
+      await env.AUTH_DB
+        .prepare(`UPDATE "runtimes" SET last_heartbeat = ? WHERE id = ?`)
+        .bind(Math.floor(Date.now() / 1000) - 300, runtimeId)
+        .run();
+
+      await runInDurableObject(stub, async (instance) => {
+        const room = instance as unknown as {
+          ctx: {
+            getTags(socket: WebSocket): string[];
+            getWebSockets(tag?: string): WebSocket[];
+          };
+          attachDaemon(request: Request): Promise<Response>;
+          webSocketClose(socket: WebSocket, code: number, reason: string): Promise<void>;
+        };
+        const originalGetTags = room.ctx.getTags.bind(room.ctx);
+        const originalGetWebSockets = room.ctx.getWebSockets.bind(room.ctx);
+        const staleSocket = {
+          send() {},
+          close() {},
+        } as unknown as WebSocket;
+        room.ctx.getWebSockets = (tag?: string) =>
+          tag === "daemon" ? [staleSocket] : originalGetWebSockets(tag);
+        room.ctx.getTags = (socket: WebSocket) =>
+          socket === staleSocket ? ["daemon"] : originalGetTags(socket);
+
+        const response = await room.attachDaemon(
+          new Request("http://runtime-room/_attach_daemon", {
+            headers: {
+              Upgrade: "websocket",
+              "x-runtime-id": runtimeId,
+              "x-runtime-user": userId,
+            },
+          }),
+        );
+        expect(response.status).toBe(101);
+
+        await room.webSocketClose(staleSocket, 1012, "lease expired");
+      });
+
+      const row = await env.AUTH_DB
+        .prepare(`SELECT status FROM "runtimes" WHERE id = ?`)
+        .bind(runtimeId)
+        .first<{ status: string }>();
+      expect(row?.status).toBe("online");
+    });
+
+    it("drops messages from a daemon that no longer owns the room", async () => {
+      const { stub } = await freshRoom(["tn_ws_owner"]);
+      await runInDurableObject(stub, async (instance, state) => {
+        const sid = `sess_old_owner_${Math.random().toString(36).slice(2, 6)}`;
+        const staleSocket = {} as WebSocket;
+        const room = instance as unknown as {
+          ctx: { getTags(socket: WebSocket): string[] };
+          webSocketMessage(socket: WebSocket, message: string): Promise<void>;
+        };
+        const originalGetTags = room.ctx.getTags.bind(room.ctx);
+        room.ctx.getTags = (socket: WebSocket) =>
+          socket === staleSocket
+            ? ["daemon", "daemon-owner:owner_old"]
+            : originalGetTags(socket);
+        await state.storage.put("active_daemon_owner", "owner_new");
+
+        await room.webSocketMessage(
+          staleSocket,
+          JSON.stringify({
+            type: "session.ready",
+            session_id: sid,
+            tenant_id: "tn_ws_owner",
+            acp_session_id: "acp-from-stale-owner",
+          }),
+        );
+
+        expect(await state.storage.get(`session_state:${sid}`)).toBeUndefined();
+      });
+    });
+
+    it("does not let an evicted daemon error mark the active owner offline", async () => {
+      const { stub, runtimeId } = await freshRoom(["tn_ws_error_fence"]);
+      await env.AUTH_DB
+        .prepare(`UPDATE "runtimes" SET status = 'online' WHERE id = ?`)
+        .bind(runtimeId)
+        .run();
+
+      await runInDurableObject(stub, async (instance, state) => {
+        const staleSocket = { close() {} } as unknown as WebSocket;
+        const room = instance as unknown as {
+          ctx: { getTags(socket: WebSocket): string[] };
+          webSocketError(socket: WebSocket, error: unknown): Promise<void>;
+        };
+        const originalGetTags = room.ctx.getTags.bind(room.ctx);
+        room.ctx.getTags = (socket: WebSocket) =>
+          socket === staleSocket
+            ? ["daemon", "daemon-owner:owner_old"]
+            : originalGetTags(socket);
+        await state.storage.put("active_daemon_owner", "owner_new");
+
+        await room.webSocketError(staleSocket, new Error("late socket error"));
+      });
+
+      const row = await env.AUTH_DB
+        .prepare(`SELECT status FROM "runtimes" WHERE id = ?`)
+        .bind(runtimeId)
+        .first<{ status: string }>();
+      expect(row?.status).toBe("online");
+    });
+
+    it("routes harness commands only to the active daemon owner", async () => {
+      const { stub } = await freshRoom(["tn_ws_route_owner"]);
+      await runInDurableObject(stub, async (instance, state) => {
+        const oldMessages: string[] = [];
+        const newMessages: string[] = [];
+        const oldSocket = { send: (message: string) => oldMessages.push(message) } as unknown as WebSocket;
+        const newSocket = { send: (message: string) => newMessages.push(message) } as unknown as WebSocket;
+        const room = instance as unknown as {
+          ctx: {
+            getTags(socket: WebSocket): string[];
+            getWebSockets(tag?: string): WebSocket[];
+          };
+          onHarnessMessage(sessionId: string, message: Record<string, unknown>): Promise<void>;
+        };
+        const originalGetTags = room.ctx.getTags.bind(room.ctx);
+        const originalGetWebSockets = room.ctx.getWebSockets.bind(room.ctx);
+        room.ctx.getWebSockets = (tag?: string) =>
+          tag === "daemon" ? [oldSocket, newSocket] : originalGetWebSockets(tag);
+        room.ctx.getTags = (socket: WebSocket) => {
+          if (socket === oldSocket) return ["daemon", "daemon-owner:owner_old"];
+          if (socket === newSocket) return ["daemon", "daemon-owner:owner_new"];
+          return originalGetTags(socket);
+        };
+        await state.storage.put("active_daemon_owner", "owner_new");
+
+        await room.onHarnessMessage("sess_route_owner", {
+          type: "session.prompt",
+          turn_id: "turn_route_owner",
+          text: "route to current owner",
+        });
+
+        expect(oldMessages).toEqual([]);
+        expect(newMessages).toHaveLength(1);
+      });
+    });
+
     it("refreshAuthorizedTenants RPC: revoking a row mid-life → next inbound msg for that tenant drops", async () => {
       const { stub, runtimeId } = await freshRoom(["tn_rpc_a", "tn_rpc_b"]);
       // Before revoke: both tenants accepted.


### PR DESCRIPTION
Closes #29

## Summary
- replace Hibernatable WebSocket send-as-liveness with a server-observed 90s heartbeat lease
- allow immediate takeover when the runtime is already marked offline
- assign each daemon connection an owner token and fence late messages, close/error callbacks, and harness command routing from evicted owners
- retain fail-closed behavior when the lease lookup itself fails

## Verification
- `pnpm exec vitest run test/integration/runtimes-route.test.ts` (19 tests)
- `pnpm exec vitest run test/unit/runtime-room-boundary.test.ts` (2 tests)
- `pnpm typecheck`
- RED/GREEN regressions cover fresh-owner rejection, stale/offline takeover, old-owner message/close/error fencing, and active-owner-only command routing